### PR TITLE
Refactor Docker status check in install-k8s.ps1

### DIFF
--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -417,7 +417,7 @@ function Install-DockerDesktop {
   }
 
   $dockerRunning = $false
-  try { docker info 2>&1 | Out-Null; $dockerRunning = ($LASTEXITCODE -eq 0) } catch {}
+  docker info *>$null 2>&1; if ($LASTEXITCODE -eq 0) { $dockerRunning = $true }
 
   if (-not $dockerRunning) {
     Start-Process $dockerExe -ErrorAction SilentlyContinue
@@ -428,7 +428,7 @@ function Install-DockerDesktop {
     $f = 0
     for ($i = 1; $i -le $maxWait; $i++) {
       Start-Sleep -Seconds 3
-      try { docker info 2>&1 | Out-Null; if ($LASTEXITCODE -eq 0) { $dockerRunning = $true; break } } catch {}
+      docker info *>$null 2>&1; if ($LASTEXITCODE -eq 0) { $dockerRunning = $true; break }
       Write-Host "`r  " -NoNewline
       Write-Host $frames[$f] -ForegroundColor Cyan -NoNewline
       Write-Host " Waiting for Docker..." -NoNewline


### PR DESCRIPTION
- Updated the method for checking Docker's running status to use a more concise syntax, improving readability and maintaining functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small but user-facing installer change: removing `try/catch` may alter behavior when the `docker` CLI is missing/unavailable, potentially causing the script to fail earlier during setup.
> 
> **Overview**
> **Refactors Docker readiness detection** in the Windows installer by replacing `try/catch { docker info ... }` probes with a simpler `docker info *>$null` call that checks `$LASTEXITCODE` both initially and inside the startup wait loop.
> 
> This keeps the same overall flow (probe → launch Docker Desktop → poll until ready) while changing how errors/output from `docker info` are handled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b302042d1038ca28885b9619015344aa8ffd2fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->