### PR TITLE
feat(mysql): set readOnlyRootFilesystem on mysql-client

### DIFF
--- a/client/templates/mysql-deployment.yaml
+++ b/client/templates/mysql-deployment.yaml
@@ -45,6 +45,7 @@ spec:
           runAsUser: 999
           runAsGroup: 999
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
             - ALL
@@ -83,6 +84,16 @@ spec:
           mountPath: /etc/mysql/conf.d/
         - name: mysql-logs
           mountPath: /var/log/mysql/
+        # Writable scratch dirs required by mysqld under readOnlyRootFilesystem:
+        # /var/run/mysqld -> pid file + unix socket
+        # /tmp            -> temp tables, sort buffers, LOAD DATA staging
+        # /var/lib/mysql-files -> default secure_file_priv; mysqld touches it at start
+        - name: mysql-run
+          mountPath: /var/run/mysqld
+        - name: mysql-tmp
+          mountPath: /tmp
+        - name: mysql-files
+          mountPath: /var/lib/mysql-files
       {{- if include "tracebloc.useImagePullSecrets" . }}
       imagePullSecrets:
       - name: {{ include "tracebloc.registrySecretName" . }}
@@ -95,4 +106,10 @@ spec:
         configMap:
           name: mysql-client-config
       - name: mysql-logs
+        emptyDir: {}
+      - name: mysql-run
+        emptyDir: {}
+      - name: mysql-tmp
+        emptyDir: {}
+      - name: mysql-files
         emptyDir: {}


### PR DESCRIPTION
## Summary
- Sets `readOnlyRootFilesystem: true` on the mysql-client container
- Adds three emptyDir scratch mounts required by mysqld under ROFS:
  - `/var/run/mysqld` — pid file + unix socket
  - `/tmp` — temp tables, sort buffers, LOAD DATA staging
  - `/var/lib/mysql-files` — default `secure_file_priv`; mysqld touches at start

## Why
Closes the last writable-root surface on the workload side of the chart. The
training-pod refactor already set ROFS; this brings mysql-client to parity so
the entire release namespace runs with immutable container filesystems.

## Test plan
- [x] `helm template` renders clean across AKS / EKS / bm / OC value files
- [x] Live EKS upgrade on the tracebloc-templates release: mysql rolled cleanly,
      0 restarts, jobs-manager heartbeats continue to report mysql_service
      data (query path intact)
- [x] Fresh minikube install from this branch: mysql pod Running 1/1 as UID 999,
      `touch /etc/nope` rejected (ROFS enforced), fresh initdb produced
      `mysql` / `performance_schema` / `sys` / `training_test_datasets`
      databases + certs + ibdata1/ibtmp1/ib_logfile0/1; `/var/run/mysqld` has
      mysqld.pid + mysqld.sock; `/tmp` and `/var/lib/mysql-files` writable