### PR TITLE
fix(client): pin resource-monitor by digest (v1.0.7)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.0.6
-appVersion: "1.0.6"
+version: 1.0.7
+appVersion: "1.0.7"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -42,8 +42,8 @@ spec:
         - operator: "Exists"
       containers:
         - name: tracebloc-resource-monitor
-          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" .Values.env.CLIENT_ENV "registry" "docker.io") | quote }}
-          imagePullPolicy: Always
+          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.resourceMonitor.digest "registry" "docker.io") | quote }}
+          imagePullPolicy: {{ if .Values.images.resourceMonitor.digest }}IfNotPresent{{ else }}Always{{ end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -264,6 +264,15 @@
             }
           }
         },
+        "resourceMonitor": {
+          "type": "object",
+          "properties": {
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$"
+            }
+          }
+        },
         "mysqlClient": {
           "type": "object",
           "properties": {

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -181,6 +181,8 @@ images:
     digest: ""
   podsMonitor:
     digest: ""
+  resourceMonitor:
+    digest: ""
   mysqlClient:
     # mysql-client is only published under the "prod" tag — it has no dev/
     # staging variants, so we decouple it from env.CLIENT_ENV. Override only


### PR DESCRIPTION
## Summary

PR #53 ("harden image pinning and credentials") added `digest:` + conditional `imagePullPolicy` for every chart-shipped image *except* resource-monitor. This PR closes that gap so the whole chart can be locked to sha256 digests.

- `client/templates/resource-monitor-daemonset.yaml`: thread `.Values.images.resourceMonitor.digest` into the `tracebloc.image` helper; flip `imagePullPolicy` to the conditional pattern used by jobs-manager / pods-monitor.
- `client/values.yaml`: add `images.resourceMonitor.digest: ""` alongside the other image entries.
- `client/values.schema.json`: add the matching `resourceMonitor` schema entry (same `^(sha256:[a-f0-9]{64})?$` pattern).
- `client/Chart.yaml`: bump 1.0.6 → 1.0.7.

**Severity:** low — not a breakage, it's a supply-chain hardening gap. Without this change, anyone with push access to `tracebloc/resource-monitor:prod` can swap the image under any cluster that upgrades the DaemonSet.

## Test plan

- [x] `helm lint ./client` — no new errors (the two pre-existing `clientId/clientPassword` errors are unrelated and by design)
- [x] `helm template` with empty digest → renders `docker.io/tracebloc/resource-monitor:prod` + `imagePullPolicy: Always` (backwards compatible)
- [x] `helm template` with a valid digest → renders `@sha256:...` + `imagePullPolicy: IfNotPresent`
- [x] Schema rejects malformed digests (e.g. `not-a-digest`) with `Does not match pattern`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Helm chart-only change that adds optional digest pinning for `tracebloc/resource-monitor` and tweaks `imagePullPolicy`; behavior is unchanged when no digest is provided.
> 
> **Overview**
> Updates the Helm chart to support **digest-pinning for the `resource-monitor` DaemonSet image**, aligning it with the other chart-managed images.
> 
> `resource-monitor-daemonset.yaml` now passes `.Values.images.resourceMonitor.digest` to `tracebloc.image` and conditionally switches `imagePullPolicy` to `IfNotPresent` when a digest is set (otherwise keeps `Always`). The chart also adds `images.resourceMonitor.digest` to `values.yaml` and `values.schema.json`, and bumps the chart `version`/`appVersion` to `1.0.7`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca291d3ead72374ba90127e1684368deae0d1886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->