### PR TITLE
Prod: harden training pod security measures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Narrow CODEOWNERS — security backstop only.
+# Author picks reviewers for everything else; this just ensures a security-aware
+# co-approver on a small set of files where a regression would be expensive.
+
+/client/templates/                                      @saadqbal
+/client/values.schema.json                              @saadqbal
+/client/values.yaml                                     @saadqbal
+/docs/SECURITY.md                                       @saadqbal

--- a/.github/workflows/add-to-kanban.yml
+++ b/.github/workflows/add-to-kanban.yml
@@ -1,0 +1,16 @@
+name: Add to engineer kanban
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/tracebloc/projects/2
+          github-token: ${{ secrets.PROJECTS_KANBAN_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Repo-level guidance for Claude Code
+
+## Helm chart migrations — always read `docs/MIGRATIONS.md` first
+
+Before planning any migration from one Helm release/chart to another in this repo, **read `docs/MIGRATIONS.md` in full**. It documents a specific, non-obvious gotcha that cost the tracebloc team a production PVC set on 2026-04-22:
+
+> `helm.sh/resource-policy: keep` is read from the **stored release manifest**, not the live resource. `kubectl annotate pvc X helm.sh/resource-policy=keep` does NOT protect the PVC from `helm uninstall` if the chart template didn't render the annotation.
+
+The mandatory pre-flight check before any `helm uninstall` that is part of a migration:
+
+```bash
+helm get manifest <release> -n <ns> | grep -B2 -A1 'resource-policy'
+```
+
+If the annotation is missing from the stored manifest for any resource you need to preserve, do not proceed with `helm uninstall` until you've applied Option A, B, or C from `docs/MIGRATIONS.md`. Do not assume live annotations will work.
+
+## Default branch
+
+Integration branch for this repo (and all tracebloc repos) is `develop`, not `main`. Target PRs at `develop`.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ $env:CLUSTER_NAME = "myapp"; $env:AGENTS = "3"; irm https://raw.githubuserconten
 
 The **tracebloc** chart is the unified chart for AKS, EKS, bare-metal, and OpenShift. For production-ready install steps (from repo, from `.tgz`, or from source), prerequisites, required values, upgrade, and rollback, see **[docs/INSTALL.md](docs/INSTALL.md)**.
 
+### Security
+
+For the threat model, defense layers, per-platform caveats, operator responsibilities, and verification steps, see **[docs/SECURITY.md](docs/SECURITY.md)**. The chart ships hardened defaults against untrusted user-submitted ML code; deployment still requires a CNI that enforces NetworkPolicy — that file explains exactly what to check.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,335 +1,74 @@
-# 🌐 tracebloc Client
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE) [![Docker](https://img.shields.io/badge/docker-tracebloc%2Fclient-2496ED.svg)](https://hub.docker.com/r/tracebloc/client) [![Platform](https://img.shields.io/badge/platform-tracebloc-00C9A7.svg)](https://ai.tracebloc.io)
 
+# tracebloc Client 🔒
 
-## 📄 Description
-tracebloc Client is a Kubernetes-based application that runs experiments and communicates results to the tracebloc backend. It's designed to handle distributed machine learning workloads efficiently and securely.
+The runtime that keeps your data where it belongs — on your infrastructure.
 
-## 🛠️ Tech Stack
-- Kubernetes
-- Helm 3.x
-- Azure Service Bus (AmqpOverWebsocket)
-- Docker
-- Persistent Volume Storage
+The tracebloc client deploys inside your Kubernetes cluster and executes all model training, fine-tuning, and inference locally. It connects to the tracebloc backend for orchestration only. No data, no model weights, no artifacts ever leave your environment.
 
-## 🚀 Quick Install
+## Architecture
 
-Set up a local Kubernetes cluster with GPU support in one command.
-
-**Bash (Linux / macOS / WSL):**
-
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/tracebloc/client/main/scripts/install.sh)
+```
+Your infrastructure
+┌─────────────────────────────────────────────────────────┐
+│                                                         │
+│   ┌──────────────────┐      ┌───────────────────────┐   │
+│   │  tracebloc        │      │  Kubernetes cluster   │   │
+│   │  client           │◄────►│                       │   │
+│   │                   │      │  ● Training jobs      │   │
+│   │  Orchestrates     │      │  ● Inference jobs     │   │
+│   │  training,        │      │  ● Your datasets      │   │
+│   │  enforces budgets │      │  ● Fine-tuned weights │   │
+│   └────────┬──────────┘      │                       │   │
+│            │                 │  Everything stays here │   │
+│            │                 └───────────────────────┘   │
+└────────────┼────────────────────────────────────────────┘
+             │
+             │ Encrypted (orchestration only — no data)
+             ▼
+    ┌─────────────────┐
+    │  tracebloc       │
+    │  backend         │
+    │                  │
+    │  Coordinates     │
+    │  experiments,    │
+    │  serves web UI   │
+    └─────────────────┘
 ```
 
-**PowerShell (Windows):**
+## What the client manages
 
-```powershell
-irm https://raw.githubusercontent.com/tracebloc/client/main/scripts/install.sh | iex
-```
+- **Training execution** — runs vendor models in isolated, containerized sandboxes
+- **Compute budgets** — enforces per-vendor FLOPs or runtime quotas
+- **Security boundaries** — namespace isolation, encrypted communication, audit logging
+- **Multi-framework support** — PyTorch, TensorFlow, custom containers
+- **Hardware scheduling** — CPUs, GPUs, TPUs via Kubernetes-native orchestration
 
-With custom configuration (environment variables are optional and can be combined as needed):
-
-**Bash:**
-
-```bash
-CLUSTER_NAME=myapp AGENTS=3 \
-  bash <(curl -fsSL https://raw.githubusercontent.com/tracebloc/client/main/scripts/install.sh)
-```
-
-**PowerShell:**
-
-```powershell
-$env:CLUSTER_NAME = "myapp"; $env:AGENTS = "3"; irm https://raw.githubusercontent.com/tracebloc/client/main/scripts/install.sh | iex
-```
-
-| Variable | Default | Description |
-|---|---|---|
-| `CLUSTER_NAME` | `k3s-local` | Name of the k3d cluster |
-| `SERVERS` | `1` | Number of control-plane nodes |
-| `AGENTS` | `2` | Number of worker nodes |
-| `K8S_VERSION` | latest stable | k3s version tag |
-| `HTTP_PORT` | `80` | Host port mapped to cluster ingress (HTTP) |
-| `HTTPS_PORT` | `443` | Host port mapped to cluster ingress (HTTPS) |
-
-### Prerequisites
-- `kubectl` installed and configured
-- `Helm 3.x` installed
-- Access to a Kubernetes cluster
-
-### System Requirements
-
-#### Network Requirements
-- One-way communication with tracebloc backend
-- Port 443 open for Azure Service Bus (AmqpOverWebsocket)
-- Secure metric and weight file transmission
-
-#### Cluster Specifications
-- **RAM:** 50 GB (minimum)
-- **CPU:** 20 cores (minimum)
-
-#### Storage
-- Persistent volumes for:
-  - Training data
-  - Models
-  - Weight files
-
-### Required Credentials
-1. Docker Registry Access:
-   - Username
-   - Password
-
-2. Client Authentication:
-   - Client ID
-   - Username
-   - Password
-
-## 📦 Deployment Guide
-
-1. Ensure all prerequisites are met
-2. Configure your credentials
-3. Follow our detailed deployment guide at:
-   [Create Your Client](https://traceblocdocsdev.azureedge.net/environment-setup/create-your-client)
-
-### Installing the tracebloc Helm chart (production)
-
-The **tracebloc** chart is the unified chart for AKS, EKS, bare-metal, and OpenShift. For production-ready install steps (from repo, from `.tgz`, or from source), prerequisites, required values, upgrade, and rollback, see **[docs/INSTALL.md](docs/INSTALL.md)**.
-
-### Security
+## Security
 
 For the threat model, defense layers, per-platform caveats, operator responsibilities, and verification steps, see **[docs/SECURITY.md](docs/SECURITY.md)**. The chart ships hardened defaults against untrusted user-submitted ML code; deployment still requires a CNI that enforces NetworkPolicy — that file explains exactly what to check.
 
+## Deploy
 
-
-
-# Helm Chart Verification Guide
-
-## Manual Verification Steps
-
-### 1. Lint the Chart
-Checks for common issues, best practices, and potential problems:
-
-**Bash / PowerShell:**
 ```bash
-helm lint eks/
+docker pull tracebloc/client:latest
 ```
 
-**What it checks:**
-- Chart structure and metadata
-- Template syntax
-- Values file structure
-- Best practices compliance
+Deployment varies by infrastructure. Follow the guide for your setup:
 
-### 2. Render Templates (Dry Run)
-Renders all templates with your values to check for syntax errors:
+- [Deployment overview](https://docs.tracebloc.io/environment-setup/deployment-overview)
+- [Local — Linux](https://docs.tracebloc.io/environment-setup/local-linux)
+- [Local — macOS](https://docs.tracebloc.io/environment-setup/local-macos)
+- [AWS](https://docs.tracebloc.io/environment-setup/aws)
 
-**Bash / PowerShell:**
-```bash
-helm template eks eks/ --namespace test-namespace
-```
+Full documentation → [docs.tracebloc.io](https://docs.tracebloc.io/)
 
-**With debug output:**
-```bash
-helm template eks eks/ --namespace test-namespace --debug
-```
+## Links
 
-**What it checks:**
-- Template syntax errors
-- Missing required values
-- Incorrect template functions
-- YAML formatting issues
+[Platform](https://ai.tracebloc.io/) · [Docs](https://docs.tracebloc.io/) · [Discord](https://discord.gg/tracebloc)
 
-### 3. Validate Kubernetes Manifests
-Validates that the rendered YAML is valid Kubernetes:
+## License
 
-**Bash:**
-```bash
-helm template eks eks/ --namespace test-namespace | kubectl apply --dry-run=client -f -
-```
+Apache 2.0 — see [LICENSE](LICENSE).
 
-**PowerShell:**
-```powershell
-helm template eks eks/ --namespace test-namespace | kubectl apply --dry-run=client -f -
-```
-
-**What it checks:**
-- Valid Kubernetes API versions
-- Correct resource definitions
-- Required fields are present
-
-### 4. Test Installation (Dry Run)
-Simulates an installation without actually deploying:
-
-**Bash / PowerShell:**
-```bash
-helm install test-release eks/ --namespace test-namespace --dry-run --debug
-```
-
-**What it checks:**
-- All resources would be created correctly
-- Dependencies are resolved
-- Values are properly substituted
-
-### 5. Package the Chart
-Creates a chart package to verify it can be packaged:
-
-**Bash / PowerShell:**
-```bash
-helm package eks/
-```
-
-**What it checks:**
-- Chart can be packaged for distribution
-- All required files are included
-- Chart metadata is correct
-
-### 6. Check for Placeholder Values
-Search for placeholder values that need to be replaced:
-
-**Bash:**
-```bash
-helm template eks eks/ --namespace test-namespace | grep -E "<.*>"
-```
-
-**PowerShell:**
-```powershell
-helm template eks eks/ --namespace test-namespace | Select-String -Pattern "<.*>"
-```
-
-Or check values.yaml directly:
-
-**Bash:**
-```bash
-grep -E "<.*>" eks/values.yaml
-```
-
-**PowerShell:**
-```powershell
-Select-String -Path eks/values.yaml -Pattern "<.*>"
-```
-
-## Common Issues to Check
-
-### ✅ Before Submitting, Verify:
-
-1. **No placeholder values** - Replace all `<PLACEHOLDER>`, `<NAMESPACE>`, etc.
-2. **All required values are set** - Check values.yaml for any empty required fields
-3. **Template syntax is correct** - All `{{ }}` blocks are properly closed
-4. **Resource names are unique** - No conflicts with existing resources
-5. **RBAC permissions are correct** - Service accounts have necessary permissions
-6. **Image tags are specified** - No `latest` tags in production
-7. **Resource limits are set** - Containers have appropriate resource requests/limits
-8. **Secrets are handled properly** - No hardcoded secrets in templates
-9. **Namespace is configurable** - Uses `.Release.Namespace` or `.Values.namespace`
-10. **Labels and selectors match** - All resources have consistent labeling
-
-## Pre-Submission Checklist
-
-- [ ] `helm lint eks/` passes without errors
-- [ ] `helm template eks eks/` renders without errors
-- [ ] All placeholder values in values.yaml are replaced or documented
-- [ ] Kubernetes manifest validation passes
-- [ ] Chart packages successfully
-- [ ] All template files are properly formatted
-- [ ] RBAC resources are correctly configured
-- [ ] Service accounts reference correct ClusterRoles
-- [ ] Image pull secrets are configured
-- [ ] Resource requests/limits are set appropriately
-- [ ] Documentation is updated (if applicable)
-
-## Testing with Different Values
-
-Test your chart with different value files:
-
-**Bash / PowerShell:**
-```bash
-# Test with custom values
-helm template eks eks/ -f values-16-dev.yaml --namespace dev
-
-# Test with multiple value files
-helm template eks eks/ -f values.yaml -f values-16-dev.yaml --namespace dev
-```
-
-## Advanced Validation
-
-### Validate against Kubernetes schema
-
-**Bash:**
-```bash
-helm template eks eks/ --namespace test-namespace | \
-  kubectl apply --dry-run=server -f -
-```
-
-**PowerShell:**
-```powershell
-helm template eks eks/ --namespace test-namespace | kubectl apply --dry-run=server -f -
-```
-
-### Check for deprecated APIs
-
-**Bash:**
-```bash
-helm template eks eks/ --namespace test-namespace | \
-  kubectl convert --local -f - 2>&1 | grep -i deprecated
-```
-
-**PowerShell:**
-```powershell
-helm template eks eks/ --namespace test-namespace | kubectl convert --local -f - 2>&1 | Select-String -Pattern "deprecated" -CaseSensitive:$false
-```
-
-### View all rendered resources
-
-**Bash:**
-```bash
-helm template eks eks/ --namespace test-namespace | \
-  kubectl get -f - --dry-run=client -o name
-```
-
-**PowerShell:**
-```powershell
-helm template eks eks/ --namespace test-namespace | kubectl get -f - --dry-run=client -o name
-```
-
-## Troubleshooting
-
-### Docker / k3d "permission denied" (Linux / WSL)
-If `k3d cluster list` or `docker` fails with `permission denied` on the Docker socket:
-- Your user must be in the `docker` group. The installer adds you; if you run commands in a terminal opened before that, the group is not active yet.
-- **Quick fix (Bash):** run `newgrp docker` in that terminal (or open a new terminal), then run `k3d cluster list` or re-run the installer.
-- Or log out and log back in so the `docker` group is applied to your session.
-
-### PowerShell execution policy (Windows)
-If `irm ... | iex` fails with a script execution error, allow scripts for the current user:
-```powershell
-Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
-```
-Then re-run the Quick Install command.
-
-### Template rendering errors:
-- Check for unclosed `{{ }}` blocks
-- Verify all referenced values exist in values.yaml
-- Ensure proper indentation in templates
-
-### Lint warnings:
-- Review warnings and fix critical issues
-- Some warnings may be acceptable (document why)
-
-### Kubernetes validation errors:
-- Check API versions are correct for your cluster
-- Verify required fields are present
-- Ensure resource names follow Kubernetes naming conventions
-
-
-
-
-
-
-
-## 📜 License
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-
-## 📞 Support
-For additional support or questions, please refer to our documentation or contact the tracebloc support team.
-
+**Deployment help?** [support@tracebloc.io](mailto:support@tracebloc.io) or [open an issue](https://github.com/tracebloc/client/issues).

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.0.7
-appVersion: "1.0.7"
+version: 1.0.8
+appVersion: "1.0.8"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -18,6 +18,6 @@ sources:
 maintainers:
   - name: Tracebloc Team
     url: https://tracebloc.com
-kubeVersion: ">=1.24.0"
+kubeVersion: ">=1.24.0-0"
 annotations:
   category: Machine Learning

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.0.6
-appVersion: "1.0.6"
+version: 1.0.7
+appVersion: "1.0.7"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.0.4
-appVersion: "1.0.4"
+version: 1.0.5
+appVersion: "1.0.5"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.0.5
-appVersion: "1.0.5"
+version: 1.0.6
+appVersion: "1.0.6"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.0.3
-appVersion: "1.0.3"
+version: 1.0.4
+appVersion: "1.0.4"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/MIGRATION.md
+++ b/client/MIGRATION.md
@@ -137,6 +137,29 @@ helm install <release-name> ./client -n <namespace> -f new-values.yaml
 
 > **Important:** PVCs have `helm.sh/resource-policy: keep` so they survive `helm uninstall`. Verify PVCs still exist before installing the new chart.
 
+### 6. Clean up pre-Helm `resource-monitor` remnants
+
+Some early-era edges were installed with a `resource-monitor` DaemonSet deployed via raw `kubectl apply` — **before** the per-platform charts existed. The live manifest has no Helm ownership annotations (`meta.helm.sh/release-*`), and its pods are named `resource-monitor-<suffix>` (not `tracebloc-resource-monitor-<suffix>`).
+
+The unified chart's `tracebloc-resource-monitor` DaemonSet supersedes it. After migrating, delete the legacy resources so the namespace has a single node-level agent and isn't carrying an unmanaged, hostPath-mounting pod that blocks PSA `enforce=restricted`:
+
+```bash
+# Check whether your cluster has the legacy DS
+kubectl -n <namespace> get ds resource-monitor 2>/dev/null
+
+# If present, delete it and its cluster-scoped RBAC (all four names are exact).
+# The ClusterRole/Binding are global — verify they aren't shared by any other workload first:
+kubectl get clusterrolebinding resource-monitor -o jsonpath='{.subjects}'
+# Expect a single subject: ServiceAccount/resource-monitor in <namespace>.
+
+kubectl -n <namespace> delete ds resource-monitor
+kubectl -n <namespace> delete sa resource-monitor
+kubectl delete clusterrolebinding resource-monitor
+kubectl delete clusterrole resource-monitor
+```
+
+The chart-managed `tracebloc-resource-monitor` keeps running throughout; no rollout is triggered.
+
 ## Rollback
 
 The old charts remain in `aks/`, `bm/`, `eks/`, `oc/` and can be used at any time:

--- a/client/ci/aks-values.yaml
+++ b/client/ci/aks-values.yaml
@@ -15,6 +15,13 @@ storageClass:
 
 clusterScope: true
 
+# NetworkPolicy: AKS requires the cluster to be created with Azure NPM
+# (`--network-policy azure`) or with Calico to enforce NetworkPolicies.
+# Leave enabled here; document the cluster-creation requirement in README.
+networkPolicy:
+  training:
+    enabled: true
+
 clientId: "ci-test-id"
 clientPassword: "ci-test-password"
 

--- a/client/ci/bm-values.yaml
+++ b/client/ci/bm-values.yaml
@@ -15,6 +15,13 @@ storageClass:
 
 clusterScope: true
 
+# NetworkPolicy: bare-metal enforcement depends on the CNI installed.
+# Calico / Cilium / kube-router enforce. Flannel alone does NOT.
+# Leave enabled here; customers on Flannel-only installations must override.
+networkPolicy:
+  training:
+    enabled: true
+
 clientId: "ci-test-id"
 clientPassword: "ci-test-password"
 

--- a/client/ci/bm-values.yaml
+++ b/client/ci/bm-values.yaml
@@ -2,6 +2,15 @@
 hostPath:
   enabled: true
 
+# enforce=restricted rejects the privileged init-mysql-data chown container
+# that hostPath installs require (kubelet does not apply fsGroup to hostPath
+# volumes -- kubernetes/kubernetes#138411). warn+audit stay on so violations
+# are still visible.
+namespace:
+  podSecurity:
+    enforce: ""
+    enforceVersion: ""
+
 pvcAccessMode: ReadWriteOnce
 
 storageClass:

--- a/client/ci/eks-values.yaml
+++ b/client/ci/eks-values.yaml
@@ -15,6 +15,14 @@ storageClass:
 
 clusterScope: true
 
+# NetworkPolicy: EKS with the default AWS VPC CNI does NOT enforce
+# NetworkPolicy. Leaving this disabled is the safe default — a policy that
+# isn't enforced gives a false sense of security. Customers running
+# Calico or Cilium as an add-on should override this to enabled: true.
+networkPolicy:
+  training:
+    enabled: false
+
 clientId: "ci-test-id"
 clientPassword: "ci-test-password"
 

--- a/client/ci/oc-values.yaml
+++ b/client/ci/oc-values.yaml
@@ -11,6 +11,18 @@ openshift:
   scc:
     enabled: true
 
+# NetworkPolicy: OpenShift OVN-Kubernetes enforces by default.
+# DNS selector + in-cluster CIDRs differ from the Kubernetes defaults.
+networkPolicy:
+  training:
+    enabled: true
+    dnsNamespace: openshift-dns
+    dnsSelector:
+      dns.operator.openshift.io/daemonset-dns: default
+    clusterCidrs:
+      - "10.128.0.0/14"   # OpenShift default pod CIDR
+      - "172.30.0.0/16"   # OpenShift default service CIDR
+
 clientId: "ci-test-id"
 clientPassword: "ci-test-password"
 

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -91,9 +91,17 @@ true
 
 {{/*
 Image reference — defaults to docker.io when no registry is provided.
-Tag defaults to "prod" when CLIENT_ENV is omitted or empty.
-Usage: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "registry" "docker.io") }}
+When `digest` (sha256:...) is set, renders registry/repo@digest (immutable pin,
+preferred for security). Otherwise falls back to registry/repo:tag, where tag
+defaults to "prod" when CLIENT_ENV is omitted or empty.
+Usage: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.jobsManager.digest "registry" "docker.io") }}
 */}}
 {{- define "tracebloc.image" -}}
-{{ .registry | default "docker.io" }}/{{ .repository }}:{{ .tag | default "prod" }}
+{{- $registry := .registry | default "docker.io" -}}
+{{- $digest := .digest | default "" -}}
+{{- if $digest -}}
+{{ $registry }}/{{ .repository }}@{{ $digest }}
+{{- else -}}
+{{ $registry }}/{{ .repository }}:{{ .tag | default "prod" }}
+{{- end -}}
 {{- end }}

--- a/client/templates/docker-registry-secret.yaml
+++ b/client/templates/docker-registry-secret.yaml
@@ -9,4 +9,21 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- if and (ne .Values.resourceMonitor false) (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
+---
+# Mirrored into the node-agents namespace so the resource-monitor DaemonSet
+# can pull its image via imagePullSecrets. dockerconfigjson Secrets are
+# namespace-scoped like all Secrets.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tracebloc.registrySecretName" . }}
+  namespace: {{ .Values.nodeAgents.namespace.name }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app: tracebloc-resource-monitor
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end }}
 {{- end }}

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -28,8 +28,8 @@ spec:
           type: RuntimeDefault
       containers:
       - name: api
-        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "registry" "docker.io") | quote }}
-        imagePullPolicy: Always
+        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.jobsManager.digest "registry" "docker.io") | quote }}
+        imagePullPolicy: {{ if .Values.images.jobsManager.digest }}IfNotPresent{{ else }}Always{{ end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -84,8 +84,8 @@ spec:
         {{- end }}
         {{- end }}
       - name: pods-monitor-container
-        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/pods-monitor" "tag" .Values.env.CLIENT_ENV "registry" "docker.io") | quote }}
-        imagePullPolicy: Always
+        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/pods-monitor" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.podsMonitor.digest "registry" "docker.io") | quote }}
+        imagePullPolicy: {{ if .Values.images.podsMonitor.digest }}IfNotPresent{{ else }}Always{{ end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/client/templates/mysql-deployment.yaml
+++ b/client/templates/mysql-deployment.yaml
@@ -45,6 +45,7 @@ spec:
           runAsUser: 999
           runAsGroup: 999
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
             - ALL
@@ -83,6 +84,16 @@ spec:
           mountPath: /etc/mysql/conf.d/
         - name: mysql-logs
           mountPath: /var/log/mysql/
+        # Writable scratch dirs required by mysqld under readOnlyRootFilesystem:
+        # /var/run/mysqld -> pid file + unix socket
+        # /tmp            -> temp tables, sort buffers, LOAD DATA staging
+        # /var/lib/mysql-files -> default secure_file_priv; mysqld touches it at start
+        - name: mysql-run
+          mountPath: /var/run/mysqld
+        - name: mysql-tmp
+          mountPath: /tmp
+        - name: mysql-files
+          mountPath: /var/lib/mysql-files
       {{- if include "tracebloc.useImagePullSecrets" . }}
       imagePullSecrets:
       - name: {{ include "tracebloc.registrySecretName" . }}
@@ -95,4 +106,10 @@ spec:
         configMap:
           name: mysql-client-config
       - name: mysql-logs
+        emptyDir: {}
+      - name: mysql-run
+        emptyDir: {}
+      - name: mysql-tmp
+        emptyDir: {}
+      - name: mysql-files
         emptyDir: {}

--- a/client/templates/mysql-deployment.yaml
+++ b/client/templates/mysql-deployment.yaml
@@ -29,16 +29,29 @@ spec:
       # deployments (EKS/AKS/OC) skip this and rely on fsGroup.
       initContainers:
       - name: init-mysql-data
-        image: busybox:1.35
+        image: {{ include "tracebloc.image" (dict "repository" "library/busybox" "tag" .Values.images.busybox.tag "digest" .Values.images.busybox.digest "registry" "docker.io") | quote }}
+        # Must run as root to chown the hostPath mount; kubelet does not apply
+        # fsGroup to hostPath volumes (kubernetes/kubernetes#138411).
+        # Scope privilege tightly: only CHOWN is needed, no privilege escalation,
+        # read-only root fs, default seccomp.
         securityContext:
           runAsUser: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+            add: ["CHOWN"]
+          seccompProfile:
+            type: RuntimeDefault
         command: ['sh', '-c', 'chown 999:999 /var/lib/mysql && chmod 755 /var/lib/mysql']
         volumeMounts:
         - name: mysql-persistent-storage
           mountPath: /var/lib/mysql/
       {{- end }}
       containers:
-      - image: {{ include "tracebloc.image" (dict "repository" "tracebloc/mysql-client" "tag" "latest" "registry" "docker.io") | quote }}
+      - image: {{ include "tracebloc.image" (dict "repository" "tracebloc/mysql-client" "tag" (.Values.images.mysqlClient.tag | default "prod") "digest" .Values.images.mysqlClient.digest "registry" "docker.io") | quote }}
+        imagePullPolicy: IfNotPresent
         name: mysql-client
         securityContext:
           runAsNonRoot: true

--- a/client/templates/mysql-deployment.yaml
+++ b/client/templates/mysql-deployment.yaml
@@ -32,8 +32,10 @@ spec:
         image: {{ include "tracebloc.image" (dict "repository" "library/busybox" "tag" .Values.images.busybox.tag "digest" .Values.images.busybox.digest "registry" "docker.io") | quote }}
         # Must run as root to chown the hostPath mount; kubelet does not apply
         # fsGroup to hostPath volumes (kubernetes/kubernetes#138411).
-        # Scope privilege tightly: only CHOWN is needed, no privilege escalation,
-        # read-only root fs, default seccomp.
+        # Scope privilege tightly: only CHOWN is needed — no FOWNER, so do not
+        # chmod here. On re-install the dir is already owned by 999, and
+        # chmod-by-non-owner without CAP_FOWNER returns EPERM (kubelet creates
+        # the dir 0755 via DirectoryOrCreate, so chmod was a no-op anyway).
         securityContext:
           runAsUser: 0
           runAsNonRoot: false
@@ -44,7 +46,7 @@ spec:
             add: ["CHOWN"]
           seccompProfile:
             type: RuntimeDefault
-        command: ['sh', '-c', 'chown 999:999 /var/lib/mysql && chmod 755 /var/lib/mysql']
+        command: ['sh', '-c', 'chown 999:999 /var/lib/mysql']
         volumeMounts:
         - name: mysql-persistent-storage
           mountPath: /var/lib/mysql/

--- a/client/templates/mysql-deployment.yaml
+++ b/client/templates/mysql-deployment.yaml
@@ -22,26 +22,34 @@ spec:
       securityContext:
         fsGroup: 999
         fsGroupChangePolicy: "OnRootMismatch"
+      {{- if .Values.hostPath.enabled }}
+      # kubelet does not apply fsGroup to hostPath volumes
+      # (kubernetes/kubernetes#138411), so bare-metal installs need a
+      # privileged bootstrap to chown /var/lib/mysql to 999:999. CSI-backed
+      # deployments (EKS/AKS/OC) skip this and rely on fsGroup.
       initContainers:
       - name: init-mysql-data
         image: busybox:1.35
         securityContext:
           runAsUser: 0
-        command: ['sh', '-c', 'mkdir -p /var/lib/mysql && chown 999:999 /var/lib/mysql && chmod 755 /var/lib/mysql']
+        command: ['sh', '-c', 'chown 999:999 /var/lib/mysql && chmod 755 /var/lib/mysql']
         volumeMounts:
         - name: mysql-persistent-storage
           mountPath: /var/lib/mysql/
-      - name: init-mysql-logs
-        image: busybox:1.35
-        securityContext:
-          runAsUser: 0
-        command: ['sh', '-c', 'mkdir -p /var/log/mysql && chown -R 999:999 /var/log/mysql && chmod -R 755 /var/log/mysql']
-        volumeMounts:
-        - name: mysql-logs
-          mountPath: /var/log/mysql/
+      {{- end }}
       containers:
       - image: {{ include "tracebloc.image" (dict "repository" "tracebloc/mysql-client" "tag" "latest" "registry" "docker.io") | quote }}
         name: mysql-client
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 999
+          runAsGroup: 999
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
         resources:
           requests:
             memory: 256Mi

--- a/client/templates/namespace.yaml
+++ b/client/templates/namespace.yaml
@@ -1,0 +1,53 @@
+{{/*
+  Optional Namespace resource with Pod Security Admission labels.
+
+  Default is OFF (namespace.create: false). The chart assumes the operator
+  pre-created the namespace via `kubectl create namespace` or
+  `helm install --create-namespace`.
+
+  Set namespace.create: true ONLY on greenfield installs to have the chart
+  template the Namespace with Pod Security Admission labels applied:
+
+    pod-security.kubernetes.io/warn:  restricted   (kubectl warnings)
+    pod-security.kubernetes.io/audit: restricted   (audit-log events)
+    pod-security.kubernetes.io/enforce: <off>      (does NOT reject pods)
+
+  Enforce mode is deliberately left unset by default -- the mysql init
+  containers (runAsUser: 0) and the resource-monitor DaemonSet (hostPath
+  mounts) violate the restricted profile and would be rejected. Customers
+  can opt into enforce once those are refactored or moved to a separate
+  namespace; `warn` + `audit` give useful visibility in the meantime.
+
+  helm.sh/resource-policy: keep ensures `helm uninstall` does NOT delete
+  the namespace (which would take PVC-backed data with it).
+
+  See README for labelling an EXISTING namespace via kubectl.
+*/}}
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    {{- with .Values.namespace.podSecurity.warn }}
+    pod-security.kubernetes.io/warn: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.namespace.podSecurity.warnVersion }}
+    pod-security.kubernetes.io/warn-version: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.namespace.podSecurity.audit }}
+    pod-security.kubernetes.io/audit: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.namespace.podSecurity.auditVersion }}
+    pod-security.kubernetes.io/audit-version: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.namespace.podSecurity.enforce }}
+    pod-security.kubernetes.io/enforce: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.namespace.podSecurity.enforceVersion }}
+    pod-security.kubernetes.io/enforce-version: {{ . | quote }}
+    {{- end }}
+{{- end }}

--- a/client/templates/namespace.yaml
+++ b/client/templates/namespace.yaml
@@ -8,17 +8,18 @@
   Set namespace.create: true ONLY on greenfield installs to have the chart
   template the Namespace with Pod Security Admission labels applied:
 
-    pod-security.kubernetes.io/warn:  restricted   (kubectl warnings)
-    pod-security.kubernetes.io/audit: restricted   (audit-log events)
-    pod-security.kubernetes.io/enforce: <off>      (does NOT reject pods)
+    pod-security.kubernetes.io/warn:    restricted   (kubectl warnings)
+    pod-security.kubernetes.io/audit:   restricted   (audit-log events)
+    pod-security.kubernetes.io/enforce: restricted   (rejects violating pods)
 
-  Enforce mode is deliberately left unset by default -- the mysql init
-  containers still run as UID 0 and would be rejected. The resource-monitor
-  DaemonSet (hostPath mounts) previously blocked enforce too, but now lives
-  in the dedicated `nodeAgents.namespace.name` namespace (privileged PSA),
-  so it no longer constrains this namespace. Customers can opt into enforce
-  once the mysql init is refactored; `warn` + `audit` give useful visibility
-  in the meantime.
+  enforce=restricted is the default for CSI-backed deployments (EKS/AKS/OC).
+  The mysql init-container has been gated on hostPath.enabled, and the
+  resource-monitor DaemonSet was moved to the dedicated nodeAgents
+  namespace (privileged PSA), so the release namespace no longer has
+  workloads that violate restricted. Bare-metal installs override enforce
+  to "" via ci/bm-values.yaml because kubelet does not apply fsGroup to
+  hostPath volumes (kubernetes/kubernetes#138411), so init-mysql-data is
+  still required there and would be rejected; warn+audit remain on.
 
   helm.sh/resource-policy: keep ensures `helm uninstall` does NOT delete
   the namespace (which would take PVC-backed data with it).

--- a/client/templates/namespace.yaml
+++ b/client/templates/namespace.yaml
@@ -13,10 +13,12 @@
     pod-security.kubernetes.io/enforce: <off>      (does NOT reject pods)
 
   Enforce mode is deliberately left unset by default -- the mysql init
-  containers (runAsUser: 0) and the resource-monitor DaemonSet (hostPath
-  mounts) violate the restricted profile and would be rejected. Customers
-  can opt into enforce once those are refactored or moved to a separate
-  namespace; `warn` + `audit` give useful visibility in the meantime.
+  containers still run as UID 0 and would be rejected. The resource-monitor
+  DaemonSet (hostPath mounts) previously blocked enforce too, but now lives
+  in the dedicated `nodeAgents.namespace.name` namespace (privileged PSA),
+  so it no longer constrains this namespace. Customers can opt into enforce
+  once the mysql init is refactored; `warn` + `audit` give useful visibility
+  in the meantime.
 
   helm.sh/resource-policy: keep ensures `helm uninstall` does NOT delete
   the namespace (which would take PVC-backed data with it).

--- a/client/templates/network-policy-training.yaml
+++ b/client/templates/network-policy-training.yaml
@@ -1,0 +1,67 @@
+{{/*
+  Training pod egress lockdown.
+
+  Training pods run untrusted ML code uploaded by external data scientists.
+  This NetworkPolicy:
+    1. Denies all ingress to training pods (nothing should connect TO them).
+    2. Allows DNS to the cluster's DNS service.
+    3. Allows TCP/443 egress to addresses OUTSIDE the cluster CIDRs only —
+       blocking pod-to-pod, MySQL, K8s API, jobs-manager pod IPs, etc.
+
+  Selects pods by label tracebloc.io/workload=training. The jobs-manager
+  injects this label when spawning each training Job (see client-runtime
+  jobs_manager._prepare_job_config).
+
+  Requires a CNI that enforces NetworkPolicy. Not enforced by:
+    - kindnet (minikube / KIND)
+    - flannel (without kube-router add-on)
+    - AWS VPC CNI (without Calico add-on)
+  See values.yaml networkPolicy.training.enabled for platform notes.
+*/}}
+{{- if .Values.networkPolicy.training.enabled }}
+{{- $dnsSelector := .Values.networkPolicy.training.dnsSelector }}
+{{- if not $dnsSelector }}{{ $dnsSelector = dict "k8s-app" "kube-dns" }}{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-training-egress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      tracebloc.io/workload: training
+  policyTypes:
+    - Ingress
+    - Egress
+  # Deny all ingress — no one should connect TO a training pod.
+  ingress: []
+  egress:
+    # 1. DNS to the cluster's DNS service.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.training.dnsNamespace | default "kube-system" }}
+          podSelector:
+            matchLabels:
+              {{- toYaml $dnsSelector | nindent 14 }}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # 2. External HTTPS — everything NOT in the cluster's pod/service CIDRs.
+    #    Training pods call backend, Azure Service Bus, App Insights, etc.
+    #    This blocks pod-to-pod, ClusterIPs, MySQL, jobs-manager, K8s API.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              {{- range .Values.networkPolicy.training.clusterCidrs }}
+              - {{ . | quote }}
+              {{- end }}
+      ports:
+        - port: 443
+          protocol: TCP
+{{- end }}

--- a/client/templates/network-policy-training.yaml
+++ b/client/templates/network-policy-training.yaml
@@ -19,6 +19,9 @@
   See values.yaml networkPolicy.training.enabled for platform notes.
 */}}
 {{- if .Values.networkPolicy.training.enabled }}
+{{- if not .Values.networkPolicy.training.clusterCidrs }}
+{{- fail "networkPolicy.training.enabled is true but networkPolicy.training.clusterCidrs is empty. An empty list renders `except: null`, which Kubernetes treats as no exceptions — training pods would get unrestricted port-443 egress to MySQL, the K8s API, jobs-manager, and other in-cluster destinations. Set the list to your cluster's pod+service CIDRs, or disable the policy." }}
+{{- end }}
 {{- $dnsSelector := .Values.networkPolicy.training.dnsSelector }}
 {{- if not $dnsSelector }}{{ $dnsSelector = dict "k8s-app" "kube-dns" }}{{- end }}
 apiVersion: networking.k8s.io/v1

--- a/client/templates/node-agents-namespace.yaml
+++ b/client/templates/node-agents-namespace.yaml
@@ -1,0 +1,40 @@
+{{/*
+  Dedicated namespace for node-level agents (tracebloc-resource-monitor).
+
+  The resource-monitor DaemonSet mounts hostPath /proc and /sys to collect
+  node metrics; Pod Security Admission's `restricted` profile bans hostPath
+  volumes outright, so the DaemonSet cannot be made compliant in a
+  restricted namespace. Isolating it in its own `privileged` namespace
+  lets the release namespace (jobs-manager, mysql, training pods) run
+  under `enforce: restricted` once the other blockers are resolved.
+
+  Gated on:
+    nodeAgents.namespace.create                   - skip when managing the namespace out-of-band
+    resourceMonitor != false                      - skip when the DaemonSet is disabled
+    nodeAgents.namespace.name != Release.Namespace - skip when the operator
+        has pointed node-agents back at the release namespace. Otherwise this
+        template would stamp `privileged` PSA labels onto the release
+        namespace (defeating the whole point of the split) and, combined
+        with namespace.create=true, would render two Namespace resources
+        with the same name — a render-time collision.
+
+  helm.sh/resource-policy: keep ensures `helm uninstall` does NOT delete
+  the namespace. The namespace itself carries no persistent data, but
+  keeping it avoids recreating the PSA labels on every reinstall and
+  prevents race conditions where a DaemonSet from a concurrent install
+  lands in the not-yet-relabelled namespace.
+*/}}
+{{- if and (ne .Values.resourceMonitor false) .Values.nodeAgents.namespace.create (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.nodeAgents.namespace.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app: tracebloc-node-agents
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged
+{{- end }}

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -42,8 +42,16 @@ spec:
         - operator: "Exists"
       containers:
         - name: tracebloc-resource-monitor
-          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.resourceMonitor.digest "registry" "docker.io") | quote }}
-          imagePullPolicy: {{ if .Values.images.resourceMonitor.digest }}IfNotPresent{{ else }}Always{{ end }}
+          {{- /*
+            images.resourceMonitor was added in 1.0.7; older releases that
+            upgrade via `helm upgrade --reuse-values` won't have the block in
+            their stored values, so read it defensively (nested `default dict`
+            tolerates a missing `images` map AND a missing `resourceMonitor`
+            entry). `dig` is not usable here — it rejects chartutil.Values.
+          */}}
+          {{- $rmDigest := (default (dict) (default (dict) .Values.images).resourceMonitor).digest | default "" }}
+          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" .Values.env.CLIENT_ENV "digest" $rmDigest "registry" "docker.io") | quote }}
+          imagePullPolicy: {{ if $rmDigest }}IfNotPresent{{ else }}Always{{ end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: tracebloc-resource-monitor
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.nodeAgents.namespace.name }}
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
@@ -50,10 +50,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # The monitor queries workloads in the release namespace, not its
+            # own node-agents namespace — use the release namespace literal
+            # rather than the Downward API pod namespace.
             - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: {{ .Release.Namespace | quote }}
             - name: MONITOR_INTERVAL
               value: "30"
             - name: CLIENT_ENV

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -42,8 +42,8 @@ spec:
         - operator: "Exists"
       containers:
         - name: tracebloc-resource-monitor
-          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" .Values.env.CLIENT_ENV "registry" "docker.io") | quote }}
-          imagePullPolicy: Always
+          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.resourceMonitor.digest "registry" "docker.io") | quote }}
+          imagePullPolicy: {{ if .Values.images.resourceMonitor.digest }}IfNotPresent{{ else }}Always{{ end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -1,4 +1,18 @@
 {{- if ne .Values.resourceMonitor false }}
+{{/*
+  Pre-flight: resource-monitor polls the metrics.k8s.io API. Without
+  metrics-server registered, the DaemonSet crash-loops with 404s. We probe
+  kube-system via `lookup` first — that returns empty during `helm template`
+  (no cluster access), so offline rendering isn't blocked. On a real install
+  where lookup can see the cluster, we require metrics-server up front.
+*/}}
+{{- $probe := lookup "v1" "Namespace" "" "kube-system" -}}
+{{- if $probe -}}
+{{- $metrics := lookup "apiregistration.k8s.io/v1" "APIService" "" "v1beta1.metrics.k8s.io" -}}
+{{- if not $metrics -}}
+{{- fail "resourceMonitor is enabled but the metrics.k8s.io/v1beta1 API is not registered. Install metrics-server (https://github.com/kubernetes-sigs/metrics-server) or set resourceMonitor: false. See SECURITY.md." -}}
+{{- end -}}
+{{- end }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/client/templates/resource-monitor-rbac.yaml
+++ b/client/templates/resource-monitor-rbac.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tracebloc-resource-monitor
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.nodeAgents.namespace.name }}
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
@@ -48,9 +48,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: tracebloc-resource-monitor
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.nodeAgents.namespace.name }}
 {{- else }}
 ---
+# Role + RoleBinding live in the RELEASE namespace so the resource-monitor
+# can list pods/logs where the actual workloads run. The RoleBinding
+# subject points at the ServiceAccount in the node-agents namespace
+# (cross-namespace bindings are valid; the Role scope is what matters).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -88,6 +92,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: tracebloc-resource-monitor
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.nodeAgents.namespace.name }}
 {{- end }}
 {{- end }}

--- a/client/templates/resource-monitor-scc.yaml
+++ b/client/templates/resource-monitor-scc.yaml
@@ -44,7 +44,7 @@ seccompProfiles:
   - runtime/default
 readOnlyRootFilesystem: false
 users:
-  - system:serviceaccount:{{ .Release.Namespace }}:tracebloc-resource-monitor
+  - system:serviceaccount:{{ .Values.nodeAgents.namespace.name }}:tracebloc-resource-monitor
 groups: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -80,5 +80,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: tracebloc-resource-monitor
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.nodeAgents.namespace.name }}
 {{- end }}

--- a/client/templates/secrets.yaml
+++ b/client/templates/secrets.yaml
@@ -9,3 +9,21 @@ type: Opaque
 data:
   CLIENT_ID: {{ required "clientId is required" .Values.clientId | b64enc | quote }}
   CLIENT_PASSWORD: {{ required "clientPassword is required" .Values.clientPassword | b64enc | quote }}
+{{- if and (ne .Values.resourceMonitor false) (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
+---
+# Mirrored into the node-agents namespace so the resource-monitor DaemonSet
+# can read CLIENT_ID / CLIENT_PASSWORD via secretKeyRef. Secrets are
+# namespace-scoped; a pod cannot reference a Secret in another namespace.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tracebloc.secretName" . }}
+  namespace: {{ .Values.nodeAgents.namespace.name }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app: tracebloc-resource-monitor
+type: Opaque
+data:
+  CLIENT_ID: {{ required "clientId is required" .Values.clientId | b64enc | quote }}
+  CLIENT_PASSWORD: {{ required "clientPassword is required" .Values.clientPassword | b64enc | quote }}
+{{- end }}

--- a/client/templates/secrets.yaml
+++ b/client/templates/secrets.yaml
@@ -1,3 +1,7 @@
+{{- $clientId := required "clientId is required (set via --set clientId=... or values file)" .Values.clientId -}}
+{{- $clientPassword := required "clientPassword is required (set via --set clientPassword=... or values file)" .Values.clientPassword -}}
+{{- if regexMatch "^<.*>$" $clientId -}}{{- fail "clientId looks like a placeholder (e.g. \"<CLIENT_ID>\"); set a real value" -}}{{- end -}}
+{{- if regexMatch "^<.*>$" $clientPassword -}}{{- fail "clientPassword looks like a placeholder (e.g. \"<CLIENT_PASSWORD>\"); set a real value" -}}{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,8 +11,8 @@ metadata:
     {{- include "tracebloc.labels" . | nindent 4 }}
 type: Opaque
 data:
-  CLIENT_ID: {{ required "clientId is required" .Values.clientId | b64enc | quote }}
-  CLIENT_PASSWORD: {{ required "clientPassword is required" .Values.clientPassword | b64enc | quote }}
+  CLIENT_ID: {{ $clientId | b64enc | quote }}
+  CLIENT_PASSWORD: {{ $clientPassword | b64enc | quote }}
 {{- if and (ne .Values.resourceMonitor false) (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
 ---
 # Mirrored into the node-agents namespace so the resource-monitor DaemonSet
@@ -24,6 +28,6 @@ metadata:
     app: tracebloc-resource-monitor
 type: Opaque
 data:
-  CLIENT_ID: {{ required "clientId is required" .Values.clientId | b64enc | quote }}
-  CLIENT_PASSWORD: {{ required "clientPassword is required" .Values.clientPassword | b64enc | quote }}
+  CLIENT_ID: {{ $clientId | b64enc | quote }}
+  CLIENT_PASSWORD: {{ $clientPassword | b64enc | quote }}
 {{- end }}

--- a/client/tests/namespace_test.yaml
+++ b/client/tests/namespace_test.yaml
@@ -1,0 +1,121 @@
+suite: Namespace PSA labels
+templates:
+  - templates/namespace.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: should not render when namespace.create is false
+    set:
+      namespace:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render Namespace with keep annotation when create is true
+    set:
+      namespace:
+        create: true
+        podSecurity:
+          warn: restricted
+          warnVersion: "latest"
+          audit: restricted
+          auditVersion: "latest"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Namespace
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: should apply warn + audit restricted labels by default
+    set:
+      namespace:
+        create: true
+        podSecurity:
+          warn: restricted
+          warnVersion: "latest"
+          audit: restricted
+          auditVersion: "latest"
+    asserts:
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/warn"]
+          value: restricted
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/audit"]
+          value: restricted
+
+  - it: should include version labels when provided
+    set:
+      namespace:
+        create: true
+        podSecurity:
+          warn: restricted
+          warnVersion: "v1.29"
+          audit: restricted
+          auditVersion: "v1.29"
+    asserts:
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/warn-version"]
+          value: v1.29
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/audit-version"]
+          value: v1.29
+
+  - it: should omit enforce label when enforce is empty
+    set:
+      namespace:
+        create: true
+        podSecurity:
+          warn: restricted
+          audit: restricted
+          enforce: ""
+    asserts:
+      - notExists:
+          path: metadata.labels["pod-security.kubernetes.io/enforce"]
+
+  - it: should include enforce label when explicitly set
+    set:
+      namespace:
+        create: true
+        podSecurity:
+          warn: restricted
+          audit: restricted
+          enforce: restricted
+          enforceVersion: "latest"
+    asserts:
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/enforce"]
+          value: restricted
+
+  - it: should allow baseline profile instead of restricted
+    set:
+      namespace:
+        create: true
+        podSecurity:
+          warn: baseline
+          audit: baseline
+    asserts:
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/warn"]
+          value: baseline
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/audit"]
+          value: baseline
+
+  - it: should name the namespace after the release namespace
+    release:
+      namespace: my-custom-ns
+    set:
+      namespace:
+        create: true
+        podSecurity:
+          warn: restricted
+          audit: restricted
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-custom-ns

--- a/client/tests/network_policy_test.yaml
+++ b/client/tests/network_policy_test.yaml
@@ -1,0 +1,173 @@
+suite: Training-pod NetworkPolicy
+templates:
+  - templates/network-policy-training.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: should not render when networkPolicy.training.enabled is false
+    set:
+      networkPolicy:
+        training:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a NetworkPolicy when enabled
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-training-egress
+
+  - it: should select on tracebloc.io/workload training label
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+    asserts:
+      - equal:
+          path: spec.podSelector
+          value:
+            matchLabels:
+              tracebloc.io/workload: training
+
+  - it: should deny all ingress via empty ingress rules
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - equal:
+          path: spec.ingress
+          value: []
+
+  - it: should allow DNS egress on UDP and TCP port 53
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+    asserts:
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            port: 53
+            protocol: UDP
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            port: 53
+            protocol: TCP
+
+  - it: should select DNS pods by namespace + label
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0]
+          value:
+            namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: kube-system
+            podSelector:
+              matchLabels:
+                k8s-app: kube-dns
+
+  - it: should allow external TCP 443 and block in-cluster CIDRs
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+    asserts:
+      - equal:
+          path: spec.egress[1].to[0].ipBlock.cidr
+          value: 0.0.0.0/0
+      - contains:
+          path: spec.egress[1].to[0].ipBlock.except
+          content: 10.0.0.0/8
+      - contains:
+          path: spec.egress[1].to[0].ipBlock.except
+          content: 172.16.0.0/12
+      - contains:
+          path: spec.egress[1].to[0].ipBlock.except
+          content: 192.168.0.0/16
+      - contains:
+          path: spec.egress[1].ports
+          content:
+            port: 443
+            protocol: TCP
+
+  - it: should support OpenShift DNS selector override
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: openshift-dns
+          dnsSelector:
+            dns.operator.openshift.io/daemonset-dns: default
+          clusterCidrs:
+            - 10.128.0.0/14
+            - 172.30.0.0/16
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0]
+          value:
+            namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-dns
+            podSelector:
+              matchLabels:
+                dns.operator.openshift.io/daemonset-dns: default
+      - contains:
+          path: spec.egress[1].to[0].ipBlock.except
+          content: 10.128.0.0/14
+      - contains:
+          path: spec.egress[1].to[0].ipBlock.except
+          content: 172.30.0.0/16

--- a/client/tests/network_policy_test.yaml
+++ b/client/tests/network_policy_test.yaml
@@ -14,6 +14,33 @@ tests:
       - hasDocuments:
           count: 0
 
+  # The minItems:1 guard on clusterCidrs must be scoped via `if: enabled=true`
+  # in values.schema.json. Without the scope, an operator running on a
+  # non-enforcing CNI (sets enabled: false) and omitting clusterCidrs gets a
+  # schema error even though the policy is off.
+  - it: should not render and should not fail schema when disabled with empty clusterCidrs
+    set:
+      networkPolicy:
+        training:
+          enabled: false
+          clusterCidrs: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when enabled with an empty clusterCidrs list
+    # The JSON schema's minItems:1 constraint short-circuits the template-side
+    # fail guard; both gates are kept as defense-in-depth (the template guard
+    # catches `helm template --validate=false` and other schema-bypass paths).
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          clusterCidrs: []
+    asserts:
+      - failedTemplate:
+          errorPattern: "networkPolicy\\.training\\.clusterCidrs: Array must have at least 1 items"
+
   - it: should render a NetworkPolicy when enabled
     set:
       networkPolicy:

--- a/client/tests/node_agents_namespace_test.yaml
+++ b/client/tests/node_agents_namespace_test.yaml
@@ -1,0 +1,297 @@
+suite: Node-agents namespace + resource-monitor placement
+templates:
+  - templates/node-agents-namespace.yaml
+  - templates/resource-monitor-daemonset.yaml
+  - templates/resource-monitor-rbac.yaml
+  - templates/resource-monitor-scc.yaml
+  - templates/secrets.yaml
+  - templates/docker-registry-secret.yaml
+release:
+  namespace: tracebloc-templates
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  # --- node-agents namespace template ---
+  - it: should render the node-agents namespace by default
+    template: templates/node-agents-namespace.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Namespace
+      - equal:
+          path: metadata.name
+          value: tracebloc-node-agents
+
+  - it: should apply privileged PSA labels on all three modes
+    template: templates/node-agents-namespace.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/enforce"]
+          value: privileged
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/warn"]
+          value: privileged
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/audit"]
+          value: privileged
+
+  - it: should carry the keep annotation so uninstall preserves the namespace
+    template: templates/node-agents-namespace.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: should not render when nodeAgents.namespace.create is false
+    template: templates/node-agents-namespace.yaml
+    set:
+      nodeAgents:
+        namespace:
+          create: false
+          name: pre-existing-ns
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when resourceMonitor is disabled
+    template: templates/node-agents-namespace.yaml
+    set:
+      resourceMonitor: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when node-agents ns name equals release namespace
+    template: templates/node-agents-namespace.yaml
+    set:
+      nodeAgents:
+        namespace:
+          create: true
+          name: tracebloc-templates
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should honour a custom namespace name
+    template: templates/node-agents-namespace.yaml
+    set:
+      nodeAgents:
+        namespace:
+          create: true
+          name: my-agents
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-agents
+
+  # --- resource-monitor DaemonSet placement ---
+  - it: should deploy DaemonSet into the node-agents namespace, not release namespace
+    template: templates/resource-monitor-daemonset.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-node-agents
+
+  - it: should follow a custom node-agents namespace name
+    template: templates/resource-monitor-daemonset.yaml
+    set:
+      nodeAgents:
+        namespace:
+          create: true
+          name: my-agents
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-agents
+
+  - it: should set NAMESPACE env to the release namespace literal, not the Downward API pod namespace
+    template: templates/resource-monitor-daemonset.yaml
+    set:
+      nodeAgents:
+        namespace:
+          create: true
+          name: tracebloc-node-agents
+    asserts:
+      # The monitor watches workloads in the release namespace, so NAMESPACE must
+      # resolve to the release ns, NOT the pod's own (node-agents) namespace.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NAMESPACE
+            value: tracebloc-templates
+      # Guard against regressing to the Downward API form, which would now point
+      # at the node-agents namespace and break pod/log lookups.
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+
+  # --- resource-monitor RBAC placement ---
+  - it: should place the ServiceAccount in the node-agents namespace
+    template: templates/resource-monitor-rbac.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-node-agents
+
+  - it: should bind the ClusterRoleBinding subject to the node-agents namespace
+    template: templates/resource-monitor-rbac.yaml
+    set:
+      clusterScope: true
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: subjects[0].namespace
+          value: tracebloc-node-agents
+
+  - it: should keep namespace-scoped Role + RoleBinding in the release namespace when clusterScope is false, with SA subject in node-agents
+    template: templates/resource-monitor-rbac.yaml
+    set:
+      clusterScope: false
+    asserts:
+      # Role must grant access where the monitored workloads live (release ns)
+      - isKind:
+          of: Role
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+        documentIndex: 1
+      # RoleBinding sits in the release ns so it applies the Role there
+      - isKind:
+          of: RoleBinding
+        documentIndex: 2
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+        documentIndex: 2
+      # ...but the subject SA lives in the node-agents namespace
+      - equal:
+          path: subjects[0].namespace
+          value: tracebloc-node-agents
+        documentIndex: 2
+
+  # --- Secret mirroring (cross-namespace Secrets are not supported by Kubernetes) ---
+  - it: should mirror the tracebloc Opaque Secret into the node-agents namespace by default
+    template: templates/secrets.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Secret
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+        documentIndex: 0
+      - isKind:
+          of: Secret
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-node-agents
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-secrets
+        documentIndex: 1
+      - isNotEmpty:
+          path: data.CLIENT_ID
+        documentIndex: 1
+      - isNotEmpty:
+          path: data.CLIENT_PASSWORD
+        documentIndex: 1
+
+  - it: should not mirror the tracebloc Secret when resourceMonitor is disabled
+    template: templates/secrets.yaml
+    set:
+      resourceMonitor: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+
+  - it: should not mirror the tracebloc Secret when node-agents namespace equals release namespace
+    template: templates/secrets.yaml
+    set:
+      nodeAgents:
+        namespace:
+          create: false
+          name: tracebloc-templates
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+
+  - it: should mirror the docker registry Secret into the node-agents namespace when in use
+    template: templates/docker-registry-secret.yaml
+    set:
+      dockerRegistry:
+        create: true
+        server: https://index.docker.io/v1/
+        username: u
+        password: p
+        email: e@e.com
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-node-agents
+        documentIndex: 1
+      - equal:
+          path: type
+          value: kubernetes.io/dockerconfigjson
+        documentIndex: 1
+
+  - it: should not mirror the docker registry Secret when resourceMonitor is disabled
+    template: templates/docker-registry-secret.yaml
+    set:
+      resourceMonitor: false
+      dockerRegistry:
+        create: true
+        server: https://index.docker.io/v1/
+        username: u
+        password: p
+        email: e@e.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-templates
+
+  # --- OpenShift SCC ---
+  - it: should reference the node-agents ServiceAccount in the SCC users list
+    template: templates/resource-monitor-scc.yaml
+    set:
+      openshift:
+        scc:
+          enabled: true
+    asserts:
+      - equal:
+          path: users[0]
+          value: system:serviceaccount:tracebloc-node-agents:tracebloc-resource-monitor
+        documentIndex: 0
+      - equal:
+          path: subjects[0].namespace
+          value: tracebloc-node-agents
+        documentIndex: 2

--- a/client/tests/resource_monitor_test.yaml
+++ b/client/tests/resource_monitor_test.yaml
@@ -1,0 +1,42 @@
+suite: Resource-monitor DaemonSet
+templates:
+  - templates/resource-monitor-daemonset.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: should render with tag fallback when no digest is set
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/tracebloc/resource-monitor:prod"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: should pin by digest when images.resourceMonitor.digest is set
+    set:
+      images:
+        resourceMonitor:
+          digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/tracebloc/resource-monitor@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  # Regression guard: `helm upgrade --reuse-values` from <1.0.7 carries forward
+  # stored values that never included images.resourceMonitor. The template must
+  # tolerate the whole images map being missing without nil-pointer.
+  - it: should render when images block is entirely absent
+    set:
+      images: null
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/tracebloc/resource-monitor:prod"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always

--- a/client/tests/secrets_test.yaml
+++ b/client/tests/secrets_test.yaml
@@ -28,6 +28,8 @@ tests:
   - it: should create docker registry secret when create is true
     template: templates/docker-registry-secret.yaml
     set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
       dockerRegistry:
         create: true
         server: https://index.docker.io/v1/
@@ -49,6 +51,8 @@ tests:
   - it: should not create docker registry secret when create is omitted (default false)
     template: templates/docker-registry-secret.yaml
     set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
       dockerRegistry:
         server: https://index.docker.io/v1/
         username: testuser
@@ -60,9 +64,28 @@ tests:
 
   - it: should not create docker registry secret when dockerRegistry is omitted (public images)
     template: templates/docker-registry-secret.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
     values:
       - values-public-images.yaml
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should reject placeholder clientId value
+    template: templates/secrets.yaml
+    set:
+      clientId: "<CLIENT_ID>"
+      clientPassword: "real-pass"
+    asserts:
+      - failedTemplate: {}
+
+  - it: should reject empty credentials
+    template: templates/secrets.yaml
+    set:
+      clientId: ""
+      clientPassword: ""
+    asserts:
+      - failedTemplate: {}
 

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -145,6 +145,44 @@
         }
       }
     },
+    "namespace": {
+      "type": "object",
+      "description": "Optional chart-managed Namespace resource with Pod Security Admission labels",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, the chart templates a Namespace with PSA labels and helm.sh/resource-policy: keep. Only use on greenfield installs."
+        },
+        "podSecurity": {
+          "type": "object",
+          "description": "Pod Security Admission labels. Enforce is OFF by default; mysql init + resource-monitor currently violate restricted.",
+          "properties": {
+            "warn": {
+              "type": "string",
+              "enum": ["", "privileged", "baseline", "restricted"]
+            },
+            "warnVersion": {
+              "type": "string"
+            },
+            "audit": {
+              "type": "string",
+              "enum": ["", "privileged", "baseline", "restricted"]
+            },
+            "auditVersion": {
+              "type": "string"
+            },
+            "enforce": {
+              "type": "string",
+              "enum": ["", "privileged", "baseline", "restricted"]
+            },
+            "enforceVersion": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
     "networkPolicy": {
       "type": "object",
       "description": "NetworkPolicy egress lockdown for untrusted training pods. Requires a CNI that enforces NetworkPolicy.",

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -231,11 +231,22 @@
             },
             "clusterCidrs": {
               "type": "array",
-              "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs.",
+              "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs. Must be non-empty when networkPolicy.training.enabled is true — an empty list renders `except: null` and Kubernetes treats that as no exceptions, silently allowing unrestricted in-cluster egress.",
               "items": {
                 "type": "string",
                 "pattern": "^[0-9.]+/[0-9]+$"
               }
+            }
+          },
+          "if": {
+            "properties": {
+              "enabled": { "const": true }
+            },
+            "required": ["enabled"]
+          },
+          "then": {
+            "properties": {
+              "clusterCidrs": { "minItems": 1 }
             }
           }
         }

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -241,15 +241,69 @@
         }
       }
     },
+    "images": {
+      "type": "object",
+      "description": "Container image pinning. Prefer digest over tag for immutability.",
+      "properties": {
+        "jobsManager": {
+          "type": "object",
+          "properties": {
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$",
+              "description": "Optional image digest (sha256:...). When set, overrides the tag."
+            }
+          }
+        },
+        "podsMonitor": {
+          "type": "object",
+          "properties": {
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$"
+            }
+          }
+        },
+        "mysqlClient": {
+          "type": "object",
+          "properties": {
+            "tag": {
+              "type": "string",
+              "not": { "const": "latest" },
+              "description": "Image tag for mysql-client. Empty falls back to env.CLIENT_ENV. Must not be \"latest\"."
+            },
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$"
+            }
+          }
+        },
+        "busybox": {
+          "type": "object",
+          "properties": {
+            "tag": {
+              "type": "string",
+              "not": { "const": "latest" }
+            },
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$"
+            }
+          }
+        }
+      }
+    },
     "clientId": {
       "type": "string",
       "minLength": 1,
-      "description": "Client ID for authentication"
+      "not": { "pattern": "^<.*>$" },
+      "description": "Client ID for authentication. Must be a real value, not a placeholder like <CLIENT_ID>."
     },
     "clientPassword": {
       "type": "string",
       "minLength": 1,
-      "description": "Client authentication password"
+      "not": { "pattern": "^<.*>$" },
+      "description": "Client authentication password. Must be a real value, not a placeholder like <CLIENT_PASSWORD>."
     },
     "dockerRegistry": {
       "type": ["object", "null"],

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -145,6 +145,42 @@
         }
       }
     },
+    "networkPolicy": {
+      "type": "object",
+      "description": "NetworkPolicy egress lockdown for untrusted training pods. Requires a CNI that enforces NetworkPolicy.",
+      "properties": {
+        "training": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Create the training-egress NetworkPolicy. Set false on clusters without an enforcing CNI."
+            },
+            "dnsNamespace": {
+              "type": "string",
+              "default": "kube-system",
+              "description": "Namespace where the cluster DNS service runs"
+            },
+            "dnsSelector": {
+              "type": "object",
+              "description": "Pod labels selecting the cluster DNS service. AKS/EKS/kubeadm: {k8s-app: kube-dns}. OpenShift: {dns.operator.openshift.io/daemonset-dns: default}",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "clusterCidrs": {
+              "type": "array",
+              "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs.",
+              "items": {
+                "type": "string",
+                "pattern": "^[0-9.]+/[0-9]+$"
+              }
+            }
+          }
+        }
+      }
+    },
     "clientId": {
       "type": "string",
       "minLength": 1,

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -131,6 +131,28 @@
       "default": true,
       "description": "Deploy resource-monitor DaemonSet. Defaults to true."
     },
+    "nodeAgents": {
+      "type": "object",
+      "description": "Dedicated namespace for node-level agents (resource-monitor). Isolates hostPath-using DaemonSets from the restricted release namespace.",
+      "properties": {
+        "namespace": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "create": {
+              "type": "boolean",
+              "default": true,
+              "description": "When true, the chart templates the node-agents Namespace with privileged PSA labels. Set false when the namespace is managed out-of-band."
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Name of the namespace that hosts node-level agents. Must exist before install if create is false."
+            }
+          }
+        }
+      }
+    },
     "openshift": {
       "type": "object",
       "properties": {

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -264,6 +264,15 @@
             }
           }
         },
+        "resourceMonitor": {
+          "type": "object",
+          "properties": {
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$"
+            }
+          }
+        },
         "mysqlClient": {
           "type": "object",
           "properties": {

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -181,6 +181,8 @@ images:
     digest: ""
   podsMonitor:
     digest: ""
+  resourceMonitor:
+    digest: ""
   mysqlClient:
     # mysql-client is only published under the "prod" tag — it has no dev/
     # staging variants, so we decouple it from env.CLIENT_ENV. Override only

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -69,6 +69,38 @@ openshift:
   scc:
     enabled: false
 
+# -- Namespace management
+# Default: OFF -- the chart assumes the operator pre-created the namespace via
+#   kubectl create namespace <name>
+# or
+#   helm install --create-namespace -n <name> ...
+#
+# Set namespace.create: true ONLY on greenfield installs. The chart then
+# templates the Namespace with Pod Security Admission labels applied and
+# `helm.sh/resource-policy: keep` so uninstall does not delete your data.
+#
+# For EXISTING namespaces, leave create: false and apply the labels yourself:
+#   kubectl label namespace <name> \
+#     pod-security.kubernetes.io/warn=restricted \
+#     pod-security.kubernetes.io/audit=restricted
+#
+# Enforce mode is deliberately left OFF by default -- the mysql init
+# container and the resource-monitor DaemonSet violate the restricted
+# profile (runAsUser: 0 and hostPath respectively). Opting into enforce
+# before those are refactored will break the chart.
+namespace:
+  create: false
+  podSecurity:
+    # Kubectl warnings for pods that violate the profile
+    warn: restricted
+    warnVersion: "latest"
+    # Audit-log events for pods that violate the profile
+    audit: restricted
+    auditVersion: "latest"
+    # Pod rejection (leave empty by default; see note above)
+    enforce: ""
+    enforceVersion: ""
+
 # -- NetworkPolicy hardening for training pods.
 # Training pods run untrusted ML code; this denies ingress and restricts
 # egress to DNS + external HTTPS only (blocks pod-to-pod, MySQL, K8s API).

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -156,9 +156,35 @@ networkPolicy:
       - "172.16.0.0/12"
       - "192.168.0.0/16"
 
+# -- Container image pinning.
+# For each image, set `digest` to a sha256 (e.g. "sha256:abc123...") to pin
+# the image by content hash. Digest pinning is strongly preferred: tags are
+# mutable, so registry swaps can silently change what you run. When `digest`
+# is set the tag field is ignored and imagePullPolicy drops to IfNotPresent.
+# Leave `digest` empty to fall back to tag-based pulls (CLIENT_ENV for
+# tracebloc images, `tag` for busybox/mysql-client).
+images:
+  jobsManager:
+    digest: ""
+  podsMonitor:
+    digest: ""
+  mysqlClient:
+    # mysql-client is only published under the "prod" tag — it has no dev/
+    # staging variants, so we decouple it from env.CLIENT_ENV. Override only
+    # if you are publishing your own fork with a different tag. Never use
+    # "latest"; pin via digest instead.
+    tag: ""
+    digest: ""
+  busybox:
+    tag: "1.35"
+    digest: ""
+
 # -- Secrets
-clientId: "<CLIENT_ID>"
-clientPassword: "<CLIENT_PASSWORD>"
+# These MUST be set via --set, a values file, or an external secret manager.
+# The defaults are intentionally empty; deployment fails fast if they are not
+# overridden. Do NOT commit real credentials to version control.
+clientId: ""
+clientPassword: ""
 
 # -- Docker registry credentials (optional; only used when dockerRegistry is set and create is true)
 # Omit dockerRegistry entirely, or set create: false, for public images (no imagePullSecrets).

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -102,15 +102,18 @@ openshift:
 # For EXISTING namespaces, leave create: false and apply the labels yourself:
 #   kubectl label namespace <name> \
 #     pod-security.kubernetes.io/warn=restricted \
-#     pod-security.kubernetes.io/audit=restricted
+#     pod-security.kubernetes.io/audit=restricted \
+#     pod-security.kubernetes.io/enforce=restricted
 #
-# Enforce mode is deliberately left OFF by default -- the mysql init
-# container still violates the restricted profile (runAsUser: 0). The
-# resource-monitor DaemonSet previously violated `restricted` via its
-# hostPath mounts, but now runs in its own privileged node-agents
-# namespace (see nodeAgents below), so it no longer blocks enforcing
-# restricted on the release namespace. Flip enforce to `restricted`
-# only after the mysql init refactor lands.
+# enforce=restricted is the default for CSI-backed deployments (EKS/AKS/OC).
+# The mysql init-container has been refactored so it only renders on bare-metal
+# (hostPath.enabled=true); see client/templates/mysql-deployment.yaml.
+# The resource-monitor DaemonSet lives in its own privileged node-agents
+# namespace (nodeAgents.namespace above), so it does not constrain this one.
+# Bare-metal installs override enforce to "" via ci/bm-values.yaml because
+# kubelet does not apply fsGroup to hostPath volumes
+# (kubernetes/kubernetes#138411), so the privileged init-mysql-data chown
+# container is still needed there and would be rejected by restricted.
 namespace:
   create: false
   podSecurity:
@@ -120,9 +123,9 @@ namespace:
     # Audit-log events for pods that violate the profile
     audit: restricted
     auditVersion: "latest"
-    # Pod rejection (leave empty by default; see note above)
-    enforce: ""
-    enforceVersion: ""
+    # Pod rejection -- restricted by default on CSI; bare-metal must override to ""
+    enforce: restricted
+    enforceVersion: "latest"
 
 # -- NetworkPolicy hardening for training pods.
 # Training pods run untrusted ML code; this denies ingress and restricts

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -69,6 +69,35 @@ openshift:
   scc:
     enabled: false
 
+# -- NetworkPolicy hardening for training pods.
+# Training pods run untrusted ML code; this denies ingress and restricts
+# egress to DNS + external HTTPS only (blocks pod-to-pod, MySQL, K8s API).
+# Requires a CNI that enforces NetworkPolicy:
+#   AKS:   needs "Azure NPM" (--network-policy azure) or Calico at cluster create
+#   EKS:   needs Calico or Cilium add-on (AWS VPC CNI alone does NOT enforce)
+#   bm:    needs Calico / Cilium / kube-router (Flannel alone does NOT enforce)
+#   OC:    OVN-Kubernetes enforces by default
+# Leave `enabled: false` on clusters without an enforcing CNI — silently
+# having no protection is worse than explicitly disabling it.
+networkPolicy:
+  training:
+    enabled: true
+    dnsNamespace: kube-system
+    # CoreDNS pod selector — varies per platform. Override in ci/<platform>-values.yaml.
+    # When empty, the template falls back to {k8s-app: kube-dns}, which works
+    # on AKS / EKS / kind / kubeadm / most standard distros.
+    # OpenShift requires explicit override: see client/ci/oc-values.yaml.
+    # Helm merges map values, so to change the selector you MUST set
+    # dnsSelector to the complete desired map (not just additions).
+    dnsSelector: {}
+    # In-cluster CIDRs to block for pod-to-pod egress.
+    # The defaults cover common pod+service CIDR combinations. Override if your
+    # cluster uses different CIDRs (e.g. OpenShift defaults: 10.128.0.0/14 + 172.30.0.0/16).
+    clusterCidrs:
+      - "10.0.0.0/8"
+      - "172.16.0.0/12"
+      - "192.168.0.0/16"
+
 # -- Secrets
 clientId: "<CLIENT_ID>"
 clientPassword: "<CLIENT_PASSWORD>"

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -63,6 +63,26 @@ clusterScope: true
 # -- Resource monitor DaemonSet (node-level metrics collection)
 resourceMonitor: true
 
+# -- Node-level agents (currently: tracebloc-resource-monitor DaemonSet).
+# The resource-monitor needs hostPath /proc and /sys to read node metrics,
+# which Pod Security Admission's `restricted` profile bans outright. Rather
+# than diluting the release namespace's PSA profile, node-agents get their
+# own `privileged` namespace so the rest of the workload can run under
+# `enforce: restricted` unblocked.
+#
+# namespace.create: true  -- chart templates the namespace with PSA
+#                            privileged + helm.sh/resource-policy: keep.
+# namespace.create: false -- operator creates the namespace out-of-band
+#                            (e.g. pre-existing cluster, shared namespace,
+#                            or GitOps tool manages it). The chart still
+#                            deploys the DaemonSet, SA, and RBAC into
+#                            namespace.name; it must exist already with
+#                            privileged PSA labels.
+nodeAgents:
+  namespace:
+    create: true
+    name: tracebloc-node-agents
+
 # -- OpenShift-specific settings
 openshift:
   # Create a SecurityContextConstraints allowing hostPath for the resource monitor
@@ -85,9 +105,12 @@ openshift:
 #     pod-security.kubernetes.io/audit=restricted
 #
 # Enforce mode is deliberately left OFF by default -- the mysql init
-# container and the resource-monitor DaemonSet violate the restricted
-# profile (runAsUser: 0 and hostPath respectively). Opting into enforce
-# before those are refactored will break the chart.
+# container still violates the restricted profile (runAsUser: 0). The
+# resource-monitor DaemonSet previously violated `restricted` via its
+# hostPath mounts, but now runs in its own privileged node-agents
+# namespace (see nodeAgents below), so it no longer blocks enforcing
+# restricted on the release namespace. Flip enforce to `restricted`
+# only after the mysql init refactor lands.
 namespace:
   create: false
   podSecurity:

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -60,7 +60,20 @@ pvc:
 # -- RBAC scope: true for ClusterRole, false for namespace-scoped Role (recommended for OpenShift without cluster-admin)
 clusterScope: true
 
-# -- Resource monitor DaemonSet (node-level metrics collection)
+# -- Resource monitor DaemonSet (node-level metrics collection).
+# REQUIRES metrics-server (https://github.com/kubernetes-sigs/metrics-server):
+# the DaemonSet polls /apis/metrics.k8s.io/v1beta1 for node CPU/memory and
+# crash-loops with 404s when metrics-server is missing. The chart's
+# resource-monitor-daemonset.yaml has a pre-install `lookup` that fails the
+# release up front so misconfiguration surfaces loudly. Platform notes:
+#   k3d / k3s: metrics-server bundled by default (installer keeps it enabled).
+#   AKS:       metrics-server enabled by default.
+#   EKS:       NOT installed by default — `kubectl apply -f \
+#              https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml`
+#   OC:        uses the built-in OpenShift metrics stack.
+#   kubeadm / bare-metal: install metrics-server manually; add
+#              --kubelet-insecure-tls on clusters with self-signed kubelet certs.
+# Set to false on clusters where metrics-server cannot be installed.
 resourceMonitor: true
 
 # -- Node-level agents (currently: tracebloc-resource-monitor DaemonSet).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,6 +10,7 @@ This guide covers installing the **tracebloc** unified Helm chart (AKS, EKS, bar
 - **kubectl** configured for the cluster
 - **Helm 3.x**
 - Required credentials (see [Required configuration](#required-configuration))
+- A CNI that enforces NetworkPolicy if you want the training-pod egress lockdown to actually block traffic — see [SECURITY.md § Per-platform caveats](SECURITY.md#5-per-platform-caveats)
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -146,7 +146,7 @@ Set `namespace.create: true` in your values file. The chart will template a `Nam
 - `pod-security.kubernetes.io/audit: restricted` — audit-log events on violations
 - `helm.sh/resource-policy: keep` — `helm uninstall` leaves the namespace and its data intact
 
-Default profile for warn/audit is `restricted`. Enforce (hard rejection) is deliberately left off — the mysql init container runs as UID 0 and the resource-monitor DaemonSet uses `hostPath`; both would be rejected under `restricted` enforcement.
+Default profile for warn/audit is `restricted`. Enforce (hard rejection) is deliberately left off — the mysql init container runs as UID 0 and would be rejected. The resource-monitor DaemonSet previously blocked enforce too (it uses `hostPath`), but now lives in its own dedicated privileged namespace (`nodeAgents.namespace.name`, default `tracebloc-node-agents`), so it no longer constrains the release namespace.
 
 ```yaml
 # my-values.yaml
@@ -155,8 +155,32 @@ namespace:
   podSecurity:
     warn: restricted
     audit: restricted
-    # enforce: "" — leave off until mysql + resource-monitor are refactored
+    # enforce: "" — leave off until the mysql init is refactored
 ```
+
+### Node-agents namespace (resource-monitor)
+
+The `tracebloc-resource-monitor` DaemonSet mounts `hostPath` volumes (`/proc`, `/sys`) which Pod Security Admission's `restricted` profile bans outright. The chart isolates it in a dedicated **privileged** namespace (default `tracebloc-node-agents`) so it does not constrain the restricted profile on the release namespace.
+
+```yaml
+# my-values.yaml (defaults shown)
+nodeAgents:
+  namespace:
+    create: true                 # set false if managing the namespace out-of-band
+    name: tracebloc-node-agents
+```
+
+When `create: false`, create the namespace yourself with the required PSA labels:
+
+```bash
+kubectl create namespace tracebloc-node-agents
+kubectl label namespace tracebloc-node-agents \
+  pod-security.kubernetes.io/enforce=privileged \
+  pod-security.kubernetes.io/warn=privileged \
+  pod-security.kubernetes.io/audit=privileged
+```
+
+**Upgrading an existing release** (where the DaemonSet currently lives in the release namespace): Helm will delete the old DaemonSet / ServiceAccount / RoleBinding from the release namespace and recreate them in the node-agents namespace. Expect a brief gap in node metrics during the upgrade (DaemonSet rollout time; ~15s terminationGracePeriod + pod startup). The ClusterRole/ClusterRoleBinding keep the same name and are updated in place.
 
 ### Existing namespace — apply labels with kubectl
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -12,6 +12,8 @@ This guide covers installing the **tracebloc** unified Helm chart (AKS, EKS, bar
 - Required credentials (see [Required configuration](#required-configuration))
 - A CNI that enforces NetworkPolicy if you want the training-pod egress lockdown to actually block traffic — see [SECURITY.md § Per-platform caveats](SECURITY.md#5-per-platform-caveats)
 
+**Migrating from another chart?** Read [MIGRATIONS.md](MIGRATIONS.md) first. Skipping the pre-flight `resource-policy: keep` check can delete your PVCs during uninstall, even if you live-annotated them.
+
 ---
 
 ## 1. Add the Helm repository (recommended for production)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -129,6 +129,44 @@ kubectl get pods -n tracebloc -l app=mysql-client
 
 ---
 
+## Namespace Pod Security Admission labels
+
+Training Jobs run untrusted user-supplied ML code. In addition to the per-pod `securityContext` the chart already applies, you can layer on Kubernetes [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) labels on the release namespace for defense-in-depth.
+
+The chart supports two paths:
+
+### New (greenfield) install — chart creates the namespace
+
+Set `namespace.create: true` in your values file. The chart will template a `Namespace` resource with:
+
+- `pod-security.kubernetes.io/warn: restricted` — kubectl warnings on violations
+- `pod-security.kubernetes.io/audit: restricted` — audit-log events on violations
+- `helm.sh/resource-policy: keep` — `helm uninstall` leaves the namespace and its data intact
+
+Default profile for warn/audit is `restricted`. Enforce (hard rejection) is deliberately left off — the mysql init container runs as UID 0 and the resource-monitor DaemonSet uses `hostPath`; both would be rejected under `restricted` enforcement.
+
+```yaml
+# my-values.yaml
+namespace:
+  create: true
+  podSecurity:
+    warn: restricted
+    audit: restricted
+    # enforce: "" — leave off until mysql + resource-monitor are refactored
+```
+
+### Existing namespace — apply labels with kubectl
+
+If the namespace already exists (pre-created by `kubectl create namespace` or `helm install --create-namespace`), leave `namespace.create: false` (the default) and apply the labels yourself:
+
+```bash
+kubectl label namespace tracebloc \
+  pod-security.kubernetes.io/warn=restricted \
+  pod-security.kubernetes.io/audit=restricted
+```
+
+---
+
 ## Publishing the chart (maintainers)
 
 The chart repository used for installation is **[tracebloc/client](https://github.com/tracebloc/client)**. Charts are served from that repo’s GitHub Pages at `https://tracebloc.github.io/client`.

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -1,0 +1,138 @@
+# Helm chart migrations — data safety guide
+
+This document covers operational safety when migrating an installed Helm release from one chart to another (e.g. `eks-1.0.1` → `client-1.0.3`), where **you must preserve the underlying PVC/PV data across the uninstall/install cycle.**
+
+Read this **before** you plan any chart migration. Skipping the pre-flight verification can cost you PVCs even when you think you've protected them.
+
+---
+
+## The `resource-policy: keep` gotcha
+
+> **Helm reads `helm.sh/resource-policy: keep` from the release's stored manifest (the `sh.helm.release.v1.<release>.v<N>` Secret), NOT from the live resource.**
+>
+> Running `kubectl annotate pvc X helm.sh/resource-policy=keep` on a live resource does **nothing** at `helm uninstall` time if the chart template didn't render that annotation. Helm will delete the PVC anyway.
+
+This bit us on 2026-04-22. See [§ Case study](#case-study-tracebloc-templates-2026-04-22) at the end.
+
+---
+
+## Pre-flight verification (mandatory)
+
+Before uninstalling the old release, check whether its stored manifest has the keep annotation on every resource you intend to preserve:
+
+```bash
+helm get manifest <release> -n <ns> | grep -B2 -A1 'resource-policy'
+```
+
+For every PVC / StorageClass / Namespace / Secret you must keep, verify the annotation is present in the output. If it's missing, **do not rely on live-annotating them** — pick one of the three options below.
+
+---
+
+## Mitigation options (in order of preference)
+
+### Option A — `helm upgrade` to inject the annotation before uninstall
+
+If the old chart supports passing extra annotations on PVCs via values (or you have a post-renderer), run an upgrade that adds `helm.sh/resource-policy: keep`. This updates the stored manifest. Subsequent `helm uninstall` honours it.
+
+```bash
+helm upgrade <release> <old-chart> -n <ns> \
+  -f <current-values>.yaml \
+  --set-json 'pvcAnnotations={"helm.sh/resource-policy":"keep"}'
+# verify the annotation is now in the stored manifest:
+helm get manifest <release> -n <ns> | grep 'resource-policy'
+```
+
+Only works if the chart exposes an annotations value. Many older charts don't.
+
+### Option B — strip Helm ownership from the resource
+
+If the old chart does not support templating the annotation, remove the Helm ownership labels/annotations from the resource before uninstalling. Helm won't recognise it as owned and will skip it.
+
+```bash
+# PVC example
+kubectl label pvc <pvc> -n <ns> app.kubernetes.io/managed-by-
+kubectl annotate pvc <pvc> -n <ns> \
+  meta.helm.sh/release-name- \
+  meta.helm.sh/release-namespace-
+```
+
+After uninstall, re-stamp the metadata before installing the new chart so the new release can adopt it:
+
+```bash
+kubectl label pvc <pvc> -n <ns> app.kubernetes.io/managed-by=Helm --overwrite
+kubectl annotate pvc <pvc> -n <ns> \
+  meta.helm.sh/release-name=<new-release-name> \
+  meta.helm.sh/release-namespace=<ns> --overwrite
+```
+
+Trade-off: the resource is briefly orphaned between uninstall and re-stamp. Data is fine; only the ownership metadata is in flux.
+
+### Option C — accept PVC deletion, rely on PV `reclaimPolicy: Retain`
+
+If neither A nor B works and the underlying storage is `Retain`, the data survives PVC deletion. You'll need to rebuild the PVCs manually after uninstall:
+
+```bash
+# 1. Uninstall (PVCs deleted; PVs go to Released; underlying EFS/EBS intact)
+helm uninstall <release> -n <ns>
+
+# 2. Clear claimRef on each PV so it becomes Available
+kubectl patch pv <pv-name> --type=json \
+  -p='[{"op":"remove","path":"/spec/claimRef"}]'
+
+# 3. Re-create PVCs with spec.volumeName pointing at the retained PV
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: <pvc-name>
+  namespace: <ns>
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: <new-release-name>
+    meta.helm.sh/release-namespace: <ns>
+  labels:
+    app.kubernetes.io/managed-by: Helm
+spec:
+  storageClassName: <sc>
+  accessModes: [ReadWriteMany]
+  resources:
+    requests:
+      storage: <size>   # must match PV capacity
+  volumeName: <pv-name>
+EOF
+```
+
+Only safe if the PV's `reclaimPolicy` is `Retain`. With `Delete` you lose data the moment the PV goes Released.
+
+---
+
+## Before uninstall: checklist
+
+1. `helm get manifest <release> -n <ns> | grep resource-policy` — keep annotation present for every resource you must preserve?
+2. `kubectl get pv $(kubectl get pvc -n <ns> -o jsonpath='{.items[*].spec.volumeName}') -o custom-columns=NAME:.metadata.name,RECLAIM:.spec.persistentVolumeReclaimPolicy` — all `Retain`?
+3. Logical backup taken (for MySQL: `mysqldump | gzip > backup.sql.gz` **inside the pod**, then `kubectl cp` out — `kubectl exec > file` streams of >100 MB silently truncate)?
+4. Snapshot of the underlying storage (EFS / EBS / NFS) taken?
+5. Translated values file rendered (`helm template ... --dry-run=server`) and reviewed?
+6. PVC name + storageClassName + size in the new chart match the existing PVCs?
+
+Only proceed to `helm uninstall` when 1 **or** 2+3+4 is satisfied, and 5+6 are verified.
+
+---
+
+## Case study — `tracebloc-templates` migration, 2026-04-22
+
+- **Source:** release `tracebloc` on chart `eks-1.0.1`
+- **Target:** chart `client-1.0.3`
+- **What we did:** annotated PVCs + StorageClass with `helm.sh/resource-policy: keep` via `kubectl annotate`, then ran `helm uninstall`.
+- **What happened:** `helm uninstall` deleted all 3 PVCs + the StorageClass despite the live annotations. The uninstall output **did not** include the usual "These resources were kept due to the resource policy" block.
+- **Root cause:** the `eks-1.0.1` chart didn't template the keep annotation on PVCs. The stored release manifest had no annotation → Helm had no reason to skip them.
+- **Recovery:** PVs had `reclaimPolicy: Retain` and EFS access points survive PV deletion, so no data was lost. We applied Option C above: recreated the StorageClass, cleared `claimRef` on the 3 PVs, re-created PVCs pointing at the retained PVs via `spec.volumeName`. `helm install <new>` then adopted the PVCs. MySQL came up with all 400K rows intact; shared and logs EFS directories intact.
+- **Lesson:** never trust `kubectl annotate` alone to protect live Helm-owned resources. Always verify via `helm get manifest`.
+
+---
+
+## Verifying the new chart (`client-1.0.x` and later)
+
+The new unified `client` chart DOES template `helm.sh/resource-policy: keep` on all three PVCs (`client-pvc`, `client-logs-pvc`, `mysql-pvc`). Confirmed on 2026-04-22 by uninstalling the `tb-client-test` release — Helm correctly reported the 3 PVCs + namespace as kept.
+
+For migrations **away from** a release of this chart, Option A/B/C still apply if the destination chart uses different resource names. For migrations **between** versions of this chart, the keep annotation is already in the stored manifest — a regular `helm upgrade` is safe.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,493 @@
+# tracebloc Client — Security Architecture
+
+**Audience:** security engineers, platform operators, and customers evaluating the tracebloc client for deployment in their own Kubernetes environment.
+
+**Scope:** the defenses that protect a customer cluster against malicious code submitted by external data scientists who train models on that cluster.
+
+## TL;DR
+
+The tracebloc platform lets external data scientists upload **Python code, model weights, and training plans** that run inside a customer's Kubernetes cluster. Everything submitted by the data scientist is treated as **untrusted** — it executes only inside an ephemeral "training pod" that is isolated from the rest of the customer environment by multiple layers:
+
+| Layer | What it does | Mechanism |
+|---|---|---|
+| Identity | Training pods carry no Kubernetes API token | `automountServiceAccountToken: false` |
+| Runtime | Non-root, no privileges, no capabilities, seccomp-default | Pod + container `securityContext` |
+| Filesystem | Read-only root filesystem for the 3 new-architecture training images | `readOnlyRootFilesystem: true` + scoped `emptyDir` mounts |
+| Storage | Dataset volume mounted read-only | `readOnly: true` on the shared PVC mount |
+| Network | Default-deny ingress + narrow egress allow-list (DNS + external HTTPS only) | Kubernetes `NetworkPolicy` |
+| Admission | Namespace-level Pod Security Admission tripwire | `pod-security.kubernetes.io/warn` + `audit` labels |
+
+Every layer is implemented at the pod spec / chart level — no change to training code is required to benefit, and there is nothing the customer must configure beyond installing the chart on a cluster whose CNI enforces NetworkPolicy.
+
+---
+
+## 1. Threat model
+
+### 1.1 What we defend against
+
+A data scientist submits a malicious Python module that is distributed to one or more customer edges for training. The submitted code:
+
+- Has full control over the Python process inside the training pod (`os.environ`, `open()`, `socket`, `subprocess`, etc.).
+- Runs on the customer's own infrastructure, with access to whatever the pod spec grants.
+- Cannot be prevented with static analysis — backend-side Bandit scanning is known to be bypassable (base64-encoded payloads, dynamic imports, `__import__` at the expression level).
+
+The attacker's goals we care about:
+
+1. **Exfiltrate the customer's training data** over the network.
+2. **Impersonate the customer's edge** to the tracebloc backend or on Azure Service Bus.
+3. **Steal the customer's Azure Service Bus credentials** to forge messages affecting other customers.
+4. **Pivot to other Kubernetes workloads** in the customer cluster (cluster-level escalation).
+5. **Poison another experiment's** data, weights, or outputs on the same edge.
+6. **Persist** across training-pod termination.
+
+### 1.2 Trusted components
+
+The following parts of the system are treated as trusted and are **not** in scope for these defenses:
+
+- The tracebloc backend (`*.tracebloc.io`) and its Azure infrastructure (Service Bus, App Insights, Application Runner).
+- The **jobs-manager** and **pods-monitor** containers (tracebloc/jobs-manager, tracebloc/pods-monitor).
+- The **resource-monitor** DaemonSet (tracebloc/resource-monitor).
+- The customer's own Kubernetes cluster, including its worker nodes and admins.
+- Tracebloc engineers publishing the training base images (`tracebloc/*-cpu`, `tracebloc/*-gpu`) and the chart artifact.
+- The Helm chart itself and the values the customer provides at install time.
+
+### 1.3 Untrusted components
+
+- **The Python file, weight file, and training plan submitted by an external data scientist.**
+- **The training pod** that runs that submission — a Kubernetes `Job` spawned at request time by the jobs-manager.
+- Any package the submitted code attempts to `import` from its image-provided environment.
+
+### 1.4 Explicitly out of scope
+
+- Protecting the platform against a compromised **tracebloc engineer** (insider threat at the vendor).
+- Protecting the platform against a compromised **customer admin** (insider threat at the deploying organization).
+- Kernel-level container-escape CVEs (see §7.6 for mitigations).
+- Side-channel attacks (speculative execution, cache timing, etc.).
+- Denial-of-service by resource exhaustion from legitimate-shaped training code.
+
+---
+
+## 2. Design goals for the training-pod sandbox
+
+Seven explicit goals. Every defense in this document ties back to one or more of these.
+
+| # | Goal | Status on new-architecture (use_cases/) tasks | Status on legacy tasks |
+|---|---|---|---|
+| G1 | No long-lived edge credentials in training-pod env | 🟡 In progress (see [§8 residual risks](#8-residual-risks)) | 🟡 In progress |
+| G2 | No network egress except pre-approved in-cluster paths | ✅ Shipped — [NetworkPolicy](#42-network-egress-control) |
+| G3 | No Kubernetes API access from training pods | ✅ Shipped — [SA token off](#43-kubernetes-api-access) |
+| G4 | Non-root, no capabilities, seccomp, read-only rootfs | ✅ / ✅ / ✅ / ✅ | ✅ / ✅ / ✅ / ❌ (pending task-by-task migration) |
+| G5 | No cross-experiment read access | 🟡 Dataset sharing is by design; access is scoped to experiments the data scientist is authorized for |
+| G6 | No write access outside experiment scratch | ✅ Shipped — shared-volume is readOnly |
+| G7 | No cross-tenant Service Bus forgeability | 🟡 Pending backend work |
+
+Green = hard guarantee via chart or pod spec. Yellow = known remaining risk addressed in §8.
+
+---
+
+## 3. Architecture overview
+
+The customer deploys a single Helm chart (this repo) that creates, in their cluster namespace:
+
+- **jobs-manager** (Deployment) — long-running listener on Azure Service Bus; spawns training `Job` objects in response to backend messages.
+- **pods-monitor** (sidecar in jobs-manager) — watches training pod lifecycle.
+- **mysql-client** (Deployment) — local MySQL for dataset metadata.
+- **resource-monitor** (DaemonSet) — per-node metrics collection.
+- Supporting: ServiceAccount, RBAC Role/ClusterRole, PVCs, Secrets, optional NetworkPolicy, optional Namespace.
+
+When the backend assigns an experiment to this edge, jobs-manager creates a Kubernetes `Job`. The resulting pod runs a training image (`tracebloc/client-<category>-<arch>`) that executes the uploaded user code.
+
+The rest of this document covers how the chart and jobs-manager constrain that pod.
+
+---
+
+## 4. Defense layers
+
+### 4.1 Credential isolation (G1)
+
+Training pods do **not** carry long-lived tracebloc backend credentials. The jobs-manager is the only component authenticated to the backend; the narrow credentials a training pod needs are minted per-experiment and passed via environment variables.
+
+The work to remove legacy `CLIENT_ID` / `CLIENT_PASSWORD` injection from training pods is in progress as a separate effort; see §8 for the residual risk until it lands.
+
+### 4.2 Network egress control (G2)
+
+**Mechanism:** Kubernetes `NetworkPolicy` selected on the `tracebloc.io/workload: training` label, which the jobs-manager attaches to every spawned training pod.
+
+**Policy:**
+
+```yaml
+spec:
+  podSelector:
+    matchLabels:
+      tracebloc.io/workload: training
+  policyTypes: [Ingress, Egress]
+  ingress: []    # deny all inbound
+  egress:
+    - to:   # DNS only
+        - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: kube-system}}
+          podSelector: {matchLabels: {k8s-app: kube-dns}}
+      ports:
+        - {port: 53, protocol: UDP}
+        - {port: 53, protocol: TCP}
+    - to:   # external HTTPS only; NOT in-cluster pod/service CIDRs
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]
+      ports:
+        - {port: 443, protocol: TCP}
+```
+
+**What this blocks:**
+
+- Pod-to-pod traffic (can't reach jobs-manager's pod IP)
+- ClusterIP services (can't reach MySQL, can't reach the Kubernetes apiserver's service IP)
+- Non-443 egress (no SSH, no direct SMTP, no arbitrary ports)
+- All incoming connections
+
+**What this still allows:**
+
+- DNS lookups (needed to resolve backend + Azure endpoints)
+- Outbound HTTPS/443 to the public internet (needed today for the training container to reach the tracebloc backend and Azure Service Bus; see §8.2)
+
+**Configuration:** `networkPolicy.training.enabled: true` (the default).
+
+### 4.3 Kubernetes API access (G3)
+
+Training pods set `automountServiceAccountToken: false` on the pod spec. No token is mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token`. Training code cannot introspect or authenticate to the apiserver.
+
+The guarantee is enforced in two places — the base [`job.yaml`](../client-runtime/job.yaml) template and defensively again in the jobs-manager's `_prepare_job_config` — so the protection holds even if the template is edited.
+
+### 4.4 Container runtime hardening (G4)
+
+Every training pod has the following `securityContext` applied at admission time by the jobs-manager:
+
+**Pod-level:**
+```yaml
+securityContext:
+  runAsNonRoot: true
+  seccompProfile: {type: RuntimeDefault}
+```
+
+**Container-level:**
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities: {drop: [ALL]}
+  readOnlyRootFilesystem: true    # new-architecture categories only (see below)
+```
+
+`readOnlyRootFilesystem: true` is applied only to training pods whose `category` is in the new-architecture allow-list (`tabular_classification`, `tabular_regression`, `text_classification`). Legacy categories write weight files inside the image filesystem and cannot yet accommodate a read-only rootfs; see §8.4.
+
+When enabled, the training pod also gets three `emptyDir` mounts to host framework caches and experiment outputs:
+
+| Mount path | Why |
+|---|---|
+| `/home/appuser` | HuggingFace / Transformers / Torch caches (via `HOME`, `HF_HOME`, `TRANSFORMERS_CACHE` in the Dockerfile) |
+| `/tmp` | matplotlib, numpy, and other framework scratch |
+| `/data/scratch` | per-experiment working directory — weights, model files, intermediate state (training code reads `EXPERIMENT_SCRATCH_PATH=/data/scratch` and roots its writes there) |
+
+All three mounts are tmpfs-backed emptyDirs and are destroyed with the pod.
+
+### 4.5 Storage isolation (G5, G6)
+
+**Read-only dataset mount.** The shared-volume PVC (`/data/shared`) holds dataset inputs shared across all experiments on the edge. Training pods mount it read-only:
+
+```yaml
+volumeMounts:
+  - name: shared-volume
+    mountPath: /data/shared
+    readOnly: true
+```
+
+This prevents a malicious training pod from overwriting dataset files, planting backdoors in weight files used by other experiments, or writing executable content to shared storage.
+
+**Writable logs PVC.** `/data/logs` is writable because training code legitimately writes per-experiment log files there. Nothing else in the threat model relies on this volume being read-only.
+
+**Read-side isolation.** Training pods can read files under `/data/shared/<table_name>/` for the dataset they were assigned. Dataset sharing across experiments is by design — multiple experiments on the same dataset read from the same location for efficiency. The tracebloc backend controls which dataset a data scientist is authorized to see; the client-side enforcement is access (the experiment assignment itself), not on-disk separation.
+
+### 4.6 Cross-tenant forgeability (G7)
+
+**Still in progress.** Today the Azure Service Bus connection strings training pods use for `experiments_queue` and `flops_queue` are global settings shared across every edge in a tracebloc environment, not per-edge. A compromised training pod can extract them and post forged messages that the backend will attribute to any edge.
+
+The planned fix is a backend-side endpoint that mints short-TTL, send-only, entity-scoped SAS tokens per experiment. Training pods receive only a scoped token that can be revoked centrally. See §8.1.
+
+### 4.7 Admission-time tripwire (defense in depth)
+
+Kubernetes Pod Security Admission labels the namespace so every new pod is evaluated against the `restricted` profile:
+
+```yaml
+pod-security.kubernetes.io/warn:  restricted
+pod-security.kubernetes.io/audit: restricted
+```
+
+`warn` surfaces violations in `kubectl` output; `audit` writes them to the cluster audit log. These are **visibility**, not enforcement — a tripwire against accidental regressions in pod specs.
+
+`enforce: restricted` is deliberately NOT applied by default because two of the chart's own trusted workloads would be rejected under restricted (see §8.5). Customers who refactor or segregate those can flip enforce on via `namespace.podSecurity.enforce: restricted`.
+
+---
+
+## 5. Per-platform caveats
+
+NetworkPolicy and Pod Security Admission behave differently depending on the customer's Kubernetes distribution and CNI.
+
+### 5.1 NetworkPolicy enforcement
+
+| Platform | Default CNI | Enforces NetworkPolicy? | Operator action |
+|---|---|---|---|
+| **AKS** | Azure CNI | Only with `--network-policy azure` or Calico add-on **enabled at cluster-create time** | Create the cluster with one of these options |
+| **EKS** | AWS VPC CNI | **No** — VPC CNI alone does not enforce NetworkPolicy | Install Calico add-on or Cilium; or leave `networkPolicy.training.enabled: false` and accept the residual risk |
+| **Bare-metal** | depends on install | Calico / Cilium / kube-router: yes. Flannel alone: no | If Flannel-only, install a NetworkPolicy engine or disable the toggle |
+| **OpenShift** | OVN-Kubernetes | Yes (default) | No action — selector defaults differ, see below |
+
+**OpenShift DNS selector:** The CoreDNS selector must be overridden in [`ci/oc-values.yaml`](../client/ci/oc-values.yaml):
+
+```yaml
+networkPolicy:
+  training:
+    dnsNamespace: openshift-dns
+    dnsSelector:
+      dns.operator.openshift.io/daemonset-dns: default
+    clusterCidrs:
+      - "10.128.0.0/14"   # OpenShift default pod CIDR
+      - "172.30.0.0/16"   # OpenShift default service CIDR
+```
+
+**Silent-no-enforcement risk:** If `networkPolicy.training.enabled: true` on a cluster whose CNI does not enforce, the policy is created but ignored. Customers must verify their CNI enforces NetworkPolicy before relying on this layer. We default the EKS `ci/eks-values.yaml` to `enabled: false` for this reason.
+
+### 5.2 Pod Security Admission
+
+PSA requires Kubernetes 1.25+. On older clusters the labels are inert (no warnings, no audit events). The chart does not error out on older clusters; it just loses this layer.
+
+### 5.3 `runAsUser` and OpenShift arbitrary UIDs
+
+The chart does **not** set `runAsUser` on training pods. Training images declare `USER 1001` in their Dockerfiles, and OpenShift's SCC assigns arbitrary UIDs at admission time. Both strategies work because the image's filesystem is group-`0`-writable (`chgrp -R 0 /app && chmod -R g=u /app`) per the Dockerfile pattern.
+
+### 5.4 Bare-metal hostPath
+
+When `hostPath.enabled: true`, the PVCs backing `/data/shared`, `/data/logs`, and MySQL data are rooted at `/tracebloc/<release>/*` on the node filesystem. Training pods still mount those volumes through the PVC abstraction — the read-only enforcement applies. Operators should be aware that compromising the node directly (outside of tracebloc's threat model) gives filesystem-level access to the same data.
+
+---
+
+## 6. What operators must do themselves
+
+The chart ships safe defaults, but a few things require operator attention at install or operationally.
+
+### 6.1 Rotate secrets before trusting the install
+
+If `clientId` / `clientPassword` are leaked after install (published to a dashboard, shared in a ticket, committed to a private config repo), rotate them on the tracebloc console and re-apply the Secret:
+
+```bash
+kubectl -n <ns> create secret generic <release>-secrets \
+  --from-literal=CLIENT_ID=<new-id> \
+  --from-literal=CLIENT_PASSWORD=<new-password> \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n <ns> rollout restart deployment/<release>-jobs-manager
+```
+
+### 6.2 Verify CNI enforces NetworkPolicy
+
+Before trusting §4.2, verify the cluster's CNI actually enforces. Create a test pod with the training label and confirm a blocked destination is blocked:
+
+```bash
+kubectl -n <ns> run np-test --rm -it \
+  --labels="tracebloc.io/workload=training" \
+  --image=nicolaka/netshoot -- bash
+
+# Inside the pod:
+timeout 5 bash -c 'cat < /dev/tcp/mysql-client/3306' && echo FAIL || echo OK   # expect OK
+timeout 5 bash -c 'cat < /dev/tcp/8.8.8.8/443'       && echo OK   || echo FAIL  # expect OK
+timeout 5 bash -c 'cat < /dev/tcp/8.8.8.8/80'        && echo FAIL || echo OK   # expect OK
+```
+
+If any assertion reads the wrong way, the CNI is not enforcing — investigate before relying on §4.2.
+
+### 6.3 Apply PSA labels on existing namespaces
+
+The chart only creates a `Namespace` resource when `namespace.create: true` is explicitly set, and only on greenfield installs. If the namespace was pre-created by `kubectl create namespace` or `helm install --create-namespace`, apply the labels yourself:
+
+```bash
+kubectl label namespace <ns> \
+  pod-security.kubernetes.io/warn=restricted \
+  pod-security.kubernetes.io/audit=restricted
+```
+
+### 6.4 Monitor audit log + kubectl warnings
+
+If PSA is active, watch for audit events and kubectl warnings indicating a pod spec has regressed out of the restricted profile. These are signals that something has drifted — investigate promptly.
+
+### 6.5 Pin or trust the chart version
+
+Chart versions bundle specific Dockerfile + jobs-manager builds. Mixing an old chart with new images or vice-versa may leave hardening gaps. Prefer `helm install` from a pinned chart version and coordinate upgrades.
+
+### 6.6 Upgrade path: refactor before `enforce: restricted`
+
+If the customer wants `pod-security.kubernetes.io/enforce: restricted` on the release namespace (true rejection of non-conforming pods), two chart workloads must first be adjusted:
+
+1. **mysql-client** init containers run as `runAsUser: 0` to chown the MySQL PVC. Switch to `fsGroup: 999` on the pod spec and drop the init container — works on most storage classes, test on your specific CSI driver.
+2. **resource-monitor** DaemonSet mounts `hostPath: /proc` and `/sys`. There is no clean way to preserve its function under `restricted`; options are to disable the resource monitor, accept baseline-level admission for that pod, or move it to a separate privileged namespace.
+
+---
+
+## 7. Verification: check each layer is active
+
+After a fresh install, the following `kubectl` checks confirm each defense layer is in place.
+
+### 7.1 Training pod has the workload label
+
+```bash
+# After at least one experiment has been assigned:
+kubectl -n <ns> get jobs -l app=client -o json \
+  | jq '.items[].spec.template.metadata.labels."tracebloc.io/workload"'
+# expected: "training" (not null)
+```
+
+### 7.2 NetworkPolicy exists and targets training pods
+
+```bash
+kubectl -n <ns> get networkpolicy <release>-training-egress -o yaml \
+  | grep -A2 'podSelector'
+# expected: tracebloc.io/workload: training
+```
+
+### 7.3 Training pods have no service-account token
+
+```bash
+kubectl -n <ns> get job -l app=client -o json \
+  | jq '.items[].spec.template.spec.automountServiceAccountToken'
+# expected: false
+```
+
+### 7.4 Training pods have the restricted securityContext
+
+```bash
+kubectl -n <ns> get job -l app=client -o json \
+  | jq '.items[].spec.template.spec.securityContext'
+# expected: includes runAsNonRoot:true, seccompProfile.type:"RuntimeDefault"
+
+kubectl -n <ns> get job -l app=client -o json \
+  | jq '.items[].spec.template.spec.containers[0].securityContext'
+# expected: allowPrivilegeEscalation:false, capabilities.drop:["ALL"]
+# expected on new-arch: readOnlyRootFilesystem:true
+```
+
+### 7.5 Shared data mount is read-only
+
+```bash
+kubectl -n <ns> get job -l app=client -o json \
+  | jq '.items[].spec.template.spec.containers[0].volumeMounts[]
+        | select(.name=="shared-volume")'
+# expected: readOnly: true
+```
+
+### 7.6 Namespace has PSA labels
+
+```bash
+kubectl get namespace <ns> -o json \
+  | jq '.metadata.labels | with_entries(select(.key | startswith("pod-security.kubernetes.io")))'
+# expected: warn and audit keys set to "restricted"
+```
+
+---
+
+## 8. Residual risks
+
+Known gaps between the current state and a fully-hardened setup, with the owner of the follow-up.
+
+### 8.1 Global Service Bus connection strings (G7) — **backend team**
+
+`experiments_queue_conn_str` and `flops_conn_str` returned by `/api-token-auth/` are Django settings shared across every edge in a tracebloc environment. A compromised training pod can extract them and send forged messages that the backend will attribute to any edge, potentially affecting other customers.
+
+**Mitigation plan:** backend endpoint that mints short-TTL, entity-scoped, send-only SAS tokens per experiment. Backend team owns the design and implementation.
+
+**Interim mitigation:** the `NetworkPolicy` in §4.2 still allows outbound HTTPS, so a training pod can reach Azure Service Bus directly. The only way to hard-block forgery before backend support lands is to deny external egress entirely — not currently possible because training pods legitimately call the backend + App Insights + Service Bus. See §8.2.
+
+### 8.2 Training pods still have outbound HTTPS (G2) — **platform team**
+
+The NetworkPolicy blocks in-cluster traffic and non-443 egress but must allow outbound HTTPS to let training pods function (backend API, Azure Service Bus, App Insights). A malicious pod can still `requests.post()` to an arbitrary endpoint.
+
+**Final fix:** route all training-pod ↔ tracebloc communication through the jobs-manager sidecar, so training pods egress only to a cluster-internal IP and hold no external-facing credentials. Medium-size architectural change; not scheduled for this quarter.
+
+### 8.3 Backend tokens never expire — **backend team**
+
+The tracebloc backend uses Django REST Framework's `authtoken` with no TTL. A leaked token is valid forever until manually deleted from the DB.
+
+**Mitigation plan:** backend adds a revocation endpoint + evaluates switching to `djangorestframework-simplejwt` for TTL-bound tokens. Backend team owns.
+
+### 8.4 Legacy training image architecture (G4 partial) — **legacy-migration team**
+
+Six task types still run on the legacy `common/ping.py` architecture and write weight files inside the image at `/app/common/<experiment_id>/`. These categories cannot receive `readOnlyRootFilesystem: true` until they migrate to the `use_cases/` pattern (which honors `EXPERIMENT_SCRATCH_PATH`).
+
+- Affected: `image_classification`, `keypoint_detection`, `object_detection`, `semantic_segmentation`, `time_series_forecasting`, `time_to_event_prediction`
+- Already migrated: `tabular_classification`, `tabular_regression`, `text_classification`
+
+Adding a migrated category to `READONLY_ROOTFS_CATEGORIES` in the jobs-manager is the only code change needed to promote it once migrated. A separate engineering team owns the migration.
+
+### 8.5 PSA `enforce: restricted` is not default — **platform team**
+
+See §6.6. Two chart workloads (mysql init containers, resource-monitor DaemonSet) violate the restricted profile. Refactoring them unlocks full admission-time enforcement. Currently audit/warn only.
+
+### 8.6 NetworkPolicy silent no-op on unsupported CNI — **operator**
+
+If the customer enables the policy on a CNI that doesn't enforce (default EKS, Flannel-only bare-metal), the chart creates the resource but nothing is blocked. Customers must verify per §6.2.
+
+### 8.7 Kernel-level container escape — **out of scope today**
+
+`readOnlyRootFilesystem`, capability drop, and seccomp-default substantially reduce the exploitable attack surface for kernel CVEs, but a zero-day in the container runtime could still escape a training pod to the node. Defense-in-depth via user-namespace-based runtimes (gVisor, Kata Containers) is available: set `env.RUNTIME_CLASS_NAME` in your values to a RuntimeClass the customer has installed. Not enabled by default because RuntimeClass availability varies by cluster.
+
+### 8.8 DoS via resource exhaustion — **out of scope**
+
+A malicious model can allocate memory / consume CPU up to the pod's resource limits. `resources.limits` are applied (defaults `cpu=2,memory=8Gi`). A pod running at 100% of its limits is expected behavior for training; OOMKill or eviction is the Kubernetes-native response. The chart does not attempt to detect or prevent resource-intensive pathological inputs.
+
+---
+
+## 9. If you suspect compromise
+
+If a specific training run is suspected of malicious behavior:
+
+1. **Stop the training job** via the tracebloc console or:
+   ```bash
+   kubectl -n <ns> delete job <job-name>
+   ```
+2. **Snapshot the pod logs** before the pod is garbage-collected (default `ttlSecondsAfterFinished: 30`):
+   ```bash
+   kubectl -n <ns> logs --previous <pod-name> > suspect-pod.log
+   ```
+3. **Rotate `clientId` / `clientPassword`** if you have any reason to believe the pod exfiltrated them:
+   - Change the password on the tracebloc console (backend team can invalidate the old token)
+   - Update the Kubernetes Secret per §6.1
+4. **Check the audit log** for PSA violations or anomalous K8s API calls (though training pods have no token, so this should be a no-op):
+   ```bash
+   # Depends on cluster audit policy configuration
+   ```
+5. **Report the model to the tracebloc security team** with the job name, experiment ID, and pod logs so the model file can be quarantined on the backend and the data scientist's submission blocked.
+
+---
+
+## 10. Where each defense is implemented
+
+Cross-reference for reviewers and contributors.
+
+| Layer | Code path |
+|---|---|
+| Workload label on training pod | [`client-runtime:jobs_manager._prepare_job_config`](https://github.com/tracebloc/client-runtime/blob/develop/jobs_manager.py) |
+| `automountServiceAccountToken: false` | same |
+| Pod + container securityContext | same |
+| Shared volume `readOnly` | same |
+| `readOnlyRootFilesystem` + emptyDir mounts | same (gated by `READONLY_ROOTFS_CATEGORIES`) |
+| Training-pod NetworkPolicy | [`client:templates/network-policy-training.yaml`](../client/templates/network-policy-training.yaml) |
+| Namespace PSA labels | [`client:templates/namespace.yaml`](../client/templates/namespace.yaml) (opt-in) |
+| Experiment scratch-path env | [`tracebloc-client:core/utils/general.py`](https://github.com/tracebloc/tracebloc-client/blob/develop/core/utils/general.py) |
+| Stripped Dockerfile CMD credentials | [`tracebloc-client:*.cpu.Dockerfile`, `*.gpu.Dockerfile`](https://github.com/tracebloc/tracebloc-client) |
+
+---
+
+## 11. Document history
+
+- **2026-04** — Initial version. Documents the training-pod sandbox as shipped in client chart ≥ 1.0.4 and client-runtime images built from `develop` at that date. Reflects the narrow threat model (trusted platform, untrusted external data scientist submissions).
+
+---
+
+## 12. Questions or reports
+
+For questions about this document, issues with a specific defense, or to report a suspected vulnerability, contact the tracebloc security team at **security@tracebloc.com**. Do not file public issues for security-relevant reports.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -92,7 +92,7 @@ The customer deploys a single Helm chart (this repo) that creates, in their clus
 - **jobs-manager** (Deployment) — long-running listener on Azure Service Bus; spawns training `Job` objects in response to backend messages.
 - **pods-monitor** (sidecar in jobs-manager) — watches training pod lifecycle.
 - **mysql-client** (Deployment) — local MySQL for dataset metadata.
-- **resource-monitor** (DaemonSet) — per-node metrics collection.
+- **resource-monitor** (DaemonSet) — per-node metrics collection. Requires `metrics-server` (polls `/apis/metrics.k8s.io/v1beta1`); the chart fails the install up front if it's missing. Disable via `resourceMonitor: false` on clusters where metrics-server cannot be installed.
 - Supporting: ServiceAccount, RBAC Role/ClusterRole, PVCs, Secrets, optional NetworkPolicy, optional Namespace.
 
 When the backend assigns an experiment to this edge, jobs-manager creates a Kubernetes `Job`. The resulting pod runs a training image (`tracebloc/client-<category>-<arch>`) that executes the uploaded user code.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -222,7 +222,7 @@ pod-security.kubernetes.io/audit: restricted
 
 `warn` surfaces violations in `kubectl` output; `audit` writes them to the cluster audit log. These are **visibility**, not enforcement — a tripwire against accidental regressions in pod specs.
 
-`enforce: restricted` is deliberately NOT applied by default because two of the chart's own trusted workloads would be rejected under restricted (see §8.5). Customers who refactor or segregate those can flip enforce on via `namespace.podSecurity.enforce: restricted`.
+`enforce: restricted` is on by default on CSI-backed deployments (EKS/AKS/OC); bare-metal overrides it off via `ci/bm-values.yaml`. See §6.6 and §8.5.
 
 ---
 
@@ -307,6 +307,15 @@ If any assertion reads the wrong way, the CNI is not enforcing — investigate b
 The chart only creates a `Namespace` resource when `namespace.create: true` is explicitly set, and only on greenfield installs. If the namespace was pre-created by `kubectl create namespace` or `helm install --create-namespace`, apply the labels yourself:
 
 ```bash
+# CSI-backed deployments (EKS/AKS/OC): enforce is safe.
+kubectl label namespace <ns> \
+  pod-security.kubernetes.io/warn=restricted \
+  pod-security.kubernetes.io/audit=restricted \
+  pod-security.kubernetes.io/enforce=restricted
+
+# Bare-metal (hostPath): skip enforce -- the privileged init-mysql-data
+# chown container required on hostPath (kubernetes/kubernetes#138411)
+# would be rejected. warn+audit still give visibility.
 kubectl label namespace <ns> \
   pod-security.kubernetes.io/warn=restricted \
   pod-security.kubernetes.io/audit=restricted
@@ -320,12 +329,11 @@ If PSA is active, watch for audit events and kubectl warnings indicating a pod s
 
 Chart versions bundle specific Dockerfile + jobs-manager builds. Mixing an old chart with new images or vice-versa may leave hardening gaps. Prefer `helm install` from a pinned chart version and coordinate upgrades.
 
-### 6.6 Upgrade path: refactor before `enforce: restricted`
+### 6.6 `enforce: restricted` on bare-metal
 
-If the customer wants `pod-security.kubernetes.io/enforce: restricted` on the release namespace (true rejection of non-conforming pods), two chart workloads must first be adjusted:
+`enforce: restricted` is the chart default for CSI-backed deployments. Bare-metal installs (`hostPath.enabled: true`) cannot use enforce because the privileged `init-mysql-data` container — required because kubelet does not apply `fsGroup` to hostPath volumes ([kubernetes/kubernetes#138411](https://github.com/kubernetes/kubernetes/issues/138411)) — would be rejected. `ci/bm-values.yaml` overrides `namespace.podSecurity.enforce` to `""` accordingly. `warn` and `audit` remain on so violations are still logged.
 
-1. **mysql-client** init containers run as `runAsUser: 0` to chown the MySQL PVC. Switch to `fsGroup: 999` on the pod spec and drop the init container — works on most storage classes, test on your specific CSI driver.
-2. **resource-monitor** DaemonSet mounts `hostPath: /proc` and `/sys`. There is no clean way to preserve its function under `restricted`; options are to disable the resource monitor, accept baseline-level admission for that pod, or move it to a separate privileged namespace.
+Node-level agents (`tracebloc-resource-monitor` DaemonSet) run in a separate namespace (`tracebloc-node-agents`) at `enforce: privileged` — they legitimately need hostPath access to `/proc` / `/sys` / cgroups. The release namespace stays clean.
 
 ---
 
@@ -423,9 +431,9 @@ Six task types still run on the legacy `common/ping.py` architecture and write w
 
 Adding a migrated category to `READONLY_ROOTFS_CATEGORIES` in the jobs-manager is the only code change needed to promote it once migrated. A separate engineering team owns the migration.
 
-### 8.5 PSA `enforce: restricted` is not default — **platform team**
+### 8.5 PSA `enforce: restricted` on bare-metal — **operator**
 
-See §6.6. Two chart workloads (mysql init containers, resource-monitor DaemonSet) violate the restricted profile. Refactoring them unlocks full admission-time enforcement. Currently audit/warn only.
+`enforce: restricted` is the chart default for CSI-backed deployments (EKS/AKS/OC). Bare-metal installs cannot use enforce because kubelet does not apply `fsGroup` to hostPath volumes ([kubernetes/kubernetes#138411](https://github.com/kubernetes/kubernetes/issues/138411)), forcing the chart to render a privileged `init-mysql-data` chown container on the hostPath path. `ci/bm-values.yaml` overrides enforce to `""` so the install works; `warn` and `audit` remain on. If / when upstream fixes the hostPath fsGroup gap (or the chart moves to a rootless mysql image that doesn't need the chown), bare-metal can join the enforce default.
 
 ### 8.6 NetworkPolicy silent no-op on unsupported CNI — **operator**
 

--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -18,8 +18,6 @@
 #    $env:SERVERS       = "1"              default: 1  (control-plane nodes)
 #    $env:AGENTS        = "1"              default: 1  (worker nodes)
 #    $env:K8S_VERSION   = "v1.29.4-k3s1"  default: latest
-#    $env:HTTP_PORT     = "80"             default: 80
-#    $env:HTTPS_PORT    = "443"            default: 443
 #    $env:HOST_DATA_DIR = "C:\data"        default: $env:USERPROFILE\.tracebloc
 #    $env:CLIENT_ENV    = "dev"            optional; if not set, CLIENT_ENV is not added to env in values
 # =============================================================================
@@ -118,8 +116,6 @@ $CLUSTER_NAME  = if ($env:CLUSTER_NAME)  { $env:CLUSTER_NAME }  else { "traceblo
 $SERVERS       = if ($env:SERVERS)       { $env:SERVERS }       else { "1" }
 $AGENTS        = if ($env:AGENTS)        { $env:AGENTS }        else { "1" }
 $K8S_VERSION   = if ($env:K8S_VERSION)   { $env:K8S_VERSION }   else { "v1.29.4-k3s1" }
-$HTTP_PORT     = if ($env:HTTP_PORT)     { $env:HTTP_PORT }     else { "80" }
-$HTTPS_PORT    = if ($env:HTTPS_PORT)    { $env:HTTPS_PORT }    else { "443" }
 $HOST_DATA_DIR = if ($env:HOST_DATA_DIR) { $env:HOST_DATA_DIR } else { "$env:USERPROFILE\.tracebloc" }
 $CLIENT_ENV    = $env:CLIENT_ENV
 
@@ -149,8 +145,6 @@ Advanced configuration (environment variables):
   AGENTS         Worker nodes                    (default: 1)
   K8S_VERSION    k3s image tag                   (default: v1.29.4-k3s1)
   -NoReboot      Skip reboot prompt after enabling Windows features
-  HTTP_PORT      Host HTTP  port                 (default: 80)
-  HTTPS_PORT     Host HTTPS port                 (default: 443)
   HOST_DATA_DIR  Persistent data directory       (default: ~\.tracebloc)
 
 macOS / Linux:
@@ -172,15 +166,6 @@ function Confirm-Config {
   }
   if ($SERVERS -notmatch '^[1-9]\d*$') { Err ("SERVERS must be a positive integer >= 1 (got '" + $SERVERS + "')") }
   if ($AGENTS  -notmatch '^\d+$') { Err ("AGENTS must be a non-negative integer (got '" + $AGENTS + "')") }
-  if ($HTTP_PORT  -notmatch '^\d+$' -or [int]$HTTP_PORT -lt 1 -or [int]$HTTP_PORT -gt 65535) {
-    Err ("HTTP_PORT must be 1-65535 (got '" + $HTTP_PORT + "')")
-  }
-  if ($HTTPS_PORT -notmatch '^\d+$' -or [int]$HTTPS_PORT -lt 1 -or [int]$HTTPS_PORT -gt 65535) {
-    Err ("HTTPS_PORT must be 1-65535 (got '" + $HTTPS_PORT + "')")
-  }
-  if ($HTTP_PORT -eq $HTTPS_PORT) {
-    Err ("HTTP_PORT and HTTPS_PORT must be different (both set to " + $HTTP_PORT + ")")
-  }
   $dataDir = [System.IO.Path]::GetFullPath($HOST_DATA_DIR)
   $userProfile = [System.IO.Path]::GetFullPath($env:USERPROFILE)
   if (-not $dataDir.StartsWith($userProfile, [StringComparison]::OrdinalIgnoreCase)) {
@@ -231,7 +216,7 @@ function Print-Banner {
   Hint "  ~\.tracebloc\    (data and config)"
   Hint "  Docker           (container runtime)"
   Write-Host ""
-  Log "Cluster='$CLUSTER_NAME'  Servers=$SERVERS  Agents=$AGENTS  HTTP=$HTTP_PORT  HTTPS=$HTTPS_PORT"
+  Log "Cluster='$CLUSTER_NAME'  Servers=$SERVERS  Agents=$AGENTS"
   Log "Host data dir: $HOST_DATA_DIR"
 }
 
@@ -715,14 +700,20 @@ function New-K3dCluster {
       New-Item -ItemType Directory -Path $HOST_DATA_DIR -Force | Out-Null
     }
 
+    # The tracebloc client is outbound-only: jobs-manager + pods-monitor dial
+    # out to the platform, and the only in-cluster Service (mysql-client) is
+    # ClusterIP. Disable k3s components that exist solely to handle inbound
+    # traffic or duplicate chart-provided resources.
     $k3dArgs = @(
       "cluster", "create", $CLUSTER_NAME,
       "--servers", $SERVERS,
       "--agents",  $AGENTS,
-      "--port",    "${HTTP_PORT}:80@loadbalancer",
-      "--port",    "${HTTPS_PORT}:443@loadbalancer",
       "--api-port","6550",
       "-v",        "${HOST_DATA_DIR}:/tracebloc@all",
+      "--k3s-arg", "--disable=traefik@server:*",
+      "--k3s-arg", "--disable=servicelb@server:*",
+      "--k3s-arg", "--disable=metrics-server@server:*",
+      "--k3s-arg", "--disable=local-storage@server:*",
       "--wait"
     )
 
@@ -1069,7 +1060,6 @@ function Print-Summary {
   Log ""
   Log "=== Advanced Info (for debugging) ==="
   Log "Cluster topology: Servers=$SERVERS  Agents=$AGENTS"
-  Log "Ingress: localhost:$HTTP_PORT / localhost:$HTTPS_PORT"
   Log "Volume mount: $HOST_DATA_DIR -> /tracebloc"
   Log ""
   Log "Useful commands:"

--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -712,7 +712,6 @@ function New-K3dCluster {
       "-v",        "${HOST_DATA_DIR}:/tracebloc@all",
       "--k3s-arg", "--disable=traefik@server:*",
       "--k3s-arg", "--disable=servicelb@server:*",
-      "--k3s-arg", "--disable=metrics-server@server:*",
       "--k3s-arg", "--disable=local-storage@server:*",
       "--wait"
     )

--- a/scripts/install-k8s.sh
+++ b/scripts/install-k8s.sh
@@ -18,8 +18,6 @@
 #    SERVERS=1                   default: 1  (control-plane nodes)
 #    AGENTS=1                    default: 1  (worker nodes)
 #    K8S_VERSION=v1.29.4-k3s1   default: latest stable k3s
-#    HTTP_PORT=80                default: 80   (host → cluster ingress)
-#    HTTPS_PORT=443              default: 443
 #    HOST_DATA_DIR=~/.tracebloc  default: ~/.tracebloc
 #    CLIENT_ENV=dev              optional; if not set, CLIENT_ENV is not added to env in values
 #    TRACEBLOC_SKIP_REBOOT_PROMPT=1 (Linux) skip "Reboot now?" after NVIDIA driver install

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -75,8 +75,11 @@ _create_new_cluster() {
   # or duplicate chart-provided resources:
   #   traefik        — no Ingress resources in the chart
   #   servicelb      — no LoadBalancer Services
-  #   metrics-server — chart ships its own tracebloc-resource-monitor DaemonSet
   #   local-storage  — chart creates its own StorageClass (client-storage-class)
+  #
+  # metrics-server is kept: the tracebloc-resource-monitor DaemonSet queries
+  # the metrics.k8s.io API for node CPU/memory; without it the DaemonSet
+  # crash-loops with 404s against /apis/metrics.k8s.io/v1beta1.
   K3D_ARGS=(
     cluster create "$CLUSTER_NAME"
     --servers "$SERVERS"
@@ -85,7 +88,6 @@ _create_new_cluster() {
     -v "${HOST_DATA_DIR}:/tracebloc@all"
     --k3s-arg "--disable=traefik@server:*"
     --k3s-arg "--disable=servicelb@server:*"
-    --k3s-arg "--disable=metrics-server@server:*"
     --k3s-arg "--disable=local-storage@server:*"
     --wait
   )

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -69,14 +69,24 @@ _handle_existing_cluster() {
 }
 
 _create_new_cluster() {
+  # The tracebloc client is outbound-only: jobs-manager + pods-monitor dial out
+  # to the platform, and the only in-cluster Service (mysql-client) is ClusterIP.
+  # So we disable k3s components that exist solely to handle inbound traffic
+  # or duplicate chart-provided resources:
+  #   traefik        — no Ingress resources in the chart
+  #   servicelb      — no LoadBalancer Services
+  #   metrics-server — chart ships its own tracebloc-resource-monitor DaemonSet
+  #   local-storage  — chart creates its own StorageClass (client-storage-class)
   K3D_ARGS=(
     cluster create "$CLUSTER_NAME"
     --servers "$SERVERS"
     --agents  "$AGENTS"
-    --port "${HTTP_PORT}:80@loadbalancer"
-    --port "${HTTPS_PORT}:443@loadbalancer"
     --api-port 6550
     -v "${HOST_DATA_DIR}:/tracebloc@all"
+    --k3s-arg "--disable=traefik@server:*"
+    --k3s-arg "--disable=servicelb@server:*"
+    --k3s-arg "--disable=metrics-server@server:*"
+    --k3s-arg "--disable=local-storage@server:*"
     --wait
   )
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -238,8 +238,6 @@ SERVERS="${SERVERS:-1}"
 AGENTS="${AGENTS:-1}"
 # Pinned default; set K8S_VERSION="" to use latest (may break on new k3s releases)
 K8S_VERSION="${K8S_VERSION:-v1.29.4-k3s1}"
-HTTP_PORT="${HTTP_PORT:-80}"
-HTTPS_PORT="${HTTPS_PORT:-443}"
 HOST_DATA_DIR="${HOST_DATA_DIR:-$HOME/.tracebloc}"
 
 # ── Input validation ────────────────────────────────────────────────────────
@@ -252,12 +250,6 @@ validate_config() {
 
   [[ "$SERVERS" =~ ^[1-9][0-9]*$ ]] || error "SERVERS must be a positive integer >= 1 (got '$SERVERS')"
   [[ "$AGENTS"  =~ ^[0-9]+$ ]]     || error "AGENTS must be a non-negative integer (got '$AGENTS')"
-
-  [[ "$HTTP_PORT" =~ ^[0-9]+$ ]]  || error "HTTP_PORT must be a number (got '$HTTP_PORT')"
-  [[ "$HTTPS_PORT" =~ ^[0-9]+$ ]] || error "HTTPS_PORT must be a number (got '$HTTPS_PORT')"
-  (( HTTP_PORT >= 1 && HTTP_PORT <= 65535 ))   || error "HTTP_PORT must be 1-65535 (got '$HTTP_PORT')"
-  (( HTTPS_PORT >= 1 && HTTPS_PORT <= 65535 )) || error "HTTPS_PORT must be 1-65535 (got '$HTTPS_PORT')"
-  (( HTTP_PORT != HTTPS_PORT )) || error "HTTP_PORT and HTTPS_PORT must be different (both set to $HTTP_PORT)"
 
   # HOST_DATA_DIR must be under $HOME and must not be a system path (security)
   local dir="$HOST_DATA_DIR"
@@ -362,8 +354,6 @@ Advanced configuration (environment variables):
   SERVERS        Control-plane nodes             (default: 1)
   AGENTS         Worker nodes                    (default: 1)
   K8S_VERSION    k3s image tag                   (default: v1.29.4-k3s1)
-  HTTP_PORT      Host HTTP  port                 (default: 80)
-  HTTPS_PORT     Host HTTPS port                 (default: 443)
   HOST_DATA_DIR  Persistent data directory       (default: ~/.tracebloc)
 
 Windows:

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -74,6 +74,18 @@ install_client_helm() {
   _ensure_tracebloc_dirs
   local values_file="${HOST_DATA_DIR}/values.yaml"
 
+  # ── Dev-mode override: caller-supplied values file ───────────────────────
+  # When TRACEBLOC_VALUES_FILE is set, skip prompts and values.yaml generation
+  # and use the provided file as-is. Used for local testing against an
+  # unreleased chart (pair with TRACEBLOC_CHART_PATH).
+  if [[ -n "${TRACEBLOC_VALUES_FILE:-}" ]]; then
+    [[ -f "$TRACEBLOC_VALUES_FILE" ]] || error "TRACEBLOC_VALUES_FILE not found: $TRACEBLOC_VALUES_FILE"
+    values_file="$TRACEBLOC_VALUES_FILE"
+    TB_NAMESPACE="${TB_NAMESPACE:-default}"
+    info "Dev mode: using caller-provided values file"
+    log "Using values file: $values_file (namespace: $TB_NAMESPACE)"
+  else
+
   local use_existing=""
   local default_namespace="default"
   local default_client_id=""
@@ -191,23 +203,33 @@ EOF
 
   chmod 600 "$values_file" 2>/dev/null || true
   log "Values file written to $values_file"
+  fi
 
   _ensure_helm_runnable
 
-  # ── Add repo and install (all output goes to log) ───────────────────────
-  if ! helm repo list 2>/dev/null | grep -q "^${TRACEBLOC_HELM_REPO_NAME}[[:space:]]"; then
-    log "Adding Helm repo: $TRACEBLOC_HELM_REPO_URL"
-    helm repo add "$TRACEBLOC_HELM_REPO_NAME" "$TRACEBLOC_HELM_REPO_URL" >> "${LOG_FILE:-/dev/null}" 2>&1
+  # ── Resolve chart reference: local path (dev) or remote repo (default) ──
+  local chart_ref
+  if [[ -n "${TRACEBLOC_CHART_PATH:-}" ]]; then
+    [[ -d "$TRACEBLOC_CHART_PATH" ]] || error "TRACEBLOC_CHART_PATH not found: $TRACEBLOC_CHART_PATH"
+    chart_ref="$TRACEBLOC_CHART_PATH"
+    info "Dev mode: using local chart at $chart_ref"
+    log "Using local chart: $chart_ref"
+  else
+    if ! helm repo list 2>/dev/null | grep -q "^${TRACEBLOC_HELM_REPO_NAME}[[:space:]]"; then
+      log "Adding Helm repo: $TRACEBLOC_HELM_REPO_URL"
+      helm repo add "$TRACEBLOC_HELM_REPO_NAME" "$TRACEBLOC_HELM_REPO_URL" >> "${LOG_FILE:-/dev/null}" 2>&1
+    fi
+    log "Updating Helm repos..."
+    helm repo update >> "${LOG_FILE:-/dev/null}" 2>&1
+    chart_ref="$TRACEBLOC_HELM_REPO_NAME/$TRACEBLOC_CHART_NAME"
   fi
-  log "Updating Helm repos..."
-  helm repo update >> "${LOG_FILE:-/dev/null}" 2>&1
 
   echo ""
-  log "Installing $TB_NAMESPACE from $TRACEBLOC_HELM_REPO_NAME/$TRACEBLOC_CHART_NAME in namespace '$TB_NAMESPACE'..."
+  log "Installing $TB_NAMESPACE from $chart_ref in namespace '$TB_NAMESPACE'..."
 
   local helm_log
   helm_log="$(mktemp)"
-  if ! helm upgrade --install "$TB_NAMESPACE" "$TRACEBLOC_HELM_REPO_NAME/$TRACEBLOC_CHART_NAME" \
+  if ! helm upgrade --install "$TB_NAMESPACE" "$chart_ref" \
     --namespace "$TB_NAMESPACE" \
     --create-namespace \
     --values "$values_file" > "$helm_log" 2>&1; then

--- a/scripts/lib/summary.sh
+++ b/scripts/lib/summary.sh
@@ -53,7 +53,6 @@ _log_advanced_info() {
   log ""
   log "=== Advanced Info (for debugging) ==="
   log "Cluster topology: Servers=$SERVERS  Agents=$AGENTS"
-  log "Ingress: localhost:$HTTP_PORT / localhost:$HTTPS_PORT"
   log "Volume mount: $HOST_DATA_DIR → /tracebloc"
   log ""
   log "Useful commands:"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it changes Helm-rendered security controls (NetworkPolicy/PSA), moves `resource-monitor` into a new namespace with cross-namespace secrets/RBAC, and adds install-time failures (metrics-server/required credentials) that can break upgrades if misconfigured.
> 
> **Overview**
> **Security hardening for untrusted training pods**: adds an optional `NetworkPolicy` (`templates/network-policy-training.yaml`) that denies ingress and restricts egress to DNS + external HTTPS, with schema/template guards to prevent unsafe empty `clusterCidrs` and per-platform defaults in `ci/*-values.yaml`.
> 
> **Pod Security Admission + namespace isolation**: introduces chart-managed `Namespace` rendering with PSA labels and `helm.sh/resource-policy: keep` (`templates/namespace.yaml`), and moves `tracebloc-resource-monitor` into a dedicated privileged `nodeAgents` namespace (`templates/node-agents-namespace.yaml`) while mirroring required Secrets and registry pull secrets and updating RBAC/SCC accordingly.
> 
> **Supply-chain + runtime tightening**: adds digest-based image pinning support via `tracebloc.image`, switches workloads to use digests when provided (and adjusts `imagePullPolicy`), hardens `mysql-client` to run read-only/non-root with required writable `emptyDir` mounts, gates the privileged MySQL init container to `hostPath.enabled`, and fails fast on missing credentials/placeholder values.
> 
> Docs/ops updates include new `docs/SECURITY.md` and `docs/MIGRATIONS.md`, installation guidance updates, a new GitHub Action to auto-add issues/PRs to the org kanban, and installer changes to remove ingress port mapping and disable unnecessary k3s components while adding dev-mode overrides for installing from local chart/values paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3efc92a9e22aec82c09c27d1631634a728e046c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->