### PR TITLE
fix(client): release-scope resource-monitor names so multiple releases can coexist (v1.2.0)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.1.0
-appVersion: "1.1.0"
+version: 1.2.0
+appVersion: "1.2.0"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -25,6 +25,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ .Release.Name }}-jobs-manager
 {{- end }}
 
+{{/*
+  Release-scoped name for the resource-monitor DaemonSet, ServiceAccount,
+  ClusterRoleBinding subject, and selector/pod labels. Multiple releases
+  on the same cluster share the tracebloc-node-agents namespace; before
+  this naming, two releases collided on the literal `tracebloc-resource-monitor`
+  name and Helm refused the second install with "exists, not owned".
+  See the v1.2.0 release notes / hasan-prod migration case study.
+*/}}
+{{- define "tracebloc.resourceMonitorName" -}}
+{{ .Release.Name }}-resource-monitor
+{{- end }}
+
 {{- define "tracebloc.rbacName" -}}
 {{ .Release.Name }}-jobs-manager-rbac
 {{- end }}

--- a/client/templates/docker-registry-secret.yaml
+++ b/client/templates/docker-registry-secret.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: {{ .Values.nodeAgents.namespace.name }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
-    app: tracebloc-resource-monitor
+    app: {{ include "tracebloc.resourceMonitorName" . }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -16,24 +16,24 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: tracebloc-resource-monitor
+  name: {{ include "tracebloc.resourceMonitorName" . }}
   namespace: {{ .Values.nodeAgents.namespace.name }}
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
-    app: tracebloc-resource-monitor
+    app: {{ include "tracebloc.resourceMonitorName" . }}
 spec:
   selector:
     matchLabels:
-      app: tracebloc-resource-monitor
+      app: {{ include "tracebloc.resourceMonitorName" . }}
   template:
     metadata:
       labels:
-        app: tracebloc-resource-monitor
+        app: {{ include "tracebloc.resourceMonitorName" . }}
     spec:
-      serviceAccountName: tracebloc-resource-monitor
+      serviceAccountName: {{ include "tracebloc.resourceMonitorName" . }}
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/client/templates/resource-monitor-rbac.yaml
+++ b/client/templates/resource-monitor-rbac.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: tracebloc-resource-monitor
+  name: {{ include "tracebloc.resourceMonitorName" . }}
   namespace: {{ .Values.nodeAgents.namespace.name }}
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
-    app: tracebloc-resource-monitor
+    app: {{ include "tracebloc.resourceMonitorName" . }}
 {{- if ne .Values.clusterScope false }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,7 +22,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
-    app: tracebloc-resource-monitor
+    app: {{ include "tracebloc.resourceMonitorName" . }}
 rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "nodes", "nodes/status", "namespaces"]
@@ -40,14 +40,14 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
-    app: tracebloc-resource-monitor
+    app: {{ include "tracebloc.resourceMonitorName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: tracebloc-resource-monitor-{{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
-    name: tracebloc-resource-monitor
+    name: {{ include "tracebloc.resourceMonitorName" . }}
     namespace: {{ .Values.nodeAgents.namespace.name }}
 {{- else }}
 ---
@@ -65,7 +65,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
-    app: tracebloc-resource-monitor
+    app: {{ include "tracebloc.resourceMonitorName" . }}
 rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log"]
@@ -84,14 +84,14 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
-    app: tracebloc-resource-monitor
+    app: {{ include "tracebloc.resourceMonitorName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: tracebloc-resource-monitor-{{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
-    name: tracebloc-resource-monitor
+    name: {{ include "tracebloc.resourceMonitorName" . }}
     namespace: {{ .Values.nodeAgents.namespace.name }}
 {{- end }}
 {{- end }}

--- a/client/templates/secrets.yaml
+++ b/client/templates/secrets.yaml
@@ -25,7 +25,7 @@ metadata:
   namespace: {{ .Values.nodeAgents.namespace.name }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
-    app: tracebloc-resource-monitor
+    app: {{ include "tracebloc.resourceMonitorName" . }}
 type: Opaque
 data:
   CLIENT_ID: {{ $clientId | b64enc | quote }}

--- a/client/tests/resource_monitor_test.yaml
+++ b/client/tests/resource_monitor_test.yaml
@@ -1,11 +1,15 @@
 suite: Resource-monitor DaemonSet
 templates:
   - templates/resource-monitor-daemonset.yaml
+  - templates/resource-monitor-rbac.yaml
 set:
   clientId: "test-id"
   clientPassword: "test"
+release:
+  name: stg
 tests:
   - it: should render with tag fallback when no digest is set
+    template: templates/resource-monitor-daemonset.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
@@ -15,6 +19,7 @@ tests:
           value: Always
 
   - it: should pin by digest when images.resourceMonitor.digest is set
+    template: templates/resource-monitor-daemonset.yaml
     set:
       images:
         resourceMonitor:
@@ -31,6 +36,7 @@ tests:
   # stored values that never included images.resourceMonitor. The template must
   # tolerate the whole images map being missing without nil-pointer.
   - it: should render when images block is entirely absent
+    template: templates/resource-monitor-daemonset.yaml
     set:
       images: null
     asserts:
@@ -40,3 +46,71 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
+
+  # v1.2.0: every shared-namespace resource that used to be literally named
+  # `tracebloc-resource-monitor` is now release-scoped to `<release>-resource-monitor`,
+  # so multiple releases on one cluster can each run their own DaemonSet without
+  # colliding. Selector + pod label also have to be release-scoped or two
+  # DaemonSets in tracebloc-node-agents would each grab the other's pods.
+  - it: DaemonSet name + selector + serviceAccountName are release-scoped
+    template: templates/resource-monitor-daemonset.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: stg-resource-monitor
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: stg-resource-monitor
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: stg-resource-monitor
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: stg-resource-monitor
+
+  - it: ServiceAccount name is release-scoped
+    template: templates/resource-monitor-rbac.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: stg-resource-monitor
+
+  - it: ClusterRoleBinding subject points at the release-scoped SA
+    template: templates/resource-monitor-rbac.yaml
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: subjects[0].name
+          value: stg-resource-monitor
+
+  - it: a different release renders a non-colliding DaemonSet name
+    template: templates/resource-monitor-daemonset.yaml
+    release:
+      name: hasan-prod
+    asserts:
+      - equal:
+          path: metadata.name
+          value: hasan-prod-resource-monitor
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: hasan-prod-resource-monitor
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: hasan-prod-resource-monitor
+
+  - it: a different release renders a non-colliding ServiceAccount name
+    template: templates/resource-monitor-rbac.yaml
+    release:
+      name: hasan-prod
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: hasan-prod-resource-monitor


### PR DESCRIPTION
## Summary

Two `client` releases on the same cluster could not both deploy the resource-monitor DaemonSet — several resources templated into the shared \`tracebloc-node-agents\` namespace used the literal name \`tracebloc-resource-monitor\` rather than a release-scoped name. The second \`helm install\` failed with:

\`\`\`
Error: ServiceAccount "tracebloc-resource-monitor" in namespace "tracebloc-node-agents"
exists and cannot be imported into the current release: invalid ownership metadata;
annotation validation error: key "meta.helm.sh/release-name" must equal "internal-prod":
current value is "stg"; ...
\`\`\`

Surfaced during the 2026-04-27 \`internal-prod\` migration on \`tracebloc-templates-prod\`; the workaround was \`resourceMonitor: false\` on the second release, which means prod customers currently lose their per-\`CLIENT_ID\` metric stream until this lands.

## Changes

- **New helper \`tracebloc.resourceMonitorName\`** → \`<Release.Name>-resource-monitor\`, alongside the existing per-release name helpers (\`secretName\`, \`serviceAccountName\`).
- **DaemonSet** \`metadata.name\`, \`spec.selector.matchLabels.app\`, pod label \`app=\`, and \`spec.template.spec.serviceAccountName\` all now go through the helper. Selector + pod label move together: DaemonSet selectors are namespace-scoped, so two DaemonSets in \`tracebloc-node-agents\` both selecting \`app: tracebloc-resource-monitor\` would each grab the other's pods — worse than the surface bug.
- **ServiceAccount** \`metadata.name\` goes through the helper. \`ClusterRole\`, \`ClusterRoleBinding\`, \`Role\`, \`RoleBinding\` \`metadata.name\` were already release-scoped (\`tracebloc-resource-monitor-<release>\`) and stay as-is to avoid an unnecessary rename. Only the **subject** names in (Cluster)RoleBinding change to point at the new SA.
- **Mirrored secrets** in \`tracebloc-node-agents\`: secret names were already release-scoped via \`tracebloc.secretName\` / \`tracebloc.registrySecretName\` (no collision). Their \`app\` label was the literal value — harmless on uniquely-named resources, but inconsistent. Updated for consistency.
- Chart bumped **1.1.0 → 1.2.0**. Per-release naming of cluster-singleton resources is a behaviour change, so a minor bump signals operators should review.

## Verification

\`\`\`
=== stg ===                         === internal-prod ===
ServiceAccount stg-resource-monitor  ServiceAccount internal-prod-resource-monitor
DaemonSet      stg-resource-monitor  DaemonSet      internal-prod-resource-monitor
ClusterRoleBinding tracebloc-resource-monitor-stg  ClusterRoleBinding tracebloc-resource-monitor-internal-prod
  subject: stg-resource-monitor       subject: internal-prod-resource-monitor
\`\`\`

Both releases would now coexist on one cluster.

## Test plan

- [x] \`helm lint\` clean
- [x] \`helm unittest client\` — 98/98 (was 93). New cases:
  - DaemonSet name + selector + serviceAccountName release-scoped
  - ServiceAccount name release-scoped
  - ClusterRoleBinding subject points at the release-scoped SA
  - A different release name produces non-colliding DaemonSet + SA names
- [x] \`helm template\` rendered side-by-side for two release names; resource-monitor names diverge per release.
- [ ] **In stg**: \`helm upgrade\` from current 1.1.0 install. Watch the resource-monitor DaemonSet pods cycle (delete-then-create) on each node, then confirm a fresh DaemonSet \`stg-resource-monitor\` is running. ~30-60s metrics gap per node is expected.
- [ ] **Then in prod**: \`helm upgrade internal-prod ./client\` with \`resourceMonitor: true\` (which had to be \`false\` on the 2026-04-27 install due to this bug). Confirm \`internal-prod-resource-monitor\` DaemonSet comes up alongside stg's, both healthy, no name collisions in \`tracebloc-node-agents\`.

## Upgrade path from 1.1.0

DaemonSet and ServiceAccount rename triggers a Helm three-way merge: the names diverge in the stored manifest, so Helm DELETEs the old \`tracebloc-resource-monitor\` resource and CREATEs the new release-scoped one. ~30-60s gap on each node where resource metrics are not collected. DaemonSet selector is immutable, but the rename means Helm goes through delete+create rather than patching the immutable field, so the upgrade is automatic. **No manual orphan cleanup needed.**

## Out of scope

- Migrating away from the workaround on \`internal-prod\` (flipping \`resourceMonitor: false\` → \`true\` after this lands) is a separate operational step — it follows the same \`helm upgrade\` path documented above.
- Documentation update for \`docs/MIGRATIONS.md\` Option B (covered in the companion PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames resource-monitor DaemonSet/ServiceAccount and selector labels in a shared namespace, which will cause delete+create on upgrade and could briefly interrupt metrics collection if not coordinated.
> 
> **Overview**
> Enables multiple `client` Helm releases to coexist on the same cluster by **release-scoping all shared-namespace resource-monitor identities** (DaemonSet name, ServiceAccount name, selector/pod `app` labels, and RBAC binding subjects) via a new `tracebloc.resourceMonitorName` helper.
> 
> Updates mirrored secrets/registry-secret `app` labels for consistency, expands Helm unit tests to assert non-colliding names across releases, and bumps the chart/app version to `1.2.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db988eb0765645bc07e5c0fc8488b9c45390ae95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->