### PR TITLE
chore: add default CODEOWNERS for auto-reviewer assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,10 @@
-# Narrow CODEOWNERS — security backstop only.
-# Author picks reviewers for everything else; this just ensures a security-aware
-# co-approver on a small set of files where a regression would be expensive.
+# Default reviewer: each PR auto-requests the squad lead listed here.
+# Either reviewer can approve to satisfy branch protection (1 approval required).
+# Specific paths below override this default for security-sensitive code.
 
+*    @saadqbal @saqlainsyed007
+
+# === Narrow security CODEOWNERS (preserved from prior PRs) ===
 /client/templates/                                      @saadqbal
 /client/values.schema.json                              @saadqbal
 /client/values.yaml                                     @saadqbal


### PR DESCRIPTION
## Summary

Adds a default `*` rule to `.github/CODEOWNERS` so every PR in this repo auto-requests at least one reviewer (squad lead). Closes the gap where many PRs were landing in "In review" with no Reviewer field set.

## Why

Currently the kanban shows a lot of cards in `In review` without a Reviewer assigned — theres no automatic mechanism to pick one. Adding a default CODEOWNERS line makes GitHub auto-request the squad lead for every PR. Either of the two listed owners can approve (branch protection requires 1 review).

## What changes

- **New default rule** at the top of `.github/CODEOWNERS` (or new file if none existed)
- **Existing narrow security rules** (where present) are preserved unchanged below — they still trigger Asad as additional required co-reviewer for security-sensitive paths

## Behavior

| PR scenario | Auto-requested reviewer |
|---|---|
| Regular PR | The two squad-lead defaults |
| PR touching a file in `# === Narrow security CODEOWNERS ===` (where present) | The squad-lead defaults + Asad |
| PR opened by one of the squad leads | The other squad lead (GitHub skips the author) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)