### PR TITLE
NetworkPolicy locking down training-pod egress

### DIFF
--- a/client/ci/aks-values.yaml
+++ b/client/ci/aks-values.yaml
@@ -15,6 +15,13 @@ storageClass:
 
 clusterScope: true
 
+# NetworkPolicy: AKS requires the cluster to be created with Azure NPM
+# (`--network-policy azure`) or with Calico to enforce NetworkPolicies.
+# Leave enabled here; document the cluster-creation requirement in README.
+networkPolicy:
+  training:
+    enabled: true
+
 clientId: "ci-test-id"
 clientPassword: "ci-test-password"
 

--- a/client/ci/bm-values.yaml
+++ b/client/ci/bm-values.yaml
@@ -15,6 +15,13 @@ storageClass:
 
 clusterScope: true
 
+# NetworkPolicy: bare-metal enforcement depends on the CNI installed.
+# Calico / Cilium / kube-router enforce. Flannel alone does NOT.
+# Leave enabled here; customers on Flannel-only installations must override.
+networkPolicy:
+  training:
+    enabled: true
+
 clientId: "ci-test-id"
 clientPassword: "ci-test-password"
 

--- a/client/ci/eks-values.yaml
+++ b/client/ci/eks-values.yaml
@@ -15,6 +15,14 @@ storageClass:
 
 clusterScope: true
 
+# NetworkPolicy: EKS with the default AWS VPC CNI does NOT enforce
+# NetworkPolicy. Leaving this disabled is the safe default — a policy that
+# isn't enforced gives a false sense of security. Customers running
+# Calico or Cilium as an add-on should override this to enabled: true.
+networkPolicy:
+  training:
+    enabled: false
+
 clientId: "ci-test-id"
 clientPassword: "ci-test-password"
 

--- a/client/ci/oc-values.yaml
+++ b/client/ci/oc-values.yaml
@@ -11,6 +11,18 @@ openshift:
   scc:
     enabled: true
 
+# NetworkPolicy: OpenShift OVN-Kubernetes enforces by default.
+# DNS selector + in-cluster CIDRs differ from the Kubernetes defaults.
+networkPolicy:
+  training:
+    enabled: true
+    dnsNamespace: openshift-dns
+    dnsSelector:
+      dns.operator.openshift.io/daemonset-dns: default
+    clusterCidrs:
+      - "10.128.0.0/14"   # OpenShift default pod CIDR
+      - "172.30.0.0/16"   # OpenShift default service CIDR
+
 clientId: "ci-test-id"
 clientPassword: "ci-test-password"
 

--- a/client/templates/network-policy-training.yaml
+++ b/client/templates/network-policy-training.yaml
@@ -1,0 +1,67 @@
+{{/*
+  Training pod egress lockdown.
+
+  Training pods run untrusted ML code uploaded by external data scientists.
+  This NetworkPolicy:
+    1. Denies all ingress to training pods (nothing should connect TO them).
+    2. Allows DNS to the cluster's DNS service.
+    3. Allows TCP/443 egress to addresses OUTSIDE the cluster CIDRs only —
+       blocking pod-to-pod, MySQL, K8s API, jobs-manager pod IPs, etc.
+
+  Selects pods by label tracebloc.io/workload=training. The jobs-manager
+  injects this label when spawning each training Job (see client-runtime
+  jobs_manager._prepare_job_config).
+
+  Requires a CNI that enforces NetworkPolicy. Not enforced by:
+    - kindnet (minikube / KIND)
+    - flannel (without kube-router add-on)
+    - AWS VPC CNI (without Calico add-on)
+  See values.yaml networkPolicy.training.enabled for platform notes.
+*/}}
+{{- if .Values.networkPolicy.training.enabled }}
+{{- $dnsSelector := .Values.networkPolicy.training.dnsSelector }}
+{{- if not $dnsSelector }}{{ $dnsSelector = dict "k8s-app" "kube-dns" }}{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-training-egress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      tracebloc.io/workload: training
+  policyTypes:
+    - Ingress
+    - Egress
+  # Deny all ingress — no one should connect TO a training pod.
+  ingress: []
+  egress:
+    # 1. DNS to the cluster's DNS service.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.training.dnsNamespace | default "kube-system" }}
+          podSelector:
+            matchLabels:
+              {{- toYaml $dnsSelector | nindent 14 }}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # 2. External HTTPS — everything NOT in the cluster's pod/service CIDRs.
+    #    Training pods call backend, Azure Service Bus, App Insights, etc.
+    #    This blocks pod-to-pod, ClusterIPs, MySQL, jobs-manager, K8s API.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              {{- range .Values.networkPolicy.training.clusterCidrs }}
+              - {{ . | quote }}
+              {{- end }}
+      ports:
+        - port: 443
+          protocol: TCP
+{{- end }}

--- a/client/tests/network_policy_test.yaml
+++ b/client/tests/network_policy_test.yaml
@@ -1,0 +1,173 @@
+suite: Training-pod NetworkPolicy
+templates:
+  - templates/network-policy-training.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: should not render when networkPolicy.training.enabled is false
+    set:
+      networkPolicy:
+        training:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a NetworkPolicy when enabled
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-training-egress
+
+  - it: should select on tracebloc.io/workload training label
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+    asserts:
+      - equal:
+          path: spec.podSelector
+          value:
+            matchLabels:
+              tracebloc.io/workload: training
+
+  - it: should deny all ingress via empty ingress rules
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - equal:
+          path: spec.ingress
+          value: []
+
+  - it: should allow DNS egress on UDP and TCP port 53
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+    asserts:
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            port: 53
+            protocol: UDP
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            port: 53
+            protocol: TCP
+
+  - it: should select DNS pods by namespace + label
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0]
+          value:
+            namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: kube-system
+            podSelector:
+              matchLabels:
+                k8s-app: kube-dns
+
+  - it: should allow external TCP 443 and block in-cluster CIDRs
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+    asserts:
+      - equal:
+          path: spec.egress[1].to[0].ipBlock.cidr
+          value: 0.0.0.0/0
+      - contains:
+          path: spec.egress[1].to[0].ipBlock.except
+          content: 10.0.0.0/8
+      - contains:
+          path: spec.egress[1].to[0].ipBlock.except
+          content: 172.16.0.0/12
+      - contains:
+          path: spec.egress[1].to[0].ipBlock.except
+          content: 192.168.0.0/16
+      - contains:
+          path: spec.egress[1].ports
+          content:
+            port: 443
+            protocol: TCP
+
+  - it: should support OpenShift DNS selector override
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: openshift-dns
+          dnsSelector:
+            dns.operator.openshift.io/daemonset-dns: default
+          clusterCidrs:
+            - 10.128.0.0/14
+            - 172.30.0.0/16
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0]
+          value:
+            namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-dns
+            podSelector:
+              matchLabels:
+                dns.operator.openshift.io/daemonset-dns: default
+      - contains:
+          path: spec.egress[1].to[0].ipBlock.except
+          content: 10.128.0.0/14
+      - contains:
+          path: spec.egress[1].to[0].ipBlock.except
+          content: 172.30.0.0/16

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -145,6 +145,42 @@
         }
       }
     },
+    "networkPolicy": {
+      "type": "object",
+      "description": "NetworkPolicy egress lockdown for untrusted training pods. Requires a CNI that enforces NetworkPolicy.",
+      "properties": {
+        "training": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Create the training-egress NetworkPolicy. Set false on clusters without an enforcing CNI."
+            },
+            "dnsNamespace": {
+              "type": "string",
+              "default": "kube-system",
+              "description": "Namespace where the cluster DNS service runs"
+            },
+            "dnsSelector": {
+              "type": "object",
+              "description": "Pod labels selecting the cluster DNS service. AKS/EKS/kubeadm: {k8s-app: kube-dns}. OpenShift: {dns.operator.openshift.io/daemonset-dns: default}",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "clusterCidrs": {
+              "type": "array",
+              "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs.",
+              "items": {
+                "type": "string",
+                "pattern": "^[0-9.]+/[0-9]+$"
+              }
+            }
+          }
+        }
+      }
+    },
     "clientId": {
       "type": "string",
       "minLength": 1,

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -69,6 +69,35 @@ openshift:
   scc:
     enabled: false
 
+# -- NetworkPolicy hardening for training pods.
+# Training pods run untrusted ML code; this denies ingress and restricts
+# egress to DNS + external HTTPS only (blocks pod-to-pod, MySQL, K8s API).
+# Requires a CNI that enforces NetworkPolicy:
+#   AKS:   needs "Azure NPM" (--network-policy azure) or Calico at cluster create
+#   EKS:   needs Calico or Cilium add-on (AWS VPC CNI alone does NOT enforce)
+#   bm:    needs Calico / Cilium / kube-router (Flannel alone does NOT enforce)
+#   OC:    OVN-Kubernetes enforces by default
+# Leave `enabled: false` on clusters without an enforcing CNI — silently
+# having no protection is worse than explicitly disabling it.
+networkPolicy:
+  training:
+    enabled: true
+    dnsNamespace: kube-system
+    # CoreDNS pod selector — varies per platform. Override in ci/<platform>-values.yaml.
+    # When empty, the template falls back to {k8s-app: kube-dns}, which works
+    # on AKS / EKS / kind / kubeadm / most standard distros.
+    # OpenShift requires explicit override: see client/ci/oc-values.yaml.
+    # Helm merges map values, so to change the selector you MUST set
+    # dnsSelector to the complete desired map (not just additions).
+    dnsSelector: {}
+    # In-cluster CIDRs to block for pod-to-pod egress.
+    # The defaults cover common pod+service CIDR combinations. Override if your
+    # cluster uses different CIDRs (e.g. OpenShift defaults: 10.128.0.0/14 + 172.30.0.0/16).
+    clusterCidrs:
+      - "10.0.0.0/8"
+      - "172.16.0.0/12"
+      - "192.168.0.0/16"
+
 # -- Secrets
 clientId: "<CLIENT_ID>"
 clientPassword: "<CLIENT_PASSWORD>"


### PR DESCRIPTION
## Summary

Adds a Helm-templated NetworkPolicy that denies ingress and restricts egress on training pods. Selects on the `tracebloc.io/workload=training` label injected by the jobs-manager in the companion PR: tracebloc/client-runtime#1.

Training pods run untrusted Python code uploaded by external data scientists. This is the first kernel-level control on what that code can reach from inside the pod.

## What the policy does

**Ingress:** denied entirely — nothing should connect TO a training pod.

**Egress, allowed:**
- DNS to the cluster DNS service (`kube-system` / `openshift-dns` depending on platform)
- TCP/443 to addresses **outside** the cluster's pod/service CIDRs — this is what lets the training container still reach Azure Service Bus, App Insights, and the tracebloc backend

**Egress, blocked** (the whole point):
- Pod-to-pod in-cluster traffic
- ClusterIP services — mysql-client, jobs-manager, Kubernetes API server
- Any port other than 53 (DNS) and 443

## Per-platform defaults

| Platform | `enabled` | Reason |
|---|---|---|
| AKS | `true` | Requires Azure NPM (`--network-policy azure`) or Calico at cluster create. Documented in `ci/aks-values.yaml`. |
| EKS | **`false`** | Default AWS VPC CNI does NOT enforce NetworkPolicy. A policy that silently isn't enforced gives a false sense of security. Customers running Calico / Cilium add-ons should override to `true`. |
| BM | `true` | Requires Calico / Cilium / kube-router. Flannel alone does NOT enforce. |
| OC | `true` | OVN-Kubernetes enforces by default. Custom DNS selector + OpenShift pod/service CIDRs (10.128.0.0/14 + 172.30.0.0/16). |

## Design note: the map-merge footgun

Helm merges map values rather than replacing them. If I'd defaulted `dnsSelector: {k8s-app: kube-dns}` in `values.yaml`, the OpenShift override would **add** its label to that map rather than replacing it — producing a broken selector.

So `dnsSelector` defaults to `{}` in `values.yaml`, and the template falls back to `{k8s-app: kube-dns}` if empty. Each platform's `ci/*-values.yaml` sets the full intended selector. Documented in-line.

## Known limitations (intentional for this PR)

1. **Exfiltration to external `attacker.com` on port 443 is still possible** — this only closes in-cluster paths and non-443 egress. Closing external entirely requires routing all training-pod traffic through jobs-manager (architectural endgame, separate effort).
2. **No L7 filtering** — NetworkPolicy is L3/L4.
3. **CIDR-exclusion requires the cluster's pod/service CIDRs to be in the defaults** (10.0.0.0/8 / 172.16.0.0/12 / 192.168.0.0/16). Customers with custom CIDRs must override `clusterCidrs`.
4. **Enforcement depends on CNI** — see the platform table above.

## Test plan

- [x] `helm lint --strict` passes on all 4 platforms
- [x] `helm unittest` — 8 new cases covering rendering toggle, podSelector, ingress denial, DNS allow, external HTTPS allow, cluster CIDR blocking, OpenShift selector override. 47/47 total across 6 suites
- [x] Manual `helm template` inspection on AKS/EKS/BM/OC — EKS correctly produces no output (disabled), OC uses `openshift-dns` namespace and the correct DNS daemon-set label
- [ ] Dev-edge rollout: spin a netshoot pod with the training label, verify:
  - DNS resolution ✓
  - `curl https://api.tracebloc.io/` ✓
  - `curl mysql-client:3306` blocked
  - `curl kubernetes.default.svc` blocked
  - `curl` jobs-manager pod IP blocked
- [ ] Real experiment runs end-to-end on dev edge with policy active
- [ ] Stg 72h soak across AKS + OC + bare-metal
- [ ] Prod canary on one customer edge

## Dependency

Must land **after** tracebloc/client-runtime#1 has built a new jobs-manager image tag (`:dev` first). Otherwise the label doesn't exist and the policy selects nothing — not broken, just ineffective.

## CI note (not a blocker)

Existing helm-ci.yaml `paths:` filter triggers on `main` and `openshift` branches but not `develop`. I validated locally (`helm lint --strict`, `helm unittest`, per-platform `helm template`). Worth a follow-up to add `develop` to the trigger list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)