### PR TITLE
feat(client): harden image pinning and credentials (v1.0.4)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.0.3
-appVersion: "1.0.3"
+version: 1.0.4
+appVersion: "1.0.4"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -91,9 +91,17 @@ true
 
 {{/*
 Image reference — defaults to docker.io when no registry is provided.
-Tag defaults to "prod" when CLIENT_ENV is omitted or empty.
-Usage: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "registry" "docker.io") }}
+When `digest` (sha256:...) is set, renders registry/repo@digest (immutable pin,
+preferred for security). Otherwise falls back to registry/repo:tag, where tag
+defaults to "prod" when CLIENT_ENV is omitted or empty.
+Usage: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.jobsManager.digest "registry" "docker.io") }}
 */}}
 {{- define "tracebloc.image" -}}
-{{ .registry | default "docker.io" }}/{{ .repository }}:{{ .tag | default "prod" }}
+{{- $registry := .registry | default "docker.io" -}}
+{{- $digest := .digest | default "" -}}
+{{- if $digest -}}
+{{ $registry }}/{{ .repository }}@{{ $digest }}
+{{- else -}}
+{{ $registry }}/{{ .repository }}:{{ .tag | default "prod" }}
+{{- end -}}
 {{- end }}

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -28,8 +28,8 @@ spec:
           type: RuntimeDefault
       containers:
       - name: api
-        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "registry" "docker.io") | quote }}
-        imagePullPolicy: Always
+        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.jobsManager.digest "registry" "docker.io") | quote }}
+        imagePullPolicy: {{ if .Values.images.jobsManager.digest }}IfNotPresent{{ else }}Always{{ end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -84,8 +84,8 @@ spec:
         {{- end }}
         {{- end }}
       - name: pods-monitor-container
-        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/pods-monitor" "tag" .Values.env.CLIENT_ENV "registry" "docker.io") | quote }}
-        imagePullPolicy: Always
+        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/pods-monitor" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.podsMonitor.digest "registry" "docker.io") | quote }}
+        imagePullPolicy: {{ if .Values.images.podsMonitor.digest }}IfNotPresent{{ else }}Always{{ end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/client/templates/mysql-deployment.yaml
+++ b/client/templates/mysql-deployment.yaml
@@ -29,16 +29,29 @@ spec:
       # deployments (EKS/AKS/OC) skip this and rely on fsGroup.
       initContainers:
       - name: init-mysql-data
-        image: busybox:1.35
+        image: {{ include "tracebloc.image" (dict "repository" "library/busybox" "tag" .Values.images.busybox.tag "digest" .Values.images.busybox.digest "registry" "docker.io") | quote }}
+        # Must run as root to chown the hostPath mount; kubelet does not apply
+        # fsGroup to hostPath volumes (kubernetes/kubernetes#138411).
+        # Scope privilege tightly: only CHOWN is needed, no privilege escalation,
+        # read-only root fs, default seccomp.
         securityContext:
           runAsUser: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+            add: ["CHOWN"]
+          seccompProfile:
+            type: RuntimeDefault
         command: ['sh', '-c', 'chown 999:999 /var/lib/mysql && chmod 755 /var/lib/mysql']
         volumeMounts:
         - name: mysql-persistent-storage
           mountPath: /var/lib/mysql/
       {{- end }}
       containers:
-      - image: {{ include "tracebloc.image" (dict "repository" "tracebloc/mysql-client" "tag" "latest" "registry" "docker.io") | quote }}
+      - image: {{ include "tracebloc.image" (dict "repository" "tracebloc/mysql-client" "tag" (.Values.images.mysqlClient.tag | default "prod") "digest" .Values.images.mysqlClient.digest "registry" "docker.io") | quote }}
+        imagePullPolicy: IfNotPresent
         name: mysql-client
         securityContext:
           runAsNonRoot: true

--- a/client/templates/secrets.yaml
+++ b/client/templates/secrets.yaml
@@ -1,3 +1,7 @@
+{{- $clientId := required "clientId is required (set via --set clientId=... or values file)" .Values.clientId -}}
+{{- $clientPassword := required "clientPassword is required (set via --set clientPassword=... or values file)" .Values.clientPassword -}}
+{{- if regexMatch "^<.*>$" $clientId -}}{{- fail "clientId looks like a placeholder (e.g. \"<CLIENT_ID>\"); set a real value" -}}{{- end -}}
+{{- if regexMatch "^<.*>$" $clientPassword -}}{{- fail "clientPassword looks like a placeholder (e.g. \"<CLIENT_PASSWORD>\"); set a real value" -}}{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,8 +11,8 @@ metadata:
     {{- include "tracebloc.labels" . | nindent 4 }}
 type: Opaque
 data:
-  CLIENT_ID: {{ required "clientId is required" .Values.clientId | b64enc | quote }}
-  CLIENT_PASSWORD: {{ required "clientPassword is required" .Values.clientPassword | b64enc | quote }}
+  CLIENT_ID: {{ $clientId | b64enc | quote }}
+  CLIENT_PASSWORD: {{ $clientPassword | b64enc | quote }}
 {{- if and (ne .Values.resourceMonitor false) (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
 ---
 # Mirrored into the node-agents namespace so the resource-monitor DaemonSet
@@ -24,6 +28,6 @@ metadata:
     app: tracebloc-resource-monitor
 type: Opaque
 data:
-  CLIENT_ID: {{ required "clientId is required" .Values.clientId | b64enc | quote }}
-  CLIENT_PASSWORD: {{ required "clientPassword is required" .Values.clientPassword | b64enc | quote }}
+  CLIENT_ID: {{ $clientId | b64enc | quote }}
+  CLIENT_PASSWORD: {{ $clientPassword | b64enc | quote }}
 {{- end }}

--- a/client/tests/secrets_test.yaml
+++ b/client/tests/secrets_test.yaml
@@ -28,6 +28,8 @@ tests:
   - it: should create docker registry secret when create is true
     template: templates/docker-registry-secret.yaml
     set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
       dockerRegistry:
         create: true
         server: https://index.docker.io/v1/
@@ -49,6 +51,8 @@ tests:
   - it: should not create docker registry secret when create is omitted (default false)
     template: templates/docker-registry-secret.yaml
     set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
       dockerRegistry:
         server: https://index.docker.io/v1/
         username: testuser
@@ -60,9 +64,28 @@ tests:
 
   - it: should not create docker registry secret when dockerRegistry is omitted (public images)
     template: templates/docker-registry-secret.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
     values:
       - values-public-images.yaml
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should reject placeholder clientId value
+    template: templates/secrets.yaml
+    set:
+      clientId: "<CLIENT_ID>"
+      clientPassword: "real-pass"
+    asserts:
+      - failedTemplate: {}
+
+  - it: should reject empty credentials
+    template: templates/secrets.yaml
+    set:
+      clientId: ""
+      clientPassword: ""
+    asserts:
+      - failedTemplate: {}
 

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -241,15 +241,69 @@
         }
       }
     },
+    "images": {
+      "type": "object",
+      "description": "Container image pinning. Prefer digest over tag for immutability.",
+      "properties": {
+        "jobsManager": {
+          "type": "object",
+          "properties": {
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$",
+              "description": "Optional image digest (sha256:...). When set, overrides the tag."
+            }
+          }
+        },
+        "podsMonitor": {
+          "type": "object",
+          "properties": {
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$"
+            }
+          }
+        },
+        "mysqlClient": {
+          "type": "object",
+          "properties": {
+            "tag": {
+              "type": "string",
+              "not": { "const": "latest" },
+              "description": "Image tag for mysql-client. Empty falls back to env.CLIENT_ENV. Must not be \"latest\"."
+            },
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$"
+            }
+          }
+        },
+        "busybox": {
+          "type": "object",
+          "properties": {
+            "tag": {
+              "type": "string",
+              "not": { "const": "latest" }
+            },
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$"
+            }
+          }
+        }
+      }
+    },
     "clientId": {
       "type": "string",
       "minLength": 1,
-      "description": "Client ID for authentication"
+      "not": { "pattern": "^<.*>$" },
+      "description": "Client ID for authentication. Must be a real value, not a placeholder like <CLIENT_ID>."
     },
     "clientPassword": {
       "type": "string",
       "minLength": 1,
-      "description": "Client authentication password"
+      "not": { "pattern": "^<.*>$" },
+      "description": "Client authentication password. Must be a real value, not a placeholder like <CLIENT_PASSWORD>."
     },
     "dockerRegistry": {
       "type": ["object", "null"],

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -156,9 +156,35 @@ networkPolicy:
       - "172.16.0.0/12"
       - "192.168.0.0/16"
 
+# -- Container image pinning.
+# For each image, set `digest` to a sha256 (e.g. "sha256:abc123...") to pin
+# the image by content hash. Digest pinning is strongly preferred: tags are
+# mutable, so registry swaps can silently change what you run. When `digest`
+# is set the tag field is ignored and imagePullPolicy drops to IfNotPresent.
+# Leave `digest` empty to fall back to tag-based pulls (CLIENT_ENV for
+# tracebloc images, `tag` for busybox/mysql-client).
+images:
+  jobsManager:
+    digest: ""
+  podsMonitor:
+    digest: ""
+  mysqlClient:
+    # mysql-client is only published under the "prod" tag — it has no dev/
+    # staging variants, so we decouple it from env.CLIENT_ENV. Override only
+    # if you are publishing your own fork with a different tag. Never use
+    # "latest"; pin via digest instead.
+    tag: ""
+    digest: ""
+  busybox:
+    tag: "1.35"
+    digest: ""
+
 # -- Secrets
-clientId: "<CLIENT_ID>"
-clientPassword: "<CLIENT_PASSWORD>"
+# These MUST be set via --set, a values file, or an external secret manager.
+# The defaults are intentionally empty; deployment fails fast if they are not
+# overridden. Do NOT commit real credentials to version control.
+clientId: ""
+clientPassword: ""
 
 # -- Docker registry credentials (optional; only used when dockerRegistry is set and create is true)
 # Omit dockerRegistry entirely, or set create: false, for public images (no imagePullSecrets).


### PR DESCRIPTION
## Summary

Address the High-severity findings from the client chart security review.

- **Digest pinning** — `tracebloc.image` helper now supports an optional `digest` field. New `images.jobsManager.digest`, `images.podsMonitor.digest`, `images.mysqlClient.digest`, and `images.busybox.digest` values render `repo@sha256:...` and drop `imagePullPolicy` to `IfNotPresent` for immutable, auditable rollouts.
- **Remove `mysql-client:latest`** — now uses `images.mysqlClient.tag` (default `"prod"`). The schema rejects `"latest"`; operators wanting absolute pinning should set `images.mysqlClient.digest`.
- **Harden bare-metal mysql init-container** — still runs as root (kubelet does not apply `fsGroup` to hostPath volumes, [k8s#138411](https://github.com/kubernetes/kubernetes/issues/138411)), but now with `drop: [ALL]` + `add: [CHOWN]`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and `seccompProfile: RuntimeDefault`.
- **Remove deceptive credential placeholders** — `clientId` / `clientPassword` defaults are now empty strings. Both the schema and `secrets.yaml` reject empty values *and* `<...>`-style placeholders so deployments fail fast instead of silently base64-encoding a placeholder into the `Secret`.

Chart bumped `1.0.3` → `1.0.4`.

## Test plan

- [x] `helm lint client` passes (CSI and bare-metal value sets)
- [x] `helm unittest client` — all 76 tests pass, plus new coverage for placeholder and empty-credential rejection
- [x] `helm template` renders correct digest form when `images.*.digest` is set
- [x] `helm template` with `clientId: "<CLIENT_ID>"` fails schema validation
- [ ] Smoke install on a CSI cluster (EKS/AKS) with and without `images.mysqlClient.digest`
- [ ] Smoke install on bare-metal with `hostPath.enabled=true` to confirm the hardened init-container still succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes rendered image references/pull policies and makes `clientId`/`clientPassword` validation fail-fast, which can break existing installs that relied on placeholders or implicit pulls.
> 
> **Overview**
> Bumps the chart/app version to `1.0.4` and adds an `images.*` values block to support **optional digest-pinned images** via `tracebloc.image` (rendering `repo@sha256:...` when provided) and adjusts `imagePullPolicy` accordingly.
> 
> Removes mutable image usage by switching MySQL and init-container images to configurable tags/digests (rejecting `latest` for `mysql-client`/`busybox`) and tightens the bare-metal MySQL `initContainer` security context (minimal capabilities, no escalation, read-only rootfs, default seccomp).
> 
> Makes credentials **mandatory and non-placeholder**: defaults for `clientId`/`clientPassword` become empty, `secrets.yaml` fails on empty or `<...>` values, schema validation is updated to enforce this, and Helm unit tests are updated/added to cover the new failure cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eac812a6189f252a0057a5917a3f08e2a80c7837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->