### PR TITLE
ix(mysql): drop chmod from hostPath init (v1.0.6)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.0.5
-appVersion: "1.0.5"
+version: 1.0.6
+appVersion: "1.0.6"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/mysql-deployment.yaml
+++ b/client/templates/mysql-deployment.yaml
@@ -32,8 +32,10 @@ spec:
         image: {{ include "tracebloc.image" (dict "repository" "library/busybox" "tag" .Values.images.busybox.tag "digest" .Values.images.busybox.digest "registry" "docker.io") | quote }}
         # Must run as root to chown the hostPath mount; kubelet does not apply
         # fsGroup to hostPath volumes (kubernetes/kubernetes#138411).
-        # Scope privilege tightly: only CHOWN is needed, no privilege escalation,
-        # read-only root fs, default seccomp.
+        # Scope privilege tightly: only CHOWN is needed — no FOWNER, so do not
+        # chmod here. On re-install the dir is already owned by 999, and
+        # chmod-by-non-owner without CAP_FOWNER returns EPERM (kubelet creates
+        # the dir 0755 via DirectoryOrCreate, so chmod was a no-op anyway).
         securityContext:
           runAsUser: 0
           runAsNonRoot: false
@@ -44,7 +46,7 @@ spec:
             add: ["CHOWN"]
           seccompProfile:
             type: RuntimeDefault
-        command: ['sh', '-c', 'chown 999:999 /var/lib/mysql && chmod 755 /var/lib/mysql']
+        command: ['sh', '-c', 'chown 999:999 /var/lib/mysql']
         volumeMounts:
         - name: mysql-persistent-storage
           mountPath: /var/lib/mysql/


### PR DESCRIPTION
## Summary
- Drop `chmod 755` from the mysql init-container; keep only `chown 999:999`.
- Bump chart to `1.0.6`.

## Why
`init-mysql-data` uses `drop:[ALL] add:[CHOWN]` — no `CAP_FOWNER`. Once `chown` transfers ownership to UID 999, the subsequent `chmod` runs as non-owner and returns EPERM. Reversing the order doesn't fix it either: on re-install the hostPath dir is already 999-owned from the previous run.

kubelet's `DirectoryOrCreate` sets mode `0755` already, so the chmod was a no-op on fresh installs. Drop it.

## Test plan
- [x] Fresh install: delete hostPath dir, restart pod → kubelet creates `root:root 0755`, chown succeeds, mysql up 1/1.
- [x] Re-install: pre-existing `999:999` dir with mysql data, restart pod → chown no-op, mysql up 1/1, data intact.
- [x] `helm lint ./client --set clientId=x --set clientPassword=x` passes.
- [x] Verified on AWS VM (Ubuntu 22.04, kernel 6.8) inside k3d.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm change that only adjusts an init-container command and chart version; main impact is on bare-metal `hostPath` installs where startup behavior changes slightly.
> 
> **Overview**
> Fixes `mysql-client` bare-metal `hostPath` initialization by removing the `chmod 755` step from the `init-mysql-data` initContainer, leaving only `chown 999:999` to avoid `EPERM` on re-installs with a non-owner process.
> 
> Bumps the Helm chart `version`/`appVersion` from `1.0.5` to `1.0.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1955724448f71e084a2e054a777e9ed8827dc4d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->