### PR TITLE
Enhance CI workflows and fix MySQL resource management issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+<!-- 1–3 sentences. What does this PR do and why? -->
+
+## Related
+<!-- Closes #123 / Ref tracebloc/other-repo#456 -->
+
+## Type of change
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Tech-debt / refactor
+- [ ] Docs
+- [ ] Security / hardening
+- [ ] Breaking change
+
+## Test plan
+<!-- What did you test? Commands run? Manual steps? -->
+
+## Screenshots / recordings
+<!-- For UI changes. Remove if N/A. -->
+
+## Deployment notes
+<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->
+
+## Checklist
+- [ ] Tests added / updated and passing locally
+- [ ] Docs updated if behavior or config changed
+- [ ] No secrets / credentials in the diff
+- [ ] For security-sensitive paths: appropriate reviewer requested

--- a/.github/workflows/advance-deploy-env.yml
+++ b/.github/workflows/advance-deploy-env.yml
@@ -1,0 +1,14 @@
+name: Advance deploy env
+
+# Calls the reusable workflow in tracebloc/.github.
+# When this branch (develop/staging/master/main) receives a merge,
+# updates each contained PR's Deploy environment field on the engineer kanban.
+
+on:
+  push:
+    branches: [develop, staging, master, main]
+
+jobs:
+  advance:
+    uses: tracebloc/.github/.github/workflows/advance-deploy-env.yml@main
+    secrets: inherit

--- a/.github/workflows/customer-priority-bump.yml
+++ b/.github/workflows/customer-priority-bump.yml
@@ -1,0 +1,10 @@
+name: Customer priority bump
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  bump:
+    uses: tracebloc/.github/.github/workflows/customer-priority-bump.yml@main
+    secrets: inherit

--- a/.github/workflows/set-pr-status.yml
+++ b/.github/workflows/set-pr-status.yml
@@ -1,0 +1,10 @@
+name: Set PR Status
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, converted_to_draft]
+
+jobs:
+  set-status:
+    uses: tracebloc/.github/.github/workflows/set-pr-status.yml@main
+    secrets: inherit

--- a/.github/workflows/stale-backlog.yml
+++ b/.github/workflows/stale-backlog.yml
@@ -1,0 +1,33 @@
+name: Close stale backlog issues
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # Mondays 00:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 42  # 6 weeks of no activity → warning
+          days-before-issue-close: 14  # +2 weeks of silence → close
+          stale-issue-label: 'stale'
+          stale-issue-message: |
+            👋 This issue has had no activity for 6 weeks.
+
+            If it's still relevant, please leave a comment with current context (or assign someone). Otherwise it will auto-close in 2 weeks.
+
+            To exempt permanently, add the `keep-open` label.
+          close-issue-message: |
+            Closing due to 8+ weeks of inactivity. Please reopen with current context if relevant.
+          exempt-issue-labels: 'keep-open,blocked'
+          # PRs: don't auto-stale — branch protection + active reviews govern those
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          operations-per-run: 50

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.0.8
-appVersion: "1.0.8"
+version: 1.1.0
+appVersion: "1.1.0"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -34,13 +34,18 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+        # 256Mi was too tight under load: on a busy cluster the Service Bus
+        # client + pod-event watcher push RSS over 256Mi within minutes, the
+        # pod becomes the OOM-killer's preferred target on the node, and
+        # mysqld dies as collateral. 512Mi/1Gi covers steady state with
+        # headroom; revisit if heap profiling shows the working set growing.
         resources:
           requests:
-            cpu: 100m
-            memory: 256Mi
+            cpu: {{ .Values.resources.jobsManager.requests.cpu | default "100m" | quote }}
+            memory: {{ .Values.resources.jobsManager.requests.memory | default "512Mi" | quote }}
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: {{ .Values.resources.jobsManager.limits.cpu | default "1000m" | quote }}
+            memory: {{ .Values.resources.jobsManager.limits.memory | default "1Gi" | quote }}
         volumeMounts:
           - name: shared-volume
             mountPath: "/data/shared"
@@ -92,11 +97,11 @@ spec:
             drop: ["ALL"]
         resources:
           requests:
-            cpu: 50m
-            memory: 128Mi
+            cpu: {{ .Values.resources.podsMonitor.requests.cpu | default "50m" | quote }}
+            memory: {{ .Values.resources.podsMonitor.requests.memory | default "256Mi" | quote }}
           limits:
-            cpu: 200m
-            memory: 256Mi
+            cpu: {{ .Values.resources.podsMonitor.limits.cpu | default "500m" | quote }}
+            memory: {{ .Values.resources.podsMonitor.limits.memory | default "512Mi" | quote }}
         volumeMounts:
         - name: logs-volume
           mountPath: "/data/logs"

--- a/client/templates/jobs-manager-pdb.yaml
+++ b/client/templates/jobs-manager-pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.podDisruptionBudget.jobsManager.create }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -6,7 +7,12 @@ metadata:
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
 spec:
-  maxUnavailable: 1
+  # Single-replica deployment: maxUnavailable: 1 is a no-op (the only pod
+  # can always go away). Use minAvailable: 1 to actually block voluntary
+  # disruptions while replicas == 1. Disable when running multi-replica
+  # jobs-manager managed externally.
+  minAvailable: 1
   selector:
     matchLabels:
       app: manager
+{{- end }}

--- a/client/templates/mysql-deployment.yaml
+++ b/client/templates/mysql-deployment.yaml
@@ -19,6 +19,16 @@ spec:
         app: mysql-client
     spec:
       terminationGracePeriodSeconds: 60
+      {{- /*
+        Reference the PriorityClass whenever a name is set, regardless of
+        priorityClass.create. Operators on GitOps / shared-platform setups
+        manage the PriorityClass out-of-band (create: false) but still want
+        the pod to reference it — gating on `create` would silently strip
+        the OOM protection this chart's mysql tuning relies on.
+      */}}
+      {{- with .Values.priorityClass.name }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       securityContext:
         fsGroup: 999
         fsGroupChangePolicy: "OnRootMismatch"
@@ -66,32 +76,55 @@ spec:
             - ALL
           seccompProfile:
             type: RuntimeDefault
+        # requests.memory == limits.memory pins the cgroup memory budget so
+        # mysqld is never the largest victim during node-level OOM. CPU limit
+        # is intentionally omitted: throttled CPU causes InnoDB lock-wait
+        # timeouts (mysqld can't service heartbeats) and is a far more common
+        # cause of mysql crashes than a noisy neighbour. PriorityClass +
+        # PodDisruptionBudget cover the eviction angle instead.
         resources:
           requests:
-            memory: 256Mi
-            cpu: 100m
+            memory: {{ .Values.resources.mysql.requests.memory | default "1Gi" | quote }}
+            cpu: {{ .Values.resources.mysql.requests.cpu | default "250m" | quote }}
           limits:
-            memory: 1Gi
-            cpu: 1000m
+            memory: {{ .Values.resources.mysql.limits.memory | default "1Gi" | quote }}
+            {{- /*
+              CPU limit is intentionally unset by default (see comment block
+              above). Schema permits it, so honour an explicit override here
+              instead of silently dropping it. Operators flipping this on
+              should know what they're doing.
+            */}}
+            {{- with .Values.resources.mysql.limits.cpu }}
+            cpu: {{ . | quote }}
+            {{- end }}
         ports:
         - containerPort: 3306
           name: mysql-client
+        # timeoutSeconds defaults to 1; under CPU contention `mysqladmin ping`
+        # routinely needs >1s to even spawn, which kubelet reports as a probe
+        # failure and kills the container. 5s is generous enough to survive
+        # transient CPU pressure but still catch a real hang within ~25s.
         startupProbe:
           exec:
             command: ["mysqladmin", "ping", "-h", "localhost"]
           initialDelaySeconds: 10
           periodSeconds: 5
+          timeoutSeconds: 5
           failureThreshold: 24
         livenessProbe:
           exec:
             command: ["mysqladmin", "ping", "-h", "localhost"]
           initialDelaySeconds: 0
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
         readinessProbe:
           exec:
             command: ["mysqladmin", "ping", "-h", "localhost"]
           initialDelaySeconds: 0
           periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
         volumeMounts:
         - name: mysql-persistent-storage
           mountPath: /var/lib/mysql/

--- a/client/templates/mysql-pdb.yaml
+++ b/client/templates/mysql-pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.podDisruptionBudget.mysql.create }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -5,8 +6,16 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
+    app: mysql-client
 spec:
+  # Single-replica deployment; minAvailable: 1 blocks *voluntary* disruptions
+  # (node drains, surge upgrades, cluster-autoscaler scale-downs) while the
+  # only mysql pod is, well, the only mysql pod. Involuntary kills (kernel
+  # OOM, node failure) still happen — PriorityClass + memory parity cover
+  # those. Set podDisruptionBudget.mysql.create=false on multi-replica
+  # setups managed externally.
   minAvailable: 1
   selector:
     matchLabels:
       app: mysql-client
+{{- end }}

--- a/client/templates/priority-class.yaml
+++ b/client/templates/priority-class.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.priorityClass.create }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .Values.priorityClass.name | quote }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+  annotations:
+    # PriorityClass is cluster-scoped, so we never let helm uninstall yank it —
+    # other releases may share it. Re-installs reuse the existing object.
+    helm.sh/resource-policy: keep
+value: {{ .Values.priorityClass.value | int }}
+globalDefault: false
+description: >-
+  Tracebloc data-plane workloads (mysql-client). Sits above default user
+  workloads so the scheduler preempts noisy training jobs to keep mysql
+  running, but stays below system-cluster-critical (2,000,000,000) so it
+  cannot starve cluster-essential pods.
+{{- end }}

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -57,6 +57,19 @@ tests:
           path: spec.template.spec.containers[0].resources.requests
       - isNotEmpty:
           path: spec.template.spec.containers[0].resources.limits
+      # v1.1.0 floor: 512Mi/1Gi for api, after the prod OOM investigation.
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1Gi
+      - equal:
+          path: spec.template.spec.containers[1].resources.requests.memory
+          value: 256Mi
+      - equal:
+          path: spec.template.spec.containers[1].resources.limits.memory
+          value: 512Mi
 
   - it: should reference secret via helper
     asserts:

--- a/client/tests/mysql_test.yaml
+++ b/client/tests/mysql_test.yaml
@@ -35,15 +35,78 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe.exec.command[0]
           value: mysqladmin
 
-  - it: should have resource limits
+  - it: should have memory parity (requests == limits) and no cpu limit on mysql
     template: templates/mysql-deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
-          value: 256Mi
+          value: 1Gi
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: 1Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+      # CPU limit deliberately unset — InnoDB lock-wait timeouts under throttling.
+      - notExists:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+
+  - it: "liveness probe should tolerate CPU pressure (timeoutSeconds 5)"
+    template: templates/mysql-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 5
+
+  - it: should reference the data-plane PriorityClass when enabled
+    template: templates/mysql-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: tracebloc-data-plane
+
+  - it: should keep priorityClassName when create=false (externally managed PriorityClass)
+    template: templates/mysql-deployment.yaml
+    set:
+      priorityClass:
+        create: false
+        name: tracebloc-data-plane
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: tracebloc-data-plane
+
+  - it: should drop priorityClassName only when name is empty
+    template: templates/mysql-deployment.yaml
+    set:
+      priorityClass:
+        # Schema rejects create=true with empty name (no point templating a
+        # nameless PriorityClass), so disable creation as well to model the
+        # "no PriorityClass at all" path.
+        create: false
+        name: ""
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: should render an explicit mysql cpu limit when operator opts in
+    template: templates/mysql-deployment.yaml
+    set:
+      resources:
+        mysql:
+          limits:
+            cpu: "1500m"
+            memory: "2Gi"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 1500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 2Gi
 
   - it: should create ConfigMap with MySQL config
     template: templates/mysql-configmap.yaml

--- a/client/tests/priority_class_pdb_test.yaml
+++ b/client/tests/priority_class_pdb_test.yaml
@@ -1,0 +1,98 @@
+suite: PriorityClass and PodDisruptionBudget
+templates:
+  - templates/priority-class.yaml
+  - templates/mysql-pdb.yaml
+  - templates/jobs-manager-pdb.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: should create the data-plane PriorityClass by default
+    template: templates/priority-class.yaml
+    asserts:
+      - isKind:
+          of: PriorityClass
+      - equal:
+          path: metadata.name
+          value: tracebloc-data-plane
+      - equal:
+          path: value
+          value: 1000000
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+      - equal:
+          path: globalDefault
+          value: false
+
+  - it: should respect a custom PriorityClass name and value
+    template: templates/priority-class.yaml
+    set:
+      priorityClass:
+        create: true
+        name: tb-prio
+        value: 500000
+    asserts:
+      - equal:
+          path: metadata.name
+          value: tb-prio
+      - equal:
+          path: value
+          value: 500000
+
+  - it: should not render PriorityClass when create is false
+    template: templates/priority-class.yaml
+    set:
+      priorityClass:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: schema should reject create=true with an empty name
+    template: templates/priority-class.yaml
+    set:
+      priorityClass:
+        create: true
+        name: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "name: String length must be greater than or equal to 1"
+
+  - it: should create the mysql PDB by default
+    template: templates/mysql-pdb.yaml
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: mysql-client
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: mysql-client
+
+  - it: should not render mysql PDB when disabled
+    template: templates/mysql-pdb.yaml
+    set:
+      podDisruptionBudget:
+        mysql:
+          create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: jobs-manager PDB should use minAvailable (not maxUnavailable) to actually protect a 1-replica deployment
+    templates:
+      - templates/jobs-manager-pdb.yaml
+    template: templates/jobs-manager-pdb.yaml
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - notExists:
+          path: spec.maxUnavailable

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -313,6 +313,109 @@
         }
       }
     },
+    "resources": {
+      "type": "object",
+      "description": "Container resource requests and limits for mysql, jobs-manager, and pods-monitor. See values.yaml for the rationale behind the defaults.",
+      "properties": {
+        "mysql": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            },
+            "limits": {
+              "type": "object",
+              "description": "CPU limit deliberately omitted in defaults — throttling causes InnoDB lock-wait timeouts.",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            }
+          }
+        },
+        "jobsManager": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            }
+          }
+        },
+        "podsMonitor": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "priorityClass": {
+      "type": "object",
+      "description": "Cluster-scoped PriorityClass for tracebloc data-plane workloads (mysql). An empty `name` disables the priorityClassName reference on the mysql pod entirely (mysql falls back to default priority 0 — only set this if you explicitly want no OOM protection from the scheduler).",
+      "properties": {
+        "create": { "type": "boolean", "default": true },
+        "name":   { "type": "string", "default": "tracebloc-data-plane" },
+        "value":  { "type": "integer", "minimum": 0, "maximum": 1000000000, "default": 1000000 }
+      },
+      "allOf": [
+        {
+          "$comment": "If we are templating the PriorityClass resource, name must not be empty. `required: [create]` is needed because draft-07 `properties` only validates keys that are present — without it, omitting `create` passes the `if` vacuously and unconditionally enforces `then`. Same pattern as dockerRegistry below.",
+          "if": {
+            "properties": { "create": { "const": true } },
+            "required": ["create"]
+          },
+          "then": {
+            "properties": { "name": { "minLength": 1 } }
+          }
+        }
+      ]
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "description": "PodDisruptionBudgets for chart-managed Deployments.",
+      "properties": {
+        "mysql": {
+          "type": "object",
+          "properties": {
+            "create": { "type": "boolean", "default": true }
+          }
+        },
+        "jobsManager": {
+          "type": "object",
+          "properties": {
+            "create": { "type": "boolean", "default": true }
+          }
+        }
+      }
+    },
     "clientId": {
       "type": "string",
       "minLength": 1,

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -194,6 +194,72 @@ images:
     tag: "1.35"
     digest: ""
 
+# -- Container resource requests and limits.
+# Tuned in v1.1.0 after the prod investigation showed mysql being killed
+# every ~12 minutes when jobs-manager (under-resourced, BestEffort QoS in
+# older releases) ate node memory and triggered the kernel OOM killer.
+#
+# mysql: requests.memory == limits.memory pins the cgroup memory budget so
+# mysqld is never the largest victim during node-level OOM. CPU limit is
+# intentionally OMITTED (no `limits.cpu` field below) — CPU throttling
+# causes InnoDB lock-wait timeouts and is a far more common cause of
+# mysql crashes than a noisy CPU neighbour. PriorityClass + PDB cover
+# eviction.
+#
+# jobs-manager: 256Mi was too tight under load; bumped to 512Mi/1Gi so
+# the Service Bus client + pod watcher have headroom before OOM.
+resources:
+  mysql:
+    requests:
+      cpu: "250m"
+      memory: "1Gi"
+    limits:
+      memory: "1Gi"
+      # No cpu limit — see comment above.
+  jobsManager:
+    requests:
+      cpu: "100m"
+      memory: "512Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+  podsMonitor:
+    requests:
+      cpu: "50m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+
+# -- PriorityClass for the data-plane (mysql).
+# Cluster-scoped resource. Created with helm.sh/resource-policy: keep so a
+# release uninstall does not yank it from sibling releases that share it.
+# Value 1,000,000 sits well above default (0) so the scheduler will preempt
+# noisy training jobs to keep mysql scheduled, but well below
+# system-cluster-critical (2,000,000,000).
+#
+# create: false  — chart does not template the PriorityClass; you (or your
+#                  GitOps tool / shared platform) manage it out-of-band.
+#                  The mysql pod still references `name`, so make sure the
+#                  PriorityClass exists at install time.
+# name: ""       — disable the priorityClassName reference entirely. mysql
+#                  falls back to the cluster default priority (0) and loses
+#                  the OOM-protection this chart's mysql tuning relies on.
+priorityClass:
+  create: true
+  name: tracebloc-data-plane
+  value: 1000000
+
+# -- PodDisruptionBudgets.
+# mysql is single-replica; minAvailable: 1 blocks voluntary disruptions
+# (drains, surge upgrades, autoscaler scale-down) while only one mysql
+# pod exists. Disable if you run a multi-replica mysql managed externally.
+podDisruptionBudget:
+  mysql:
+    create: true
+  jobsManager:
+    create: true
+
 # -- Secrets
 # These MUST be set via --set, a values file, or an external secret manager.
 # The defaults are intentionally empty; deployment fails fast if they are not

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -31,6 +31,20 @@ _ensure_tracebloc_dirs() {
   chmod -R 777 "$HOST_DATA_DIR/data" "$HOST_DATA_DIR/logs" "$HOST_DATA_DIR/mysql" 2>/dev/null || true
 }
 
+# Pre-create the per-release host dirs the chart's hostPath PVs bind to.
+# The PVs use /tracebloc/<release>/{data,logs,mysql}, which maps back to
+# $HOST_DATA_DIR/<release>/{data,logs,mysql} on the host via the k3d -v mount.
+# Without pre-creating these as the host user, kubelet's DirectoryOrCreate
+# makes them root:root 0755 and the host user can't drop training data into
+# /data/shared.
+_ensure_release_dirs() {
+  local release="$1"
+  [[ -z "$release" ]] && return 0
+  local base="$HOST_DATA_DIR/$release"
+  mkdir -p "$base/data" "$base/logs" "$base/mysql"
+  chmod -R 777 "$base/data" "$base/logs" "$base/mysql" 2>/dev/null || true
+}
+
 create_cluster() {
   log "Creating k3d cluster: '$CLUSTER_NAME'"
 

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -227,6 +227,10 @@ EOF
   echo ""
   log "Installing $TB_NAMESPACE from $chart_ref in namespace '$TB_NAMESPACE'..."
 
+  # Pre-create per-release hostPath dirs so they're owned by the host user, not
+  # root:root from kubelet's DirectoryOrCreate. See _ensure_release_dirs.
+  _ensure_release_dirs "$TB_NAMESPACE"
+
   local helm_log
   helm_log="$(mktemp)"
   if ! helm upgrade --install "$TB_NAMESPACE" "$chart_ref" \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Kubernetes scheduling/eviction/resource settings for `mysql-client` and `jobs-manager`, which can affect availability and cluster behavior if defaults don’t fit all environments.
> 
> **Overview**
> Adds a PR template and several GitHub workflows, including reusable workflow calls for PR status/deploy-env automation and a scheduled `actions/stale` job to close inactive issues.
> 
> Bumps the `client` Helm chart to `1.1.0` and introduces configurable container `resources` (via `values.yaml` + schema) with higher defaults for `jobs-manager`/`pods-monitor`, plus MySQL “memory parity” (requests==limits) and more tolerant probe timeouts; MySQL CPU limits are now optional/opt-in.
> 
> Adds chart-managed disruption protection and scheduling knobs: new `PriorityClass` template (kept on uninstall), optional PDBs for `mysql` and `jobs-manager` using `minAvailable: 1`, and ensures the MySQL pod references `priorityClassName` whenever a name is set (even if the class is managed externally). Installer scripts now pre-create per-release hostPath directories to avoid root-owned directories on first run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90e01553961b4039d5a121d6b6ff05db1c1000f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->