### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ helm template eks eks/ --namespace test-namespace | \
 
 ## Troubleshooting
 
+### Docker / k3d "permission denied" (Linux)
+If `k3d cluster list` or `docker` fails with `permission denied` on the Docker socket:
+- Your user must be in the `docker` group. The installer adds you; if you run commands in a terminal opened before that, the group is not active yet.
+- **Quick fix:** run `newgrp docker` in that terminal (or open a new terminal), then run `k3d cluster list` or re-run the installer.
+- Or log out and log back in so the `docker` group is applied to your session.
+
 ### Template rendering errors:
 - Check for unclosed `{{ }}` blocks
 - Verify all referenced values exist in values.yaml

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,7 +30,6 @@ echo "Downloading Tracebloc client installer (branch: $BRANCH)..."
 
 mkdir -p "$TMPDIR/lib"
 
-echo $TMPDIR
 FILES=(
   "scripts/install-k8s.sh"
   "scripts/lib/common.sh"

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -3,13 +3,25 @@
 #  cluster.sh — k3d cluster creation, start, and kubeconfig merge
 # =============================================================================
 
-# Exact cluster name match (avoids "tracebloc" matching "tracebloc2")
+# Exact cluster name match (avoids "tracebloc" matching "tracebloc2").
+# Uses multiple detection methods so re-runs work on all distros (e.g. SUSE where
+# jq may be missing or k3d list output format differs).
 _cluster_exists() {
+  # 1) JSON output (exact name match) when jq is available
   if command -v jq &>/dev/null; then
-    k3d cluster list -o json 2>/dev/null | jq -e --arg n "$CLUSTER_NAME" '(.[] | select(.name == $n)) != null' >/dev/null 2>&1
-  else
-    k3d cluster list --no-headers 2>/dev/null | awk -v n="$CLUSTER_NAME" '$1 == n { exit 0 } END { exit 1 }'
+    if k3d cluster list -o json 2>/dev/null | jq -e --arg n "$CLUSTER_NAME" '(.[] | select(.name == $n)) != null' >/dev/null 2>&1; then
+      return 0
+    fi
   fi
+  # 2) Table format: first column is cluster name (--no-headers)
+  if k3d cluster list --no-headers 2>/dev/null | awk -v n="$CLUSTER_NAME" '$1 == n { exit 0 } END { exit 1 }'; then
+    return 0
+  fi
+  # 3) Fallback: any line whose first column equals CLUSTER_NAME (handles varying table layout)
+  if k3d cluster list 2>/dev/null | grep -qE "^[[:space:]]*${CLUSTER_NAME}[[:space:]]"; then
+    return 0
+  fi
+  return 1
 }
 
 # Ensure host dirs exist so /tracebloc/data, /tracebloc/logs, /tracebloc/mysql exist inside nodes (HOST_DATA_DIR is mounted as /tracebloc).
@@ -82,7 +94,21 @@ _create_new_cluster() {
   fi
   info "(First run pulls the k3s image — takes ~1 min on a fast connection)"
 
-  k3d "${K3D_ARGS[@]}"
+  local create_out create_rc
+  create_out="$(mktemp)"
+  if ! k3d "${K3D_ARGS[@]}" >"$create_out" 2>&1; then
+    create_rc=$?
+    if grep -qi "already exists\|a cluster with that name already exists" "$create_out" 2>/dev/null; then
+      info "Cluster '$CLUSTER_NAME' already exists (detected from k3d message). Using existing cluster."
+      rm -f "$create_out"
+      _handle_existing_cluster
+      return 0
+    fi
+    cat "$create_out" >&2
+    rm -f "$create_out"
+    exit "$create_rc"
+  fi
+  rm -f "$create_out"
   success "Cluster '$CLUSTER_NAME' created and ready!"
 }
 

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -9,6 +9,29 @@ TRACEBLOC_HELM_REPO_URL="https://tracebloc.github.io/client"
 TRACEBLOC_HELM_REPO_NAME="tracebloc"
 TRACEBLOC_CHART_NAME="client"
 
+# Ensure helm binary is executable (fixes Linux "Permission denied" exit 126 when
+# get-helm-3 installs to /usr/local/bin/helm with restrictive permissions).
+_ensure_helm_runnable() {
+  if helm version --short &>/dev/null; then
+    return 0
+  fi
+  local helm_bin
+  helm_bin="$(command -v helm 2>/dev/null)" || true
+  if [[ -z "$helm_bin" || ! -f "$helm_bin" ]]; then
+    error "Helm is not installed or not on PATH. Re-run the installer to install Helm."
+  fi
+  if [[ ! -x "$helm_bin" ]]; then
+    warn "Helm at $helm_bin is not executable (common on Linux after install). Fixing..."
+    if sudo chmod 755 "$helm_bin" 2>/dev/null; then
+      success "Helm is now executable. Continuing."
+      return 0
+    fi
+    error "Could not make Helm executable. Run manually: sudo chmod 755 $helm_bin"
+  fi
+  # Executable but still failing (e.g. noexec mount or libs)
+  error "Helm could not be run. Try: sudo chmod 755 $helm_bin then re-run this script."
+}
+
 # Extract a key's value from a simple YAML file (handles "value", 'value', or value)
 # For single-quoted YAML values, unescapes '' back to ' so credentials round-trip correctly.
 _extract_yaml_value() {
@@ -138,6 +161,9 @@ EOF
 
   chmod 600 "$values_file" 2>/dev/null || true
   success "Values file written to $values_file"
+
+  # ── Ensure helm is executable (Linux: get-helm-3 may install with wrong perms) ─
+  _ensure_helm_runnable
 
   # ── Add repo and install ───────────────────────────────────────────────────
   if ! helm repo list 2>/dev/null | grep -q "^${TRACEBLOC_HELM_REPO_NAME}[[:space:]]"; then

--- a/scripts/lib/setup-linux.sh
+++ b/scripts/lib/setup-linux.sh
@@ -122,6 +122,17 @@ install_k3d() {
 }
 
 # ── Helm ─────────────────────────────────────────────────────────────────────
+# Ensure helm binary is executable (get-helm-3 can install to /usr/local/bin with
+# restrictive perms on some Linux distros, causing "Permission denied" exit 126).
+_ensure_helm_executable() {
+  local helm_bin
+  helm_bin="$(command -v helm 2>/dev/null)" || true
+  if [[ -n "$helm_bin" && -f "$helm_bin" && ! -x "$helm_bin" ]]; then
+    info "Making Helm executable (fixing permissions)..."
+    sudo chmod 755 "$helm_bin" 2>/dev/null || true
+  fi
+}
+
 install_helm() {
   step "Step 5/5 — Helm"
   if ! has helm; then
@@ -132,8 +143,10 @@ install_helm() {
     chmod +x "$helm_script"
     spin_cmd "Installing Helm…" bash "$helm_script"
     rm -f "$helm_script"
+    _ensure_helm_executable
     success "helm: $(helm version --short 2>/dev/null || echo installed)"
   else
+    _ensure_helm_executable
     success "helm: $(helm version --short 2>/dev/null || echo present)"
   fi
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the bootstrap/installer flow around cluster creation and Helm execution, so failures could block installs on some environments. Changes are localized to shell scripts and primarily add fallbacks and clearer handling for common Linux edge cases.
> 
> **Overview**
> Improves installer reliability across Linux distros by making `k3d` cluster existence checks more robust (multiple output parsing strategies) and treating "already exists" create failures as a reuse/start-existing-cluster path.
> 
> Adds safeguards to ensure `helm` is runnable after install by fixing non-executable Helm binaries (via `chmod`/guidance) and documents a common Docker/k3d Docker-socket "permission denied" fix (`newgrp docker` / re-login).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c4961c9be7e86dad4fb23fbef991e47b3db05bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->