### PR TITLE
fix(ci): pass CI values file to release lint so --strict passes

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -36,7 +36,13 @@ jobs:
           version: v3.15.4
 
       - name: Lint chart
-        run: helm lint --strict ./client
+        # Use a CI values file so `--strict` sees non-empty clientId /
+        # clientPassword (the defaults in values.yaml are deliberately empty
+        # to force operators to supply real credentials, and the schema
+        # enforces minLength:1). Exhaustive multi-platform linting happens in
+        # helm-ci.yaml on every PR — here we just need the chart to lint
+        # cleanly for packaging.
+        run: helm lint --strict ./client -f client/ci/eks-values.yaml
 
       - name: Package tracebloc chart
         id: package


### PR DESCRIPTION
## Summary

The release workflow's `helm lint --strict ./client` step was running without a values file. The schema enforces `minLength: 1` on `clientId`/`clientPassword`; the defaults in `values.yaml` are deliberately empty (forcing operators to supply real credentials). Result: strict lint has been failing on every release run, and no tagged release since the schema constraint was added has successfully published. This is why chart versions 1.0.4, 1.0.5, 1.0.6, and 1.0.7 never reached `gh-pages` / the public Helm repo.

## Fix

Mirror [helm-ci.yaml](.github/workflows/helm-ci.yaml)'s approach — pass `-f client/ci/eks-values.yaml` (which ships `ci-test-id`/`ci-test-password`) so strict lint sees valid credentials. Exhaustive multi-platform linting continues to run in `helm-ci.yaml` on every PR; release lint just needs the chart to pass for packaging.

## Test plan

- [x] `helm lint --strict ./client -f client/ci/eks-values.yaml` → 1 chart linted, 0 failed
- [ ] Once merged, push `v1.0.8` tag and confirm the release workflow publishes `client-1.0.8.tgz` to `gh-pages`

## Follow-up

After merge + tag, a manual mirror step is still required: copy `client-1.0.8.tgz` + regenerated `index.yaml` from this repo's `gh-pages` to `tracebloc/client`'s `gh-pages`, since `scripts/install-k8s.sh` reads from the latter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the release GitHub Actions workflow lint command, with no runtime/chart template changes; main risk is an incorrect values path could still fail releases.
> 
> **Overview**
> Fixes the Helm chart release workflow failing `helm lint --strict` by running lint with a CI values file (`client/ci/eks-values.yaml`) so required `clientId`/`clientPassword` schema constraints are satisfied during packaging.
> 
> Adds inline documentation clarifying that exhaustive linting remains in `helm-ci.yaml`, while the release workflow just needs a clean strict lint before publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d0804d563573fc457fb8f6714f9d5aa36b7e9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->