### PR TITLE
feat(installer): slim k3d and add dev overrides for local testing

### DIFF
--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -18,8 +18,6 @@
 #    $env:SERVERS       = "1"              default: 1  (control-plane nodes)
 #    $env:AGENTS        = "1"              default: 1  (worker nodes)
 #    $env:K8S_VERSION   = "v1.29.4-k3s1"  default: latest
-#    $env:HTTP_PORT     = "80"             default: 80
-#    $env:HTTPS_PORT    = "443"            default: 443
 #    $env:HOST_DATA_DIR = "C:\data"        default: $env:USERPROFILE\.tracebloc
 #    $env:CLIENT_ENV    = "dev"            optional; if not set, CLIENT_ENV is not added to env in values
 # =============================================================================
@@ -118,8 +116,6 @@ $CLUSTER_NAME  = if ($env:CLUSTER_NAME)  { $env:CLUSTER_NAME }  else { "traceblo
 $SERVERS       = if ($env:SERVERS)       { $env:SERVERS }       else { "1" }
 $AGENTS        = if ($env:AGENTS)        { $env:AGENTS }        else { "1" }
 $K8S_VERSION   = if ($env:K8S_VERSION)   { $env:K8S_VERSION }   else { "v1.29.4-k3s1" }
-$HTTP_PORT     = if ($env:HTTP_PORT)     { $env:HTTP_PORT }     else { "80" }
-$HTTPS_PORT    = if ($env:HTTPS_PORT)    { $env:HTTPS_PORT }    else { "443" }
 $HOST_DATA_DIR = if ($env:HOST_DATA_DIR) { $env:HOST_DATA_DIR } else { "$env:USERPROFILE\.tracebloc" }
 $CLIENT_ENV    = $env:CLIENT_ENV
 
@@ -149,8 +145,6 @@ Advanced configuration (environment variables):
   AGENTS         Worker nodes                    (default: 1)
   K8S_VERSION    k3s image tag                   (default: v1.29.4-k3s1)
   -NoReboot      Skip reboot prompt after enabling Windows features
-  HTTP_PORT      Host HTTP  port                 (default: 80)
-  HTTPS_PORT     Host HTTPS port                 (default: 443)
   HOST_DATA_DIR  Persistent data directory       (default: ~\.tracebloc)
 
 macOS / Linux:
@@ -172,15 +166,6 @@ function Confirm-Config {
   }
   if ($SERVERS -notmatch '^[1-9]\d*$') { Err ("SERVERS must be a positive integer >= 1 (got '" + $SERVERS + "')") }
   if ($AGENTS  -notmatch '^\d+$') { Err ("AGENTS must be a non-negative integer (got '" + $AGENTS + "')") }
-  if ($HTTP_PORT  -notmatch '^\d+$' -or [int]$HTTP_PORT -lt 1 -or [int]$HTTP_PORT -gt 65535) {
-    Err ("HTTP_PORT must be 1-65535 (got '" + $HTTP_PORT + "')")
-  }
-  if ($HTTPS_PORT -notmatch '^\d+$' -or [int]$HTTPS_PORT -lt 1 -or [int]$HTTPS_PORT -gt 65535) {
-    Err ("HTTPS_PORT must be 1-65535 (got '" + $HTTPS_PORT + "')")
-  }
-  if ($HTTP_PORT -eq $HTTPS_PORT) {
-    Err ("HTTP_PORT and HTTPS_PORT must be different (both set to " + $HTTP_PORT + ")")
-  }
   $dataDir = [System.IO.Path]::GetFullPath($HOST_DATA_DIR)
   $userProfile = [System.IO.Path]::GetFullPath($env:USERPROFILE)
   if (-not $dataDir.StartsWith($userProfile, [StringComparison]::OrdinalIgnoreCase)) {
@@ -231,7 +216,7 @@ function Print-Banner {
   Hint "  ~\.tracebloc\    (data and config)"
   Hint "  Docker           (container runtime)"
   Write-Host ""
-  Log "Cluster='$CLUSTER_NAME'  Servers=$SERVERS  Agents=$AGENTS  HTTP=$HTTP_PORT  HTTPS=$HTTPS_PORT"
+  Log "Cluster='$CLUSTER_NAME'  Servers=$SERVERS  Agents=$AGENTS"
   Log "Host data dir: $HOST_DATA_DIR"
 }
 
@@ -715,14 +700,20 @@ function New-K3dCluster {
       New-Item -ItemType Directory -Path $HOST_DATA_DIR -Force | Out-Null
     }
 
+    # The tracebloc client is outbound-only: jobs-manager + pods-monitor dial
+    # out to the platform, and the only in-cluster Service (mysql-client) is
+    # ClusterIP. Disable k3s components that exist solely to handle inbound
+    # traffic or duplicate chart-provided resources.
     $k3dArgs = @(
       "cluster", "create", $CLUSTER_NAME,
       "--servers", $SERVERS,
       "--agents",  $AGENTS,
-      "--port",    "${HTTP_PORT}:80@loadbalancer",
-      "--port",    "${HTTPS_PORT}:443@loadbalancer",
       "--api-port","6550",
       "-v",        "${HOST_DATA_DIR}:/tracebloc@all",
+      "--k3s-arg", "--disable=traefik@server:*",
+      "--k3s-arg", "--disable=servicelb@server:*",
+      "--k3s-arg", "--disable=metrics-server@server:*",
+      "--k3s-arg", "--disable=local-storage@server:*",
       "--wait"
     )
 
@@ -1069,7 +1060,6 @@ function Print-Summary {
   Log ""
   Log "=== Advanced Info (for debugging) ==="
   Log "Cluster topology: Servers=$SERVERS  Agents=$AGENTS"
-  Log "Ingress: localhost:$HTTP_PORT / localhost:$HTTPS_PORT"
   Log "Volume mount: $HOST_DATA_DIR -> /tracebloc"
   Log ""
   Log "Useful commands:"

--- a/scripts/install-k8s.sh
+++ b/scripts/install-k8s.sh
@@ -18,8 +18,6 @@
 #    SERVERS=1                   default: 1  (control-plane nodes)
 #    AGENTS=1                    default: 1  (worker nodes)
 #    K8S_VERSION=v1.29.4-k3s1   default: latest stable k3s
-#    HTTP_PORT=80                default: 80   (host → cluster ingress)
-#    HTTPS_PORT=443              default: 443
 #    HOST_DATA_DIR=~/.tracebloc  default: ~/.tracebloc
 #    CLIENT_ENV=dev              optional; if not set, CLIENT_ENV is not added to env in values
 #    TRACEBLOC_SKIP_REBOOT_PROMPT=1 (Linux) skip "Reboot now?" after NVIDIA driver install

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -69,14 +69,24 @@ _handle_existing_cluster() {
 }
 
 _create_new_cluster() {
+  # The tracebloc client is outbound-only: jobs-manager + pods-monitor dial out
+  # to the platform, and the only in-cluster Service (mysql-client) is ClusterIP.
+  # So we disable k3s components that exist solely to handle inbound traffic
+  # or duplicate chart-provided resources:
+  #   traefik        — no Ingress resources in the chart
+  #   servicelb      — no LoadBalancer Services
+  #   metrics-server — chart ships its own tracebloc-resource-monitor DaemonSet
+  #   local-storage  — chart creates its own StorageClass (client-storage-class)
   K3D_ARGS=(
     cluster create "$CLUSTER_NAME"
     --servers "$SERVERS"
     --agents  "$AGENTS"
-    --port "${HTTP_PORT}:80@loadbalancer"
-    --port "${HTTPS_PORT}:443@loadbalancer"
     --api-port 6550
     -v "${HOST_DATA_DIR}:/tracebloc@all"
+    --k3s-arg "--disable=traefik@server:*"
+    --k3s-arg "--disable=servicelb@server:*"
+    --k3s-arg "--disable=metrics-server@server:*"
+    --k3s-arg "--disable=local-storage@server:*"
     --wait
   )
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -238,8 +238,6 @@ SERVERS="${SERVERS:-1}"
 AGENTS="${AGENTS:-1}"
 # Pinned default; set K8S_VERSION="" to use latest (may break on new k3s releases)
 K8S_VERSION="${K8S_VERSION:-v1.29.4-k3s1}"
-HTTP_PORT="${HTTP_PORT:-80}"
-HTTPS_PORT="${HTTPS_PORT:-443}"
 HOST_DATA_DIR="${HOST_DATA_DIR:-$HOME/.tracebloc}"
 
 # ── Input validation ────────────────────────────────────────────────────────
@@ -252,12 +250,6 @@ validate_config() {
 
   [[ "$SERVERS" =~ ^[1-9][0-9]*$ ]] || error "SERVERS must be a positive integer >= 1 (got '$SERVERS')"
   [[ "$AGENTS"  =~ ^[0-9]+$ ]]     || error "AGENTS must be a non-negative integer (got '$AGENTS')"
-
-  [[ "$HTTP_PORT" =~ ^[0-9]+$ ]]  || error "HTTP_PORT must be a number (got '$HTTP_PORT')"
-  [[ "$HTTPS_PORT" =~ ^[0-9]+$ ]] || error "HTTPS_PORT must be a number (got '$HTTPS_PORT')"
-  (( HTTP_PORT >= 1 && HTTP_PORT <= 65535 ))   || error "HTTP_PORT must be 1-65535 (got '$HTTP_PORT')"
-  (( HTTPS_PORT >= 1 && HTTPS_PORT <= 65535 )) || error "HTTPS_PORT must be 1-65535 (got '$HTTPS_PORT')"
-  (( HTTP_PORT != HTTPS_PORT )) || error "HTTP_PORT and HTTPS_PORT must be different (both set to $HTTP_PORT)"
 
   # HOST_DATA_DIR must be under $HOME and must not be a system path (security)
   local dir="$HOST_DATA_DIR"
@@ -362,8 +354,6 @@ Advanced configuration (environment variables):
   SERVERS        Control-plane nodes             (default: 1)
   AGENTS         Worker nodes                    (default: 1)
   K8S_VERSION    k3s image tag                   (default: v1.29.4-k3s1)
-  HTTP_PORT      Host HTTP  port                 (default: 80)
-  HTTPS_PORT     Host HTTPS port                 (default: 443)
   HOST_DATA_DIR  Persistent data directory       (default: ~/.tracebloc)
 
 Windows:

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -74,6 +74,18 @@ install_client_helm() {
   _ensure_tracebloc_dirs
   local values_file="${HOST_DATA_DIR}/values.yaml"
 
+  # ── Dev-mode override: caller-supplied values file ───────────────────────
+  # When TRACEBLOC_VALUES_FILE is set, skip prompts and values.yaml generation
+  # and use the provided file as-is. Used for local testing against an
+  # unreleased chart (pair with TRACEBLOC_CHART_PATH).
+  if [[ -n "${TRACEBLOC_VALUES_FILE:-}" ]]; then
+    [[ -f "$TRACEBLOC_VALUES_FILE" ]] || error "TRACEBLOC_VALUES_FILE not found: $TRACEBLOC_VALUES_FILE"
+    values_file="$TRACEBLOC_VALUES_FILE"
+    TB_NAMESPACE="${TB_NAMESPACE:-default}"
+    info "Dev mode: using caller-provided values file"
+    log "Using values file: $values_file (namespace: $TB_NAMESPACE)"
+  else
+
   local use_existing=""
   local default_namespace="default"
   local default_client_id=""
@@ -191,23 +203,33 @@ EOF
 
   chmod 600 "$values_file" 2>/dev/null || true
   log "Values file written to $values_file"
+  fi
 
   _ensure_helm_runnable
 
-  # ── Add repo and install (all output goes to log) ───────────────────────
-  if ! helm repo list 2>/dev/null | grep -q "^${TRACEBLOC_HELM_REPO_NAME}[[:space:]]"; then
-    log "Adding Helm repo: $TRACEBLOC_HELM_REPO_URL"
-    helm repo add "$TRACEBLOC_HELM_REPO_NAME" "$TRACEBLOC_HELM_REPO_URL" >> "${LOG_FILE:-/dev/null}" 2>&1
+  # ── Resolve chart reference: local path (dev) or remote repo (default) ──
+  local chart_ref
+  if [[ -n "${TRACEBLOC_CHART_PATH:-}" ]]; then
+    [[ -d "$TRACEBLOC_CHART_PATH" ]] || error "TRACEBLOC_CHART_PATH not found: $TRACEBLOC_CHART_PATH"
+    chart_ref="$TRACEBLOC_CHART_PATH"
+    info "Dev mode: using local chart at $chart_ref"
+    log "Using local chart: $chart_ref"
+  else
+    if ! helm repo list 2>/dev/null | grep -q "^${TRACEBLOC_HELM_REPO_NAME}[[:space:]]"; then
+      log "Adding Helm repo: $TRACEBLOC_HELM_REPO_URL"
+      helm repo add "$TRACEBLOC_HELM_REPO_NAME" "$TRACEBLOC_HELM_REPO_URL" >> "${LOG_FILE:-/dev/null}" 2>&1
+    fi
+    log "Updating Helm repos..."
+    helm repo update >> "${LOG_FILE:-/dev/null}" 2>&1
+    chart_ref="$TRACEBLOC_HELM_REPO_NAME/$TRACEBLOC_CHART_NAME"
   fi
-  log "Updating Helm repos..."
-  helm repo update >> "${LOG_FILE:-/dev/null}" 2>&1
 
   echo ""
-  log "Installing $TB_NAMESPACE from $TRACEBLOC_HELM_REPO_NAME/$TRACEBLOC_CHART_NAME in namespace '$TB_NAMESPACE'..."
+  log "Installing $TB_NAMESPACE from $chart_ref in namespace '$TB_NAMESPACE'..."
 
   local helm_log
   helm_log="$(mktemp)"
-  if ! helm upgrade --install "$TB_NAMESPACE" "$TRACEBLOC_HELM_REPO_NAME/$TRACEBLOC_CHART_NAME" \
+  if ! helm upgrade --install "$TB_NAMESPACE" "$chart_ref" \
     --namespace "$TB_NAMESPACE" \
     --create-namespace \
     --values "$values_file" > "$helm_log" 2>&1; then

--- a/scripts/lib/summary.sh
+++ b/scripts/lib/summary.sh
@@ -53,7 +53,6 @@ _log_advanced_info() {
   log ""
   log "=== Advanced Info (for debugging) ==="
   log "Cluster topology: Servers=$SERVERS  Agents=$AGENTS"
-  log "Ingress: localhost:$HTTP_PORT / localhost:$HTTPS_PORT"
   log "Volume mount: $HOST_DATA_DIR → /tracebloc"
   log ""
   log "Useful commands:"


### PR DESCRIPTION
## Summary
- Drop unused k3s bundled components from the installer's k3d cluster: **traefik**, **servicelb**, **metrics-server**, **local-storage**. The tracebloc client is outbound-only (jobs-manager/pods-monitor dial out; only in-cluster Service is mysql-client ClusterIP), and the chart ships its own StorageClass + resource-monitor DaemonSet.
- Remove `HTTP_PORT` / `HTTPS_PORT` env vars, validation, help text, and loadbalancer port mappings — nothing in the chart binds them.
- Add two env-var overrides to `scripts/lib/install-client-helm.sh` so the installer can be run end-to-end against a local unreleased chart + custom values file:
  - `TRACEBLOC_CHART_PATH` — install from a local chart path instead of the remote `tracebloc/client` Helm repo
  - `TRACEBLOC_VALUES_FILE` — use the caller-supplied values file as-is, skipping the clientId/password prompts and values.yaml generation
- Mirrored all changes in `scripts/install-k8s.ps1` for Windows parity (pwsh AST parse verified).

## Why
1. On constrained laptops the unused k3s extras cost noticeable RAM and pollute `kube-system` with resources we never touch. After the recent PSA/security hardening the client is meaningfully client-only, so the platform can be slimmed to match.
2. Before this change, the installer always pulled the chart from `tracebloc/client` (published). There was no way to exercise the real install flow against a chart branch or local edit — you had to bypass the installer entirely and run `helm` manually, which diverges from the prod code path (prompt flow, values generation, logging, cluster setup). The two env-var overrides unblock dev testing without altering default behaviour.

## Test plan
- [ ] Default flow still works: run installer with no env vars → installs from remote Helm repo, prompts for clientId/password, writes generated values.yaml.
- [ ] Local-chart flow on macOS: `TRACEBLOC_CHART_PATH=$PWD/client TRACEBLOC_VALUES_FILE=$PWD/value_files/values-mac-tb-client-local-asad.yaml bash ./scripts/install-k8s.sh` → installs local chart with supplied values, no prompts.
- [ ] `kubectl -n kube-system get pods` after install shows no traefik / svclb / metrics-server / local-path pods.
- [ ] Chart workloads come up healthy: `jobs-manager`, `mysql-client`, `tracebloc-resource-monitor` (in `tracebloc-node-agents`).
- [ ] `bash -n` passes on all modified .sh files; `pwsh` AST parse passes on `install-k8s.ps1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches installer logic for cluster creation and Helm installation, so regressions could break fresh installs or change cluster behavior, but changes are contained to setup scripts and mainly disable unused components.
> 
> **Overview**
> **Installer cluster setup is slimmed down.** New k3d cluster creation now disables bundled k3s components (`traefik`, `servicelb`, `metrics-server`, `local-storage`) and removes the previous loadbalancer port mappings.
> 
> **Ingress port configuration is removed.** `HTTP_PORT`/`HTTPS_PORT` env vars, validation, and related help/log output are dropped across both PowerShell and bash scripts.
> 
> **Dev-mode Helm install overrides are added (bash).** `install-client-helm.sh` can now (optionally) install from a local chart via `TRACEBLOC_CHART_PATH` and/or use a caller-provided values file via `TRACEBLOC_VALUES_FILE` (skipping prompts/values generation), while keeping the default remote-repo install path unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 864766b1b8d29f9c37e5e79fac2c4f0e1cf5a6b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->