### PR TITLE
Move tracebloc-resource-monitor to dedicated privileged namespace

### DIFF
--- a/client/templates/docker-registry-secret.yaml
+++ b/client/templates/docker-registry-secret.yaml
@@ -9,4 +9,21 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- if and (ne .Values.resourceMonitor false) (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
+---
+# Mirrored into the node-agents namespace so the resource-monitor DaemonSet
+# can pull its image via imagePullSecrets. dockerconfigjson Secrets are
+# namespace-scoped like all Secrets.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tracebloc.registrySecretName" . }}
+  namespace: {{ .Values.nodeAgents.namespace.name }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app: tracebloc-resource-monitor
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end }}
 {{- end }}

--- a/client/templates/namespace.yaml
+++ b/client/templates/namespace.yaml
@@ -13,10 +13,12 @@
     pod-security.kubernetes.io/enforce: <off>      (does NOT reject pods)
 
   Enforce mode is deliberately left unset by default -- the mysql init
-  containers (runAsUser: 0) and the resource-monitor DaemonSet (hostPath
-  mounts) violate the restricted profile and would be rejected. Customers
-  can opt into enforce once those are refactored or moved to a separate
-  namespace; `warn` + `audit` give useful visibility in the meantime.
+  containers still run as UID 0 and would be rejected. The resource-monitor
+  DaemonSet (hostPath mounts) previously blocked enforce too, but now lives
+  in the dedicated `nodeAgents.namespace.name` namespace (privileged PSA),
+  so it no longer constrains this namespace. Customers can opt into enforce
+  once the mysql init is refactored; `warn` + `audit` give useful visibility
+  in the meantime.
 
   helm.sh/resource-policy: keep ensures `helm uninstall` does NOT delete
   the namespace (which would take PVC-backed data with it).

--- a/client/templates/node-agents-namespace.yaml
+++ b/client/templates/node-agents-namespace.yaml
@@ -1,0 +1,34 @@
+{{/*
+  Dedicated namespace for node-level agents (tracebloc-resource-monitor).
+
+  The resource-monitor DaemonSet mounts hostPath /proc and /sys to collect
+  node metrics; Pod Security Admission's `restricted` profile bans hostPath
+  volumes outright, so the DaemonSet cannot be made compliant in a
+  restricted namespace. Isolating it in its own `privileged` namespace
+  lets the release namespace (jobs-manager, mysql, training pods) run
+  under `enforce: restricted` once the other blockers are resolved.
+
+  Gated on:
+    nodeAgents.namespace.create   - skip when managing the namespace out-of-band
+    resourceMonitor != false      - skip when the DaemonSet is disabled
+
+  helm.sh/resource-policy: keep ensures `helm uninstall` does NOT delete
+  the namespace. The namespace itself carries no persistent data, but
+  keeping it avoids recreating the PSA labels on every reinstall and
+  prevents race conditions where a DaemonSet from a concurrent install
+  lands in the not-yet-relabelled namespace.
+*/}}
+{{- if and (ne .Values.resourceMonitor false) .Values.nodeAgents.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.nodeAgents.namespace.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app: tracebloc-node-agents
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged
+{{- end }}

--- a/client/templates/node-agents-namespace.yaml
+++ b/client/templates/node-agents-namespace.yaml
@@ -9,8 +9,14 @@
   under `enforce: restricted` once the other blockers are resolved.
 
   Gated on:
-    nodeAgents.namespace.create   - skip when managing the namespace out-of-band
-    resourceMonitor != false      - skip when the DaemonSet is disabled
+    nodeAgents.namespace.create                   - skip when managing the namespace out-of-band
+    resourceMonitor != false                      - skip when the DaemonSet is disabled
+    nodeAgents.namespace.name != Release.Namespace - skip when the operator
+        has pointed node-agents back at the release namespace. Otherwise this
+        template would stamp `privileged` PSA labels onto the release
+        namespace (defeating the whole point of the split) and, combined
+        with namespace.create=true, would render two Namespace resources
+        with the same name — a render-time collision.
 
   helm.sh/resource-policy: keep ensures `helm uninstall` does NOT delete
   the namespace. The namespace itself carries no persistent data, but
@@ -18,7 +24,7 @@
   prevents race conditions where a DaemonSet from a concurrent install
   lands in the not-yet-relabelled namespace.
 */}}
-{{- if and (ne .Values.resourceMonitor false) .Values.nodeAgents.namespace.create }}
+{{- if and (ne .Values.resourceMonitor false) .Values.nodeAgents.namespace.create (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: tracebloc-resource-monitor
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.nodeAgents.namespace.name }}
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -50,10 +50,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # The monitor queries workloads in the release namespace, not its
+            # own node-agents namespace — use the release namespace literal
+            # rather than the Downward API pod namespace.
             - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: {{ .Release.Namespace | quote }}
             - name: MONITOR_INTERVAL
               value: "30"
             - name: CLIENT_ENV

--- a/client/templates/resource-monitor-rbac.yaml
+++ b/client/templates/resource-monitor-rbac.yaml
@@ -51,11 +51,15 @@ subjects:
     namespace: {{ .Values.nodeAgents.namespace.name }}
 {{- else }}
 ---
+# Role + RoleBinding live in the RELEASE namespace so the resource-monitor
+# can list pods/logs where the actual workloads run. The RoleBinding
+# subject points at the ServiceAccount in the node-agents namespace
+# (cross-namespace bindings are valid; the Role scope is what matters).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: tracebloc-resource-monitor-{{ .Release.Name }}
-  namespace: {{ .Values.nodeAgents.namespace.name }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
@@ -74,7 +78,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tracebloc-resource-monitor-{{ .Release.Name }}
-  namespace: {{ .Values.nodeAgents.namespace.name }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}

--- a/client/templates/resource-monitor-rbac.yaml
+++ b/client/templates/resource-monitor-rbac.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tracebloc-resource-monitor
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.nodeAgents.namespace.name }}
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
@@ -48,14 +48,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: tracebloc-resource-monitor
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.nodeAgents.namespace.name }}
 {{- else }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: tracebloc-resource-monitor-{{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.nodeAgents.namespace.name }}
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
@@ -74,7 +74,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tracebloc-resource-monitor-{{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.nodeAgents.namespace.name }}
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
@@ -88,6 +88,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: tracebloc-resource-monitor
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.nodeAgents.namespace.name }}
 {{- end }}
 {{- end }}

--- a/client/templates/resource-monitor-scc.yaml
+++ b/client/templates/resource-monitor-scc.yaml
@@ -44,7 +44,7 @@ seccompProfiles:
   - runtime/default
 readOnlyRootFilesystem: false
 users:
-  - system:serviceaccount:{{ .Release.Namespace }}:tracebloc-resource-monitor
+  - system:serviceaccount:{{ .Values.nodeAgents.namespace.name }}:tracebloc-resource-monitor
 groups: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -80,5 +80,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: tracebloc-resource-monitor
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.nodeAgents.namespace.name }}
 {{- end }}

--- a/client/templates/secrets.yaml
+++ b/client/templates/secrets.yaml
@@ -9,3 +9,21 @@ type: Opaque
 data:
   CLIENT_ID: {{ required "clientId is required" .Values.clientId | b64enc | quote }}
   CLIENT_PASSWORD: {{ required "clientPassword is required" .Values.clientPassword | b64enc | quote }}
+{{- if and (ne .Values.resourceMonitor false) (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
+---
+# Mirrored into the node-agents namespace so the resource-monitor DaemonSet
+# can read CLIENT_ID / CLIENT_PASSWORD via secretKeyRef. Secrets are
+# namespace-scoped; a pod cannot reference a Secret in another namespace.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tracebloc.secretName" . }}
+  namespace: {{ .Values.nodeAgents.namespace.name }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app: tracebloc-resource-monitor
+type: Opaque
+data:
+  CLIENT_ID: {{ required "clientId is required" .Values.clientId | b64enc | quote }}
+  CLIENT_PASSWORD: {{ required "clientPassword is required" .Values.clientPassword | b64enc | quote }}
+{{- end }}

--- a/client/tests/node_agents_namespace_test.yaml
+++ b/client/tests/node_agents_namespace_test.yaml
@@ -4,6 +4,8 @@ templates:
   - templates/resource-monitor-daemonset.yaml
   - templates/resource-monitor-rbac.yaml
   - templates/resource-monitor-scc.yaml
+  - templates/secrets.yaml
+  - templates/docker-registry-secret.yaml
 release:
   namespace: tracebloc-templates
 set:
@@ -116,23 +118,130 @@ tests:
           path: subjects[0].namespace
           value: tracebloc-node-agents
 
-  - it: should place namespace-scoped Role + RoleBinding in the node-agents namespace when clusterScope is false
+  - it: should keep namespace-scoped Role + RoleBinding in the release namespace when clusterScope is false, with SA subject in node-agents
     template: templates/resource-monitor-rbac.yaml
     set:
       clusterScope: false
     asserts:
+      # Role must grant access where the monitored workloads live (release ns)
+      - isKind:
+          of: Role
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+        documentIndex: 1
+      # RoleBinding sits in the release ns so it applies the Role there
+      - isKind:
+          of: RoleBinding
+        documentIndex: 2
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+        documentIndex: 2
+      # ...but the subject SA lives in the node-agents namespace
+      - equal:
+          path: subjects[0].namespace
+          value: tracebloc-node-agents
+        documentIndex: 2
+
+  # --- Secret mirroring (cross-namespace Secrets are not supported by Kubernetes) ---
+  - it: should mirror the tracebloc Opaque Secret into the node-agents namespace by default
+    template: templates/secrets.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Secret
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+        documentIndex: 0
+      - isKind:
+          of: Secret
+        documentIndex: 1
       - equal:
           path: metadata.namespace
           value: tracebloc-node-agents
         documentIndex: 1
       - equal:
+          path: metadata.name
+          value: RELEASE-NAME-secrets
+        documentIndex: 1
+      - isNotEmpty:
+          path: data.CLIENT_ID
+        documentIndex: 1
+      - isNotEmpty:
+          path: data.CLIENT_PASSWORD
+        documentIndex: 1
+
+  - it: should not mirror the tracebloc Secret when resourceMonitor is disabled
+    template: templates/secrets.yaml
+    set:
+      resourceMonitor: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+
+  - it: should not mirror the tracebloc Secret when node-agents namespace equals release namespace
+    template: templates/secrets.yaml
+    set:
+      nodeAgents:
+        namespace:
+          create: false
+          name: tracebloc-templates
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+
+  - it: should mirror the docker registry Secret into the node-agents namespace when in use
+    template: templates/docker-registry-secret.yaml
+    set:
+      dockerRegistry:
+        create: true
+        server: https://index.docker.io/v1/
+        username: u
+        password: p
+        email: e@e.com
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+        documentIndex: 0
+      - equal:
           path: metadata.namespace
           value: tracebloc-node-agents
-        documentIndex: 2
+        documentIndex: 1
       - equal:
-          path: subjects[0].namespace
-          value: tracebloc-node-agents
-        documentIndex: 2
+          path: type
+          value: kubernetes.io/dockerconfigjson
+        documentIndex: 1
+
+  - it: should not mirror the docker registry Secret when resourceMonitor is disabled
+    template: templates/docker-registry-secret.yaml
+    set:
+      resourceMonitor: false
+      dockerRegistry:
+        create: true
+        server: https://index.docker.io/v1/
+        username: u
+        password: p
+        email: e@e.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
 
   # --- OpenShift SCC ---
   - it: should reference the node-agents ServiceAccount in the SCC users list

--- a/client/tests/node_agents_namespace_test.yaml
+++ b/client/tests/node_agents_namespace_test.yaml
@@ -63,6 +63,17 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should not render when node-agents ns name equals release namespace
+    template: templates/node-agents-namespace.yaml
+    set:
+      nodeAgents:
+        namespace:
+          create: true
+          name: tracebloc-templates
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: should honour a custom namespace name
     template: templates/node-agents-namespace.yaml
     set:
@@ -94,6 +105,31 @@ tests:
       - equal:
           path: metadata.namespace
           value: my-agents
+
+  - it: should set NAMESPACE env to the release namespace literal, not the Downward API pod namespace
+    template: templates/resource-monitor-daemonset.yaml
+    set:
+      nodeAgents:
+        namespace:
+          create: true
+          name: tracebloc-node-agents
+    asserts:
+      # The monitor watches workloads in the release namespace, so NAMESPACE must
+      # resolve to the release ns, NOT the pod's own (node-agents) namespace.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NAMESPACE
+            value: tracebloc-templates
+      # Guard against regressing to the Downward API form, which would now point
+      # at the node-agents namespace and break pod/log lookups.
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
 
   # --- resource-monitor RBAC placement ---
   - it: should place the ServiceAccount in the node-agents namespace

--- a/client/tests/node_agents_namespace_test.yaml
+++ b/client/tests/node_agents_namespace_test.yaml
@@ -1,0 +1,152 @@
+suite: Node-agents namespace + resource-monitor placement
+templates:
+  - templates/node-agents-namespace.yaml
+  - templates/resource-monitor-daemonset.yaml
+  - templates/resource-monitor-rbac.yaml
+  - templates/resource-monitor-scc.yaml
+release:
+  namespace: tracebloc-templates
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  # --- node-agents namespace template ---
+  - it: should render the node-agents namespace by default
+    template: templates/node-agents-namespace.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Namespace
+      - equal:
+          path: metadata.name
+          value: tracebloc-node-agents
+
+  - it: should apply privileged PSA labels on all three modes
+    template: templates/node-agents-namespace.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/enforce"]
+          value: privileged
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/warn"]
+          value: privileged
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/audit"]
+          value: privileged
+
+  - it: should carry the keep annotation so uninstall preserves the namespace
+    template: templates/node-agents-namespace.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: should not render when nodeAgents.namespace.create is false
+    template: templates/node-agents-namespace.yaml
+    set:
+      nodeAgents:
+        namespace:
+          create: false
+          name: pre-existing-ns
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when resourceMonitor is disabled
+    template: templates/node-agents-namespace.yaml
+    set:
+      resourceMonitor: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should honour a custom namespace name
+    template: templates/node-agents-namespace.yaml
+    set:
+      nodeAgents:
+        namespace:
+          create: true
+          name: my-agents
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-agents
+
+  # --- resource-monitor DaemonSet placement ---
+  - it: should deploy DaemonSet into the node-agents namespace, not release namespace
+    template: templates/resource-monitor-daemonset.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-node-agents
+
+  - it: should follow a custom node-agents namespace name
+    template: templates/resource-monitor-daemonset.yaml
+    set:
+      nodeAgents:
+        namespace:
+          create: true
+          name: my-agents
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-agents
+
+  # --- resource-monitor RBAC placement ---
+  - it: should place the ServiceAccount in the node-agents namespace
+    template: templates/resource-monitor-rbac.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-node-agents
+
+  - it: should bind the ClusterRoleBinding subject to the node-agents namespace
+    template: templates/resource-monitor-rbac.yaml
+    set:
+      clusterScope: true
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: subjects[0].namespace
+          value: tracebloc-node-agents
+
+  - it: should place namespace-scoped Role + RoleBinding in the node-agents namespace when clusterScope is false
+    template: templates/resource-monitor-rbac.yaml
+    set:
+      clusterScope: false
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-node-agents
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-node-agents
+        documentIndex: 2
+      - equal:
+          path: subjects[0].namespace
+          value: tracebloc-node-agents
+        documentIndex: 2
+
+  # --- OpenShift SCC ---
+  - it: should reference the node-agents ServiceAccount in the SCC users list
+    template: templates/resource-monitor-scc.yaml
+    set:
+      openshift:
+        scc:
+          enabled: true
+    asserts:
+      - equal:
+          path: users[0]
+          value: system:serviceaccount:tracebloc-node-agents:tracebloc-resource-monitor
+        documentIndex: 0
+      - equal:
+          path: subjects[0].namespace
+          value: tracebloc-node-agents
+        documentIndex: 2

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -131,6 +131,28 @@
       "default": true,
       "description": "Deploy resource-monitor DaemonSet. Defaults to true."
     },
+    "nodeAgents": {
+      "type": "object",
+      "description": "Dedicated namespace for node-level agents (resource-monitor). Isolates hostPath-using DaemonSets from the restricted release namespace.",
+      "properties": {
+        "namespace": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "create": {
+              "type": "boolean",
+              "default": true,
+              "description": "When true, the chart templates the node-agents Namespace with privileged PSA labels. Set false when the namespace is managed out-of-band."
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Name of the namespace that hosts node-level agents. Must exist before install if create is false."
+            }
+          }
+        }
+      }
+    },
     "openshift": {
       "type": "object",
       "properties": {

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -63,6 +63,26 @@ clusterScope: true
 # -- Resource monitor DaemonSet (node-level metrics collection)
 resourceMonitor: true
 
+# -- Node-level agents (currently: tracebloc-resource-monitor DaemonSet).
+# The resource-monitor needs hostPath /proc and /sys to read node metrics,
+# which Pod Security Admission's `restricted` profile bans outright. Rather
+# than diluting the release namespace's PSA profile, node-agents get their
+# own `privileged` namespace so the rest of the workload can run under
+# `enforce: restricted` unblocked.
+#
+# namespace.create: true  -- chart templates the namespace with PSA
+#                            privileged + helm.sh/resource-policy: keep.
+# namespace.create: false -- operator creates the namespace out-of-band
+#                            (e.g. pre-existing cluster, shared namespace,
+#                            or GitOps tool manages it). The chart still
+#                            deploys the DaemonSet, SA, and RBAC into
+#                            namespace.name; it must exist already with
+#                            privileged PSA labels.
+nodeAgents:
+  namespace:
+    create: true
+    name: tracebloc-node-agents
+
 # -- OpenShift-specific settings
 openshift:
   # Create a SecurityContextConstraints allowing hostPath for the resource monitor
@@ -85,9 +105,12 @@ openshift:
 #     pod-security.kubernetes.io/audit=restricted
 #
 # Enforce mode is deliberately left OFF by default -- the mysql init
-# container and the resource-monitor DaemonSet violate the restricted
-# profile (runAsUser: 0 and hostPath respectively). Opting into enforce
-# before those are refactored will break the chart.
+# container still violates the restricted profile (runAsUser: 0). The
+# resource-monitor DaemonSet previously violated `restricted` via its
+# hostPath mounts, but now runs in its own privileged node-agents
+# namespace (see nodeAgents below), so it no longer blocks enforcing
+# restricted on the release namespace. Flip enforce to `restricted`
+# only after the mysql init refactor lands.
 namespace:
   create: false
   podSecurity:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -146,7 +146,7 @@ Set `namespace.create: true` in your values file. The chart will template a `Nam
 - `pod-security.kubernetes.io/audit: restricted` — audit-log events on violations
 - `helm.sh/resource-policy: keep` — `helm uninstall` leaves the namespace and its data intact
 
-Default profile for warn/audit is `restricted`. Enforce (hard rejection) is deliberately left off — the mysql init container runs as UID 0 and the resource-monitor DaemonSet uses `hostPath`; both would be rejected under `restricted` enforcement.
+Default profile for warn/audit is `restricted`. Enforce (hard rejection) is deliberately left off — the mysql init container runs as UID 0 and would be rejected. The resource-monitor DaemonSet previously blocked enforce too (it uses `hostPath`), but now lives in its own dedicated privileged namespace (`nodeAgents.namespace.name`, default `tracebloc-node-agents`), so it no longer constrains the release namespace.
 
 ```yaml
 # my-values.yaml
@@ -155,8 +155,32 @@ namespace:
   podSecurity:
     warn: restricted
     audit: restricted
-    # enforce: "" — leave off until mysql + resource-monitor are refactored
+    # enforce: "" — leave off until the mysql init is refactored
 ```
+
+### Node-agents namespace (resource-monitor)
+
+The `tracebloc-resource-monitor` DaemonSet mounts `hostPath` volumes (`/proc`, `/sys`) which Pod Security Admission's `restricted` profile bans outright. The chart isolates it in a dedicated **privileged** namespace (default `tracebloc-node-agents`) so it does not constrain the restricted profile on the release namespace.
+
+```yaml
+# my-values.yaml (defaults shown)
+nodeAgents:
+  namespace:
+    create: true                 # set false if managing the namespace out-of-band
+    name: tracebloc-node-agents
+```
+
+When `create: false`, create the namespace yourself with the required PSA labels:
+
+```bash
+kubectl create namespace tracebloc-node-agents
+kubectl label namespace tracebloc-node-agents \
+  pod-security.kubernetes.io/enforce=privileged \
+  pod-security.kubernetes.io/warn=privileged \
+  pod-security.kubernetes.io/audit=privileged
+```
+
+**Upgrading an existing release** (where the DaemonSet currently lives in the release namespace): Helm will delete the old DaemonSet / ServiceAccount / RoleBinding from the release namespace and recreate them in the node-agents namespace. Expect a brief gap in node metrics during the upgrade (DaemonSet rollout time; ~15s terminationGracePeriod + pod startup). The ClusterRole/ClusterRoleBinding keep the same name and are updated in place.
 
 ### Existing namespace — apply labels with kubectl
 


### PR DESCRIPTION
## Summary

- Isolates the hostPath-mounting `tracebloc-resource-monitor` DaemonSet in a dedicated **privileged** namespace (`tracebloc-node-agents`, configurable) so it no longer blocks Pod Security Admission `enforce: restricted` on the release namespace.
- Templates the new namespace with `pod-security.kubernetes.io/{enforce,warn,audit}: privileged` and `helm.sh/resource-policy: keep`.
- Moves the ServiceAccount, (Cluster)RoleBinding subject, and OpenShift SCC `users` entry to the new namespace.
- 12 new helm-unittest cases; 67/67 total pass.

## Why

On the EKS cluster `tb-client-dev-templates`, namespace `tracebloc-templates` is running at `warn=restricted` + `audit=restricted` and emits PSA violation warnings on every `tracebloc-resource-monitor-*` pod. Flipping to `enforce=restricted` would reject the DaemonSet outright.

PSA `restricted` bans `hostPath` volumes with no escape hatch, and this DaemonSet legitimately needs `/proc` and `/sys` to read node-level metrics — so "make it compliant" isn't an option. A dedicated privileged namespace is the PSA-recommended pattern for node-level agents.

## Coordination with sibling node-agent fixes

This is one of three related hardenings. The other two cover:

- the non-Helm `resource-monitor` DaemonSet in `edge-infra/Node-deploy/deploy.yaml`
- the `logger-monitor` Deployment in `pods-monitor/deployment.yaml`

This PR establishes `tracebloc-node-agents` as the shared privileged namespace for node-level agents. The sibling `resource-monitor` (also hostPath) should target the same namespace. `logger-monitor` has no hostPath and no privileged caps, so it can either be made restricted-compliant in place or join the node-agents namespace for operational uniformity — caller's choice.

## Upgrade impact

Existing installs: `helm upgrade` will delete the DaemonSet / ServiceAccount / RoleBinding from the release namespace and recreate them in `tracebloc-node-agents`. The ClusterRole and ClusterRoleBinding keep their names and are updated in place. Expect a brief (~seconds) gap in node metrics during the DaemonSet rollout. No persistent data is involved.

New installs: `nodeAgents.namespace.create: true` (default) templates the namespace. Set to `false` if the namespace is managed out-of-band; `docs/INSTALL.md` includes the copy-pasteable `kubectl label` command.

Scope limited to the `client` chart (consistent with PR #43). The legacy `eks/`, `aks/`, `bm/`, `oc/` charts are not touched.

## Changes

- **new** `client/templates/node-agents-namespace.yaml` — gated on `nodeAgents.namespace.create` + `resourceMonitor`
- `client/templates/resource-monitor-daemonset.yaml` — namespace → `.Values.nodeAgents.namespace.name`
- `client/templates/resource-monitor-rbac.yaml` — SA + (Cluster)RoleBinding subject in node-agents ns (both `clusterScope` branches)
- `client/templates/resource-monitor-scc.yaml` — SCC `users` and CRB subject updated (OpenShift path)
- `client/values.yaml` + `client/values.schema.json` — new `nodeAgents.namespace` block; release-namespace comment drops resource-monitor from the enforce-blocker list
- `client/templates/namespace.yaml` + `docs/INSTALL.md` — docs for the new namespace and out-of-band labelling
- **new** `client/tests/node_agents_namespace_test.yaml` — 12 helm-unittest cases (render/skip paths, custom names, SA placement, clusterScope=false, SCC)

## Test plan

- [x] `helm lint ./client` clean
- [x] `helm unittest ./client` — 67/67 tests pass (12 new)
- [x] `helm template` renders DaemonSet, SA, and ClusterRoleBinding subject into `tracebloc-node-agents`
- [x] `helm template` renders node-agents Namespace with privileged PSA + keep annotation
- [x] `helm template --set resourceMonitor=false` renders no node-agents resources
- [x] `helm template --set nodeAgents.namespace.create=false` skips the Namespace but still routes DaemonSet/SA to the configured name
- [x] `helm template --set openshift.scc.enabled=true` updates SCC `users` and CRB subject to `tracebloc-node-agents`
- [ ] Dry-run install on `tb-client-dev-templates` with `namespace.podSecurity.enforce=restricted` → no DaemonSet violations (verify in-cluster)
- [ ] Confirm node metrics ingestion resumes after the DaemonSet rolls over in the new namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes where the `tracebloc-resource-monitor` DaemonSet, ServiceAccount, and RBAC bindings are created, which can break metrics collection or access if namespace/RBAC/Secrets aren’t aligned during upgrade.
> 
> **Overview**
> Moves the `tracebloc-resource-monitor` DaemonSet out of the release namespace into a configurable dedicated `nodeAgents.namespace.name` namespace, and ensures it still targets the release namespace by setting `NAMESPACE` explicitly.
> 
> Adds optional templating of a new node-agents `Namespace` with *privileged* Pod Security Admission labels, updates RBAC/SCC bindings to reference the ServiceAccount in that namespace (including cross-namespace `RoleBinding` when `clusterScope=false`), and mirrors required Secrets (opaque creds + docker registry pull secret) into the node-agents namespace.
> 
> Introduces `nodeAgents.namespace.{create,name}` values/schema, expands install docs for the new namespace/upgrade behavior, and adds helm-unittest coverage for the new rendering and gating logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ced34794b95c5f4b48eab0518f47d8c9d8570df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->