### PR TITLE
Rename Helm chart from 'tracebloc' to 'client' in Chart.yaml for consistency with new naming convention.

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: tracebloc
+name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
 version: 1.0.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a metadata-only rename in `Chart.yaml` with no runtime behavior changes; risk is limited to any external tooling relying on the old chart name.
> 
> **Overview**
> Renames the Helm chart in `client/Chart.yaml` by changing the chart `name` from `tracebloc` to `client` for consistency with the new naming convention.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4bb43e986dab5d079960d85a4ed30bb93657e23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->