### PR TITLE
fix(scripts): pre-create per-release hostPath dirs as host user

### DIFF
--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -31,6 +31,20 @@ _ensure_tracebloc_dirs() {
   chmod -R 777 "$HOST_DATA_DIR/data" "$HOST_DATA_DIR/logs" "$HOST_DATA_DIR/mysql" 2>/dev/null || true
 }
 
+# Pre-create the per-release host dirs the chart's hostPath PVs bind to.
+# The PVs use /tracebloc/<release>/{data,logs,mysql}, which maps back to
+# $HOST_DATA_DIR/<release>/{data,logs,mysql} on the host via the k3d -v mount.
+# Without pre-creating these as the host user, kubelet's DirectoryOrCreate
+# makes them root:root 0755 and the host user can't drop training data into
+# /data/shared.
+_ensure_release_dirs() {
+  local release="$1"
+  [[ -z "$release" ]] && return 0
+  local base="$HOST_DATA_DIR/$release"
+  mkdir -p "$base/data" "$base/logs" "$base/mysql"
+  chmod -R 777 "$base/data" "$base/logs" "$base/mysql" 2>/dev/null || true
+}
+
 create_cluster() {
   log "Creating k3d cluster: '$CLUSTER_NAME'"
 

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -227,6 +227,10 @@ EOF
   echo ""
   log "Installing $TB_NAMESPACE from $chart_ref in namespace '$TB_NAMESPACE'..."
 
+  # Pre-create per-release hostPath dirs so they're owned by the host user, not
+  # root:root from kubelet's DirectoryOrCreate. See _ensure_release_dirs.
+  _ensure_release_dirs "$TB_NAMESPACE"
+
   local helm_log
   helm_log="$(mktemp)"
   if ! helm upgrade --install "$TB_NAMESPACE" "$chart_ref" \


### PR DESCRIPTION
## Summary

- Adds `_ensure_release_dirs <release>` in `scripts/lib/cluster.sh` to pre-create `$HOST_DATA_DIR/<release>/{data,logs,mysql}` with mode 0777 owned by the host user.
- Calls it from `scripts/lib/install-client-helm.sh` just before `helm upgrade --install`, where `TB_NAMESPACE` (= release name) is known in both the prompt and `TRACEBLOC_VALUES_FILE` dev-mode flows.

## Why

The chart's hostPath PVs bind to `/tracebloc/{{ .Release.Name }}/{data,logs,mysql}` (see [`client/templates/shared-images-pvc.yaml`](../blob/develop/client/templates/shared-images-pvc.yaml#L20), [`logs-pvc.yaml`](../blob/develop/client/templates/logs-pvc.yaml#L20), [`mysql-storage-pvc.yaml`](../blob/develop/client/templates/mysql-storage-pvc.yaml#L20)), which maps back to `$HOST_DATA_DIR/<release>/{data,logs,mysql}` on the host through the k3d `-v "${HOST_DATA_DIR}:/tracebloc@all"` mount.

The existing `_ensure_tracebloc_dirs` only chmods `$HOST_DATA_DIR/{data,logs,mysql}` — a path the chart never touches. When the pod schedules, kubelet's `DirectoryOrCreate` creates the per-release subdirs as `root:root` mode `0755`, leaving the host user (e.g. `ubuntu` on a typical EC2 box) unable to write there.

**Repro (before this fix), with release `ml-mrdan`:**
```
ubuntu@host:~$ ls -la ~/.tracebloc/ml-mrdan/data/
drwxr-xr-x 2 root root 4096 ... .
ubuntu@host:~$ echo test > ~/.tracebloc/ml-mrdan/data/test.txt
-bash: /home/ubuntu/.tracebloc/ml-mrdan/data/test.txt: Permission denied
```

After this fix, fresh installs pre-create the per-release dirs as the host user with `0777`, so files dropped there appear at `/data/shared` inside the `jobs-manager` pod's `api` container as expected.

## Notes

- **Existing installs** where the per-release dirs already exist as `root:root 0755` will need a one-time manual `sudo chmod -R 777 ~/.tracebloc/<release>/{data,logs,mysql}`. The `chmod` in the new function is best-effort (`2>/dev/null || true`) so re-running the installer won't error out, but it can't relax permissions on dirs the user doesn't own.
- The existing `_ensure_tracebloc_dirs` is left untouched. Its chmod on `$HOST_DATA_DIR/{data,logs,mysql}` is a no-op for the chart but harmless and removing it is out of scope for this fix.

## Test plan

- [x] `bash -n` syntax check on both modified files.
- [x] Sourced `cluster.sh` and ran `_ensure_release_dirs ml-mrdan` against a temp `HOST_DATA_DIR` — confirmed dirs created with mode `0777` owned by current user.
- [x] Empty release name short-circuits with exit 0 (defensive).
- [x] `helm template ml-mrdan ./client --set hostPath.enabled=true ...` confirms PV `path:` values are `/tracebloc/ml-mrdan/{data,logs,mysql}` — matches what the function pre-creates.
- [ ] End-to-end: fresh `scripts/install.sh` on a clean EC2 box, verify `~/.tracebloc/<release>/data/test.txt` written by host user appears in `/data/shared/` of the `jobs-manager` pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script change limited to installer/cluster setup; main impact is filesystem permissions (creates/chmods release-specific dirs).
> 
> **Overview**
> Fixes fresh installs where hostPath-backed volumes end up owned by `root` by pre-creating release-scoped directories on the host.
> 
> Adds `_ensure_release_dirs <release>` to create/chmod `$HOST_DATA_DIR/<release>/{data,logs,mysql}`, and calls it in `install-client-helm.sh` immediately before `helm upgrade --install` using `TB_NAMESPACE` as the release name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b123cff19d621e7f9d19ca12de3652b148bc52ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->