### PR TITLE
Merge pull request #62 from tracebloc/fix/release-workflow-lint

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -36,7 +36,13 @@ jobs:
           version: v3.15.4
 
       - name: Lint chart
-        run: helm lint --strict ./client
+        # Use a CI values file so `--strict` sees non-empty clientId /
+        # clientPassword (the defaults in values.yaml are deliberately empty
+        # to force operators to supply real credentials, and the schema
+        # enforces minLength:1). Exhaustive multi-platform linting happens in
+        # helm-ci.yaml on every PR — here we just need the chart to lint
+        # cleanly for packaging.
+        run: helm lint --strict ./client -f client/ci/eks-values.yaml
 
       - name: Package tracebloc chart
         id: package


### PR DESCRIPTION
fix(ci): pass CI values file to release lint so --strict passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; it only affects the Helm chart release pipeline by adjusting lint inputs to avoid false failures and does not alter chart packaging or runtime behavior.
> 
> **Overview**
> Updates the `Release Helm Chart` GitHub Actions workflow to run `helm lint --strict` with a CI values file (`client/ci/eks-values.yaml`), avoiding strict-schema failures caused by intentionally-empty default credentials.
> 
> Adds clarifying comments that PR-time linting remains in `helm-ci.yaml`, while the release workflow just needs a clean lint prior to packaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1d085f19a0f548c468f058146f69369e6431a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->