### PR TITLE
feat(psa): enforce=restricted by default on CSI; bare-metal overrides

### DIFF
--- a/client/ci/bm-values.yaml
+++ b/client/ci/bm-values.yaml
@@ -2,6 +2,15 @@
 hostPath:
   enabled: true
 
+# enforce=restricted rejects the privileged init-mysql-data chown container
+# that hostPath installs require (kubelet does not apply fsGroup to hostPath
+# volumes -- kubernetes/kubernetes#138411). warn+audit stay on so violations
+# are still visible.
+namespace:
+  podSecurity:
+    enforce: ""
+    enforceVersion: ""
+
 pvcAccessMode: ReadWriteOnce
 
 storageClass:

--- a/client/templates/namespace.yaml
+++ b/client/templates/namespace.yaml
@@ -8,17 +8,18 @@
   Set namespace.create: true ONLY on greenfield installs to have the chart
   template the Namespace with Pod Security Admission labels applied:
 
-    pod-security.kubernetes.io/warn:  restricted   (kubectl warnings)
-    pod-security.kubernetes.io/audit: restricted   (audit-log events)
-    pod-security.kubernetes.io/enforce: <off>      (does NOT reject pods)
+    pod-security.kubernetes.io/warn:    restricted   (kubectl warnings)
+    pod-security.kubernetes.io/audit:   restricted   (audit-log events)
+    pod-security.kubernetes.io/enforce: restricted   (rejects violating pods)
 
-  Enforce mode is deliberately left unset by default -- the mysql init
-  containers still run as UID 0 and would be rejected. The resource-monitor
-  DaemonSet (hostPath mounts) previously blocked enforce too, but now lives
-  in the dedicated `nodeAgents.namespace.name` namespace (privileged PSA),
-  so it no longer constrains this namespace. Customers can opt into enforce
-  once the mysql init is refactored; `warn` + `audit` give useful visibility
-  in the meantime.
+  enforce=restricted is the default for CSI-backed deployments (EKS/AKS/OC).
+  The mysql init-container has been gated on hostPath.enabled, and the
+  resource-monitor DaemonSet was moved to the dedicated nodeAgents
+  namespace (privileged PSA), so the release namespace no longer has
+  workloads that violate restricted. Bare-metal installs override enforce
+  to "" via ci/bm-values.yaml because kubelet does not apply fsGroup to
+  hostPath volumes (kubernetes/kubernetes#138411), so init-mysql-data is
+  still required there and would be rejected; warn+audit remain on.
 
   helm.sh/resource-policy: keep ensures `helm uninstall` does NOT delete
   the namespace (which would take PVC-backed data with it).

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -102,15 +102,18 @@ openshift:
 # For EXISTING namespaces, leave create: false and apply the labels yourself:
 #   kubectl label namespace <name> \
 #     pod-security.kubernetes.io/warn=restricted \
-#     pod-security.kubernetes.io/audit=restricted
+#     pod-security.kubernetes.io/audit=restricted \
+#     pod-security.kubernetes.io/enforce=restricted
 #
-# Enforce mode is deliberately left OFF by default -- the mysql init
-# container still violates the restricted profile (runAsUser: 0). The
-# resource-monitor DaemonSet previously violated `restricted` via its
-# hostPath mounts, but now runs in its own privileged node-agents
-# namespace (see nodeAgents below), so it no longer blocks enforcing
-# restricted on the release namespace. Flip enforce to `restricted`
-# only after the mysql init refactor lands.
+# enforce=restricted is the default for CSI-backed deployments (EKS/AKS/OC).
+# The mysql init-container has been refactored so it only renders on bare-metal
+# (hostPath.enabled=true); see client/templates/mysql-deployment.yaml.
+# The resource-monitor DaemonSet lives in its own privileged node-agents
+# namespace (nodeAgents.namespace above), so it does not constrain this one.
+# Bare-metal installs override enforce to "" via ci/bm-values.yaml because
+# kubelet does not apply fsGroup to hostPath volumes
+# (kubernetes/kubernetes#138411), so the privileged init-mysql-data chown
+# container is still needed there and would be rejected by restricted.
 namespace:
   create: false
   podSecurity:
@@ -120,9 +123,9 @@ namespace:
     # Audit-log events for pods that violate the profile
     audit: restricted
     auditVersion: "latest"
-    # Pod rejection (leave empty by default; see note above)
-    enforce: ""
-    enforceVersion: ""
+    # Pod rejection -- restricted by default on CSI; bare-metal must override to ""
+    enforce: restricted
+    enforceVersion: "latest"
 
 # -- NetworkPolicy hardening for training pods.
 # Training pods run untrusted ML code; this denies ingress and restricts

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -222,7 +222,7 @@ pod-security.kubernetes.io/audit: restricted
 
 `warn` surfaces violations in `kubectl` output; `audit` writes them to the cluster audit log. These are **visibility**, not enforcement — a tripwire against accidental regressions in pod specs.
 
-`enforce: restricted` is deliberately NOT applied by default because two of the chart's own trusted workloads would be rejected under restricted (see §8.5). Customers who refactor or segregate those can flip enforce on via `namespace.podSecurity.enforce: restricted`.
+`enforce: restricted` is on by default on CSI-backed deployments (EKS/AKS/OC); bare-metal overrides it off via `ci/bm-values.yaml`. See §6.6 and §8.5.
 
 ---
 
@@ -307,6 +307,15 @@ If any assertion reads the wrong way, the CNI is not enforcing — investigate b
 The chart only creates a `Namespace` resource when `namespace.create: true` is explicitly set, and only on greenfield installs. If the namespace was pre-created by `kubectl create namespace` or `helm install --create-namespace`, apply the labels yourself:
 
 ```bash
+# CSI-backed deployments (EKS/AKS/OC): enforce is safe.
+kubectl label namespace <ns> \
+  pod-security.kubernetes.io/warn=restricted \
+  pod-security.kubernetes.io/audit=restricted \
+  pod-security.kubernetes.io/enforce=restricted
+
+# Bare-metal (hostPath): skip enforce -- the privileged init-mysql-data
+# chown container required on hostPath (kubernetes/kubernetes#138411)
+# would be rejected. warn+audit still give visibility.
 kubectl label namespace <ns> \
   pod-security.kubernetes.io/warn=restricted \
   pod-security.kubernetes.io/audit=restricted
@@ -320,12 +329,11 @@ If PSA is active, watch for audit events and kubectl warnings indicating a pod s
 
 Chart versions bundle specific Dockerfile + jobs-manager builds. Mixing an old chart with new images or vice-versa may leave hardening gaps. Prefer `helm install` from a pinned chart version and coordinate upgrades.
 
-### 6.6 Upgrade path: refactor before `enforce: restricted`
+### 6.6 `enforce: restricted` on bare-metal
 
-If the customer wants `pod-security.kubernetes.io/enforce: restricted` on the release namespace (true rejection of non-conforming pods), two chart workloads must first be adjusted:
+`enforce: restricted` is the chart default for CSI-backed deployments. Bare-metal installs (`hostPath.enabled: true`) cannot use enforce because the privileged `init-mysql-data` container — required because kubelet does not apply `fsGroup` to hostPath volumes ([kubernetes/kubernetes#138411](https://github.com/kubernetes/kubernetes/issues/138411)) — would be rejected. `ci/bm-values.yaml` overrides `namespace.podSecurity.enforce` to `""` accordingly. `warn` and `audit` remain on so violations are still logged.
 
-1. **mysql-client** init containers run as `runAsUser: 0` to chown the MySQL PVC. Switch to `fsGroup: 999` on the pod spec and drop the init container — works on most storage classes, test on your specific CSI driver.
-2. **resource-monitor** DaemonSet mounts `hostPath: /proc` and `/sys`. There is no clean way to preserve its function under `restricted`; options are to disable the resource monitor, accept baseline-level admission for that pod, or move it to a separate privileged namespace.
+Node-level agents (`tracebloc-resource-monitor` DaemonSet) run in a separate namespace (`tracebloc-node-agents`) at `enforce: privileged` — they legitimately need hostPath access to `/proc` / `/sys` / cgroups. The release namespace stays clean.
 
 ---
 
@@ -423,9 +431,9 @@ Six task types still run on the legacy `common/ping.py` architecture and write w
 
 Adding a migrated category to `READONLY_ROOTFS_CATEGORIES` in the jobs-manager is the only code change needed to promote it once migrated. A separate engineering team owns the migration.
 
-### 8.5 PSA `enforce: restricted` is not default — **platform team**
+### 8.5 PSA `enforce: restricted` on bare-metal — **operator**
 
-See §6.6. Two chart workloads (mysql init containers, resource-monitor DaemonSet) violate the restricted profile. Refactoring them unlocks full admission-time enforcement. Currently audit/warn only.
+`enforce: restricted` is the chart default for CSI-backed deployments (EKS/AKS/OC). Bare-metal installs cannot use enforce because kubelet does not apply `fsGroup` to hostPath volumes ([kubernetes/kubernetes#138411](https://github.com/kubernetes/kubernetes/issues/138411)), forcing the chart to render a privileged `init-mysql-data` chown container on the hostPath path. `ci/bm-values.yaml` overrides enforce to `""` so the install works; `warn` and `audit` remain on. If / when upstream fixes the hostPath fsGroup gap (or the chart moves to a rootless mysql image that doesn't need the chown), bare-metal can join the enforce default.
 
 ### 8.6 NetworkPolicy silent no-op on unsupported CNI — **operator**
 


### PR DESCRIPTION
## Summary

- Flips `namespace.podSecurity.enforce` default to `restricted` for CSI-backed deployments (EKS/AKS/OC) — closes out the PSA admission-time tripwire that was tracked as residual risk §8.5 in `SECURITY.md`.
- Bare-metal (`hostPath.enabled: true`) keeps `enforce=""` via `ci/bm-values.yaml` because kubelet does not apply `fsGroup` to hostPath volumes ([kubernetes/kubernetes#138411](https://github.com/kubernetes/kubernetes/issues/138411)), so the required privileged `init-mysql-data` chown container would be rejected. `warn` + `audit` remain on.
- Builds on the node-agents segregation from #50: `tracebloc-resource-monitor` lives in its own privileged namespace, so the release namespace has no workloads that need `privileged` anymore (on CSI).

## Changes

- `client/values.yaml` — `namespace.podSecurity.enforce: restricted` (was `""`); docstring rewritten to reflect the CSI-default / bare-metal-override split + point at the already-landed mysql refactor and node-agents segregation.
- `client/ci/bm-values.yaml` — adds `namespace.podSecurity.enforce: ""` override with comment.
- `client/templates/namespace.yaml` — docstring updated.
- `docs/SECURITY.md` — §4.7, §6.3, §6.6, §8.5 rewritten.

## Test plan

- [x] `helm template --set namespace.create=true -f ci/eks-values.yaml` → Namespace renders `pod-security.kubernetes.io/enforce: restricted`; node-agents namespace renders `privileged`.
- [x] `helm template --set namespace.create=true -f ci/bm-values.yaml` → Namespace renders warn+audit only, no enforce label; node-agents namespace renders `privileged`.
- [x] Live cluster (`tb-client-dev-templates` / `tracebloc-templates`): applied `enforce=restricted` manually and rollout-restarted `mysql-client`, `logger-monitor`, `tracebloc-jobs-manager`. All rolled cleanly with no PSA violation events.
- [x] Bare-metal chart install with `namespace.create=true` — not executed in this PR; the override logic uses the same `{{- with }}` path already exercised by the warn+audit case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching PSA to `enforce=restricted` can cause pod rejections on upgrade if any workload still violates the restricted profile or operators apply the labels to existing namespaces incorrectly. Bare-metal remains exempt via `ci/bm-values.yaml`, reducing the risk for hostPath installs.
> 
> **Overview**
> Turns on **Pod Security Admission enforcement** by default by setting `namespace.podSecurity.enforce: restricted` (and `enforceVersion: latest`) in `client/values.yaml`, so violating pods are rejected rather than only warned/audited.
> 
> Adds a bare-metal/hostPath escape hatch in `client/ci/bm-values.yaml` that overrides enforcement back to `""` (warn/audit still on), and updates the Namespace template and `docs/SECURITY.md` to document the CSI-default vs bare-metal behavior and the correct labeling commands for existing namespaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b3716fcdb11b1ff54c08783eb0beae271403d0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->