### PR TITLE
fix(client): reject empty clusterCidrs on training NetworkPolicy (v1.0.8)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.0.7
-appVersion: "1.0.7"
+version: 1.0.8
+appVersion: "1.0.8"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/network-policy-training.yaml
+++ b/client/templates/network-policy-training.yaml
@@ -19,6 +19,9 @@
   See values.yaml networkPolicy.training.enabled for platform notes.
 */}}
 {{- if .Values.networkPolicy.training.enabled }}
+{{- if not .Values.networkPolicy.training.clusterCidrs }}
+{{- fail "networkPolicy.training.enabled is true but networkPolicy.training.clusterCidrs is empty. An empty list renders `except: null`, which Kubernetes treats as no exceptions — training pods would get unrestricted port-443 egress to MySQL, the K8s API, jobs-manager, and other in-cluster destinations. Set the list to your cluster's pod+service CIDRs, or disable the policy." }}
+{{- end }}
 {{- $dnsSelector := .Values.networkPolicy.training.dnsSelector }}
 {{- if not $dnsSelector }}{{ $dnsSelector = dict "k8s-app" "kube-dns" }}{{- end }}
 apiVersion: networking.k8s.io/v1

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -42,8 +42,16 @@ spec:
         - operator: "Exists"
       containers:
         - name: tracebloc-resource-monitor
-          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.resourceMonitor.digest "registry" "docker.io") | quote }}
-          imagePullPolicy: {{ if .Values.images.resourceMonitor.digest }}IfNotPresent{{ else }}Always{{ end }}
+          {{- /*
+            images.resourceMonitor was added in 1.0.7; older releases that
+            upgrade via `helm upgrade --reuse-values` won't have the block in
+            their stored values, so read it defensively (nested `default dict`
+            tolerates a missing `images` map AND a missing `resourceMonitor`
+            entry). `dig` is not usable here — it rejects chartutil.Values.
+          */}}
+          {{- $rmDigest := (default (dict) (default (dict) .Values.images).resourceMonitor).digest | default "" }}
+          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" .Values.env.CLIENT_ENV "digest" $rmDigest "registry" "docker.io") | quote }}
+          imagePullPolicy: {{ if $rmDigest }}IfNotPresent{{ else }}Always{{ end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/client/tests/network_policy_test.yaml
+++ b/client/tests/network_policy_test.yaml
@@ -14,6 +14,20 @@ tests:
       - hasDocuments:
           count: 0
 
+  # The minItems:1 guard on clusterCidrs must be scoped via `if: enabled=true`
+  # in values.schema.json. Without the scope, an operator running on a
+  # non-enforcing CNI (sets enabled: false) and omitting clusterCidrs gets a
+  # schema error even though the policy is off.
+  - it: should not render and should not fail schema when disabled with empty clusterCidrs
+    set:
+      networkPolicy:
+        training:
+          enabled: false
+          clusterCidrs: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: should fail when enabled with an empty clusterCidrs list
     # The JSON schema's minItems:1 constraint short-circuits the template-side
     # fail guard; both gates are kept as defense-in-depth (the template guard

--- a/client/tests/network_policy_test.yaml
+++ b/client/tests/network_policy_test.yaml
@@ -14,6 +14,19 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should fail when enabled with an empty clusterCidrs list
+    # The JSON schema's minItems:1 constraint short-circuits the template-side
+    # fail guard; both gates are kept as defense-in-depth (the template guard
+    # catches `helm template --validate=false` and other schema-bypass paths).
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          clusterCidrs: []
+    asserts:
+      - failedTemplate:
+          errorPattern: "networkPolicy\\.training\\.clusterCidrs: Array must have at least 1 items"
+
   - it: should render a NetworkPolicy when enabled
     set:
       networkPolicy:

--- a/client/tests/resource_monitor_test.yaml
+++ b/client/tests/resource_monitor_test.yaml
@@ -1,0 +1,42 @@
+suite: Resource-monitor DaemonSet
+templates:
+  - templates/resource-monitor-daemonset.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: should render with tag fallback when no digest is set
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/tracebloc/resource-monitor:prod"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: should pin by digest when images.resourceMonitor.digest is set
+    set:
+      images:
+        resourceMonitor:
+          digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/tracebloc/resource-monitor@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  # Regression guard: `helm upgrade --reuse-values` from <1.0.7 carries forward
+  # stored values that never included images.resourceMonitor. The template must
+  # tolerate the whole images map being missing without nil-pointer.
+  - it: should render when images block is entirely absent
+    set:
+      images: null
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/tracebloc/resource-monitor:prod"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -232,11 +232,21 @@
             "clusterCidrs": {
               "type": "array",
               "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs. Must be non-empty when networkPolicy.training.enabled is true — an empty list renders `except: null` and Kubernetes treats that as no exceptions, silently allowing unrestricted in-cluster egress.",
-              "minItems": 1,
               "items": {
                 "type": "string",
                 "pattern": "^[0-9.]+/[0-9]+$"
               }
+            }
+          },
+          "if": {
+            "properties": {
+              "enabled": { "const": true }
+            },
+            "required": ["enabled"]
+          },
+          "then": {
+            "properties": {
+              "clusterCidrs": { "minItems": 1 }
             }
           }
         }

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -231,7 +231,8 @@
             },
             "clusterCidrs": {
               "type": "array",
-              "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs.",
+              "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs. Must be non-empty when networkPolicy.training.enabled is true — an empty list renders `except: null` and Kubernetes treats that as no exceptions, silently allowing unrestricted in-cluster egress.",
+              "minItems": 1,
               "items": {
                 "type": "string",
                 "pattern": "^[0-9.]+/[0-9]+$"


### PR DESCRIPTION
## Summary

Bug bot flagged a silent-security-failure in the training NetworkPolicy:

When `networkPolicy.training.enabled: true` and `clusterCidrs: []`, the template's `range` loop produces no items, so `except:` renders as `null`. Kubernetes treats a null `except` as "no exceptions" to `cidr: 0.0.0.0/0` — silently granting training pods unrestricted port-443 egress to MySQL, the K8s API, jobs-manager, and every other in-cluster destination the policy is meant to block.

This is a **medium-severity hardening gap**, not an active exploit: the shipped default populates `clusterCidrs` with RFC1918 ranges, so out-of-the-box installs are fine. The risk is an operator who overrides the list (e.g. platform-specific values file) and leaves it empty — they'd get a rendered NetworkPolicy that looks protective but enforces nothing.

## Changes

- `client/values.schema.json` — add `minItems: 1` to `networkPolicy.training.clusterCidrs`. Fires at `helm install`/`upgrade` validation with a clear error.
- `client/templates/network-policy-training.yaml` — add a `{{ fail }}` guard as defense-in-depth for schema-bypass paths (`helm template --validate=false`, tooling that disables schema checks).
- `client/tests/network_policy_test.yaml` — unit test asserting the failure when `enabled=true` + empty list.
- `client/Chart.yaml` — 1.0.7 → 1.0.8.

## Test plan

- [x] `helm unittest ./client -f 'tests/network_policy_test.yaml'` — 9/9 pass (new case: "should fail when enabled with an empty clusterCidrs list")
- [x] `helm template` with defaults → renders normally (1 NetworkPolicy doc)
- [x] `helm template` with `clusterCidrs: []` and `enabled: true` → fails with schema error `networkPolicy.training.clusterCidrs: Array must have at least 1 items`
- [x] `helm template` with `enabled: false` → no policy rendered (no failure either — guard only fires when the policy is actually being created)

Credit: bug bot finding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens a security control by making `networkPolicy.training.clusterCidrs` mandatory when the policy is enabled; misconfiguration now fails installs/upgrades instead of silently allowing in-cluster egress. Also adjusts Helm templating for `resource-monitor` images to avoid nil-value upgrade issues, which could affect upgrade paths.
> 
> **Overview**
> Bumps the `client` Helm chart to **v1.0.8**.
> 
> Prevents a silent hardening gap in the training egress `NetworkPolicy` by **rejecting empty `networkPolicy.training.clusterCidrs` when `enabled: true`** (JSON schema conditional `minItems` + a template-side `fail` guard for schema-bypass rendering paths), and adds unittest coverage for both the enabled/disabled cases.
> 
> Hardens `resource-monitor` DaemonSet rendering to **tolerate missing `images.resourceMonitor` values during `helm upgrade --reuse-values`** by safely defaulting the digest lookup, with new tests verifying tag fallback, digest pinning, and the nil-images regression case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d6ba49d065237222a796b5ce41a1848783e4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->