### PR TITLE
chore: add auto-add to engineer kanban workflow

### DIFF
--- a/.github/workflows/add-to-kanban.yml
+++ b/.github/workflows/add-to-kanban.yml
@@ -10,7 +10,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/tracebloc/projects/2
           github-token: ${{ secrets.PROJECTS_KANBAN_TOKEN }}

--- a/.github/workflows/add-to-kanban.yml
+++ b/.github/workflows/add-to-kanban.yml
@@ -1,0 +1,16 @@
+name: Add to engineer kanban
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/orgs/tracebloc/projects/2
+          github-token: ${{ secrets.PROJECTS_KANBAN_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a 14-line GitHub Actions workflow that auto-adds every new issue and pull request from this repo to the engineer kanban project:

→ https://github.com/orgs/tracebloc/projects/2

Fires on `issues: opened|reopened|transferred` and `pull_request: opened|reopened|ready_for_review`. No effect on existing items.

## Why

GitHub Projects v2's built-in "Auto-add to project" workflow only supports **one repo per project**. This action-based approach is GitHub's recommended workaround to get cross-repo visibility on a single kanban.

## Dependencies

Uses the org-level secret `PROJECTS_KANBAN_TOKEN` (already configured with `project` + `repo` scopes, visible to all repositories).

## Testing

After merge, open any new issue or PR and confirm it appears in the `Backlog` column of the kanban within a few seconds. If it doesn't, check the Actions tab for the workflow run.

## Related

One of ~18 identical PRs being rolled out across the tracebloc org so every repo's work lands on the shared engineer kanban.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
