### PR TITLE
docs(client): add pre-Helm resource-monitor cleanup step to MIGRATION.md

### DIFF
--- a/client/MIGRATION.md
+++ b/client/MIGRATION.md
@@ -137,6 +137,29 @@ helm install <release-name> ./client -n <namespace> -f new-values.yaml
 
 > **Important:** PVCs have `helm.sh/resource-policy: keep` so they survive `helm uninstall`. Verify PVCs still exist before installing the new chart.
 
+### 6. Clean up pre-Helm `resource-monitor` remnants
+
+Some early-era edges were installed with a `resource-monitor` DaemonSet deployed via raw `kubectl apply` — **before** the per-platform charts existed. The live manifest has no Helm ownership annotations (`meta.helm.sh/release-*`), and its pods are named `resource-monitor-<suffix>` (not `tracebloc-resource-monitor-<suffix>`).
+
+The unified chart's `tracebloc-resource-monitor` DaemonSet supersedes it. After migrating, delete the legacy resources so the namespace has a single node-level agent and isn't carrying an unmanaged, hostPath-mounting pod that blocks PSA `enforce=restricted`:
+
+```bash
+# Check whether your cluster has the legacy DS
+kubectl -n <namespace> get ds resource-monitor 2>/dev/null
+
+# If present, delete it and its cluster-scoped RBAC (all four names are exact).
+# The ClusterRole/Binding are global — verify they aren't shared by any other workload first:
+kubectl get clusterrolebinding resource-monitor -o jsonpath='{.subjects}'
+# Expect a single subject: ServiceAccount/resource-monitor in <namespace>.
+
+kubectl -n <namespace> delete ds resource-monitor
+kubectl -n <namespace> delete sa resource-monitor
+kubectl delete clusterrolebinding resource-monitor
+kubectl delete clusterrole resource-monitor
+```
+
+The chart-managed `tracebloc-resource-monitor` keeps running throughout; no rollout is triggered.
+
 ## Rollback
 
 The old charts remain in `aks/`, `bm/`, `eks/`, `oc/` and can be used at any time:


### PR DESCRIPTION
## Summary

- Appends Step 6 to `client/MIGRATION.md` documenting cleanup of the legacy, pre-Helm `resource-monitor` DaemonSet + its SA + ClusterRole + ClusterRoleBinding.
- No chart / template changes — this is a documentation-only PR. The cluster-side cleanup has already been executed on `tb-client-dev-templates`; this PR captures the procedure so other edges can repeat it.

## Design note

On `tb-client-dev-templates` / `tracebloc-templates`, PSA `enforce=restricted` was warning on pods matching `resource-monitor-*`. On inspection there were **two** DaemonSets in the namespace running the same `tracebloc/resource-monitor:dev` image:

| Name | Age | Source | Security context | hostPath |
|---|---|---|---|---|
| `resource-monitor` | 113d | raw `kubectl apply` (no Helm ownership) | empty `{}` | `/proc`, `/sys` |
| `tracebloc-resource-monitor` | 23h | Helm release `tracebloc` (chart `client-1.0.3`) | `runAsNonRoot`, drop `ALL`, seccomp `RuntimeDefault` | `/proc`, `/sys` |

The Helm-managed `tracebloc-resource-monitor` in `client/templates/resource-monitor-daemonset.yaml` is the canonical replacement for the pre-chart DaemonSet. Evidence of the planned migration: the Helm-managed CRB `tracebloc-resource-monitor-tracebloc` had both SAs listed as subjects (one of them — the legacy `resource-monitor` SA — manually added via `kubectl apply` after Helm install).

Three options were weighed:
- **(a) Move node-level agents to a dedicated privileged namespace.** Canonical pattern, but only makes sense if both DaemonSets are retained. Doesn't help here since we'd still have an unmanaged duplicate.
- **(b) Refactor to eliminate hostPath.** Requires the binary to read its own pod's cgroup instead of the node — doesn't fit node-level monitoring.
- **(c) Delete the legacy unmanaged DS, keep the Helm-managed one.** Chosen. The Helm template is the only source-of-truth; its PSA hardening is tracked by a sibling task that's already wiring up a dedicated privileged namespace for the node-agent workloads.

No chart change is needed — the legacy DS isn't in any chart. The cleanup is purely operational (`kubectl delete`), and this PR documents it in `client/MIGRATION.md` under the existing chart-migration flow so any other edge carrying the pre-Helm remnants follows the same procedure.

## Test plan

Executed on EKS cluster `tb-client-dev-templates`, namespace `tracebloc-templates`:

```bash
# Before (2 DaemonSets):
$ kubectl -n tracebloc-templates get ds
NAME                         DESIRED   CURRENT   READY   AGE
resource-monitor             2         2         2       113d
tracebloc-resource-monitor   2         2         2       23h

# Cleanup applied exactly as documented in the MIGRATION.md section:
$ kubectl -n tracebloc-templates delete ds resource-monitor
$ kubectl -n tracebloc-templates delete sa resource-monitor
$ kubectl delete clusterrolebinding resource-monitor
$ kubectl delete clusterrole resource-monitor

# After (1 DaemonSet, chart-managed):
$ kubectl -n tracebloc-templates get ds
NAME                         DESIRED   CURRENT   READY   AGE
tracebloc-resource-monitor   2         2         2       23h

# PSA dry-run confirms no more resource-monitor-* violators:
$ kubectl label namespace tracebloc-templates \
    pod-security.kubernetes.io/enforce=restricted --dry-run=server
Warning: existing pods in namespace "tracebloc-templates" violate the new
PodSecurity enforce level "restricted:latest"
Warning: tracebloc-resource-monitor-dbwzd (and 1 other pod): restricted volume types
namespace/tracebloc-templates labeled (server dry run)