### PR TITLE
chore: add narrow CODEOWNERS for security-sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Narrow CODEOWNERS — security backstop only.
+# Author picks reviewers for everything else; this just ensures a security-aware
+# co-approver on a small set of files where a regression would be expensive.
+
+/client/templates/                                      @saadqbal
+/client/values.schema.json                              @saadqbal
+/client/values.yaml                                     @saadqbal
+/docs/SECURITY.md                                       @saadqbal


### PR DESCRIPTION
## Summary

Adds a narrow `.github/CODEOWNERS` file listing a small set of security-sensitive paths with `@saadqbal` as a required co-reviewer.

## Why

Reviewer choice is and remains the **author's decision** for the other 95% of PRs — pick whoever has context. This file only auto-requests an additional security-aware reviewer on a small list of files where a regression would be expensive (auth code, security-critical chart templates, training-pod specs, baked credentials, etc.).

Combined with the branch-protection rule "require review from CODEOWNERS", this ensures no critical path is merged without a security-literate set of eyes, while keeping the default author-pick model intact everywhere else.

## What's protected

See the CODEOWNERS file. Short list per repo — tuned to the specific surfaces this repo exposes. If you think a path is missing, or one of the listed paths is overkill, comment on this PR and we'll adjust.

## Effect on day-to-day work

- PR touches a non-listed path: no change. Author picks a reviewer. One approval suffices.
- PR touches a listed path: GitHub automatically adds `@saadqbal` as a requested reviewer alongside whoever the author picked. Both approvals are required before merge. Author can still add any other reviewer they want.

## Related

- Branch protection applied across all 17 active tracebloc repos (API-only, no PR).
- Narrow CODEOWNERS rolled out to 4 security-sensitive repos: `client`, `client-runtime`, `tracebloc-client`, `backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
