### PR TITLE
feat(client): require metrics-server for resource-monitor (v1.0.5)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.0.4
-appVersion: "1.0.4"
+version: 1.0.5
+appVersion: "1.0.5"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -1,4 +1,18 @@
 {{- if ne .Values.resourceMonitor false }}
+{{/*
+  Pre-flight: resource-monitor polls the metrics.k8s.io API. Without
+  metrics-server registered, the DaemonSet crash-loops with 404s. We probe
+  kube-system via `lookup` first — that returns empty during `helm template`
+  (no cluster access), so offline rendering isn't blocked. On a real install
+  where lookup can see the cluster, we require metrics-server up front.
+*/}}
+{{- $probe := lookup "v1" "Namespace" "" "kube-system" -}}
+{{- if $probe -}}
+{{- $metrics := lookup "apiregistration.k8s.io/v1" "APIService" "" "v1beta1.metrics.k8s.io" -}}
+{{- if not $metrics -}}
+{{- fail "resourceMonitor is enabled but the metrics.k8s.io/v1beta1 API is not registered. Install metrics-server (https://github.com/kubernetes-sigs/metrics-server) or set resourceMonitor: false. See SECURITY.md." -}}
+{{- end -}}
+{{- end }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -60,7 +60,20 @@ pvc:
 # -- RBAC scope: true for ClusterRole, false for namespace-scoped Role (recommended for OpenShift without cluster-admin)
 clusterScope: true
 
-# -- Resource monitor DaemonSet (node-level metrics collection)
+# -- Resource monitor DaemonSet (node-level metrics collection).
+# REQUIRES metrics-server (https://github.com/kubernetes-sigs/metrics-server):
+# the DaemonSet polls /apis/metrics.k8s.io/v1beta1 for node CPU/memory and
+# crash-loops with 404s when metrics-server is missing. The chart's
+# resource-monitor-daemonset.yaml has a pre-install `lookup` that fails the
+# release up front so misconfiguration surfaces loudly. Platform notes:
+#   k3d / k3s: metrics-server bundled by default (installer keeps it enabled).
+#   AKS:       metrics-server enabled by default.
+#   EKS:       NOT installed by default — `kubectl apply -f \
+#              https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml`
+#   OC:        uses the built-in OpenShift metrics stack.
+#   kubeadm / bare-metal: install metrics-server manually; add
+#              --kubelet-insecure-tls on clusters with self-signed kubelet certs.
+# Set to false on clusters where metrics-server cannot be installed.
 resourceMonitor: true
 
 # -- Node-level agents (currently: tracebloc-resource-monitor DaemonSet).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -92,7 +92,7 @@ The customer deploys a single Helm chart (this repo) that creates, in their clus
 - **jobs-manager** (Deployment) — long-running listener on Azure Service Bus; spawns training `Job` objects in response to backend messages.
 - **pods-monitor** (sidecar in jobs-manager) — watches training pod lifecycle.
 - **mysql-client** (Deployment) — local MySQL for dataset metadata.
-- **resource-monitor** (DaemonSet) — per-node metrics collection.
+- **resource-monitor** (DaemonSet) — per-node metrics collection. Requires `metrics-server` (polls `/apis/metrics.k8s.io/v1beta1`); the chart fails the install up front if it's missing. Disable via `resourceMonitor: false` on clusters where metrics-server cannot be installed.
 - Supporting: ServiceAccount, RBAC Role/ClusterRole, PVCs, Secrets, optional NetworkPolicy, optional Namespace.
 
 When the backend assigns an experiment to this edge, jobs-manager creates a Kubernetes `Job`. The resulting pod runs a training image (`tracebloc/client-<category>-<arch>`) that executes the uploaded user code.

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -75,8 +75,11 @@ _create_new_cluster() {
   # or duplicate chart-provided resources:
   #   traefik        — no Ingress resources in the chart
   #   servicelb      — no LoadBalancer Services
-  #   metrics-server — chart ships its own tracebloc-resource-monitor DaemonSet
   #   local-storage  — chart creates its own StorageClass (client-storage-class)
+  #
+  # metrics-server is kept: the tracebloc-resource-monitor DaemonSet queries
+  # the metrics.k8s.io API for node CPU/memory; without it the DaemonSet
+  # crash-loops with 404s against /apis/metrics.k8s.io/v1beta1.
   K3D_ARGS=(
     cluster create "$CLUSTER_NAME"
     --servers "$SERVERS"
@@ -85,7 +88,6 @@ _create_new_cluster() {
     -v "${HOST_DATA_DIR}:/tracebloc@all"
     --k3s-arg "--disable=traefik@server:*"
     --k3s-arg "--disable=servicelb@server:*"
-    --k3s-arg "--disable=metrics-server@server:*"
     --k3s-arg "--disable=local-storage@server:*"
     --wait
   )


### PR DESCRIPTION
## Summary

The `tracebloc-resource-monitor` DaemonSet queries `metrics.k8s.io/v1beta1` for node CPU/memory. Without `metrics-server` registered, the DaemonSet crash-loops with 404s against `/apis/metrics.k8s.io/v1beta1` — silently, every few seconds. Found during the v1.0.4 bare-metal smoke test on a k3d cluster where `metrics-server` had been explicitly disabled.

- **`scripts/lib/cluster.sh`** — drop `--disable=metrics-server` from the k3d create args. k3s bundles `metrics-server`; the prior comment claiming the chart "ships its own" was wrong — the DaemonSet is a **consumer** of `metrics-server`, not a replacement.
- **`client/templates/resource-monitor-daemonset.yaml`** — add a pre-install `lookup` that fails the release up front when `resourceMonitor: true` but `v1beta1.metrics.k8s.io` is not registered. Guarded by a `kube-system` probe so offline `helm template` still renders cleanly.
- **`client/values.yaml`** — document the dependency inline, with per-platform install notes (k3d/AKS bundled; EKS/OC/bare-metal need manual install).
- **`docs/SECURITY.md`** — call out the dependency and the `resourceMonitor: false` escape hatch.
- Chart bumped `1.0.4` → `1.0.5`.

## Test plan

- [x] `helm lint` passes
- [x] `helm unittest client` — 76/76 tests pass
- [x] Offline `helm template` still renders (pre-flight `lookup` returns empty without cluster access)
- [x] `helm install` against a cluster **without** metrics-server fails loudly with the expected error
- [x] `helm install` with `resourceMonitor: false` succeeds on a metrics-less cluster (escape hatch verified)
- [x] Fresh k3d cluster created with the new `cluster.sh` args → metrics API available in ~30s, `resource-monitor` reaches `Running`, zero `ERROR`/`404` log lines

Target: `develop`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new install-time hard fail based on cluster state, which can block upgrades/installs on clusters without metrics-server unless `resourceMonitor` is disabled.
> 
> **Overview**
> Adds a Helm pre-flight check in `client/templates/resource-monitor-daemonset.yaml` that uses `lookup` to detect whether `v1beta1.metrics.k8s.io` is registered and **fails the release** when `resourceMonitor: true` but metrics-server is missing (while keeping `helm template` offline renders working).
> 
> Updates documentation and defaults commentary (`values.yaml`, `docs/SECURITY.md`) to explicitly state the metrics-server dependency and the `resourceMonitor: false` escape hatch, removes disabling metrics-server from the k3d cluster bootstrap script, and bumps the chart/app version to `1.0.5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc89f6e612d66d83040a21ace6da1c5f1616dd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->