### PR TITLE
fix(client): allow training pods to reach mysql-client (v1.2.1)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.2.0
-appVersion: "1.2.0"
+version: 1.2.1
+appVersion: "1.2.1"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/network-policy-training.yaml
+++ b/client/templates/network-policy-training.yaml
@@ -6,7 +6,14 @@
     1. Denies all ingress to training pods (nothing should connect TO them).
     2. Allows DNS to the cluster's DNS service.
     3. Allows TCP/443 egress to addresses OUTSIDE the cluster CIDRs only —
-       blocking pod-to-pod, MySQL, K8s API, jobs-manager pod IPs, etc.
+       blocking pod-to-pod, K8s API, jobs-manager pod IPs, etc.
+    4. Allows TCP/3306 egress to the in-namespace mysql-client pod.
+       Training pods load their training dataset via
+       core/utils/database.py::load_dataframe_from_sql_table; without this
+       rule the connect fails with "Can't connect to MySQL server (111)"
+       and the job CrashLoopBackOffs before the first batch.
+       Scoped by podSelector (app=mysql-client) so it stays tight to the
+       chart's own mysql pod and does not open the namespace generally.
 
   Selects pods by label tracebloc.io/workload=training. The jobs-manager
   injects this label when spawning each training Job (see client-runtime
@@ -56,7 +63,8 @@ spec:
           protocol: TCP
     # 2. External HTTPS — everything NOT in the cluster's pod/service CIDRs.
     #    Training pods call backend, Azure Service Bus, App Insights, etc.
-    #    This blocks pod-to-pod, ClusterIPs, MySQL, jobs-manager, K8s API.
+    #    This blocks pod-to-pod, ClusterIPs, jobs-manager, K8s API. MySQL is
+    #    explicitly re-permitted by the next rule.
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
@@ -66,5 +74,15 @@ spec:
               {{- end }}
       ports:
         - port: 443
+          protocol: TCP
+    # 3. MySQL — training pods read the training dataset from the
+    #    in-namespace mysql-client pod. podSelector with no namespaceSelector
+    #    matches pods in the same namespace as this NetworkPolicy.
+    - to:
+        - podSelector:
+            matchLabels:
+              app: mysql-client
+      ports:
+        - port: 3306
           protocol: TCP
 {{- end }}

--- a/client/tests/network_policy_test.yaml
+++ b/client/tests/network_policy_test.yaml
@@ -171,6 +171,29 @@ tests:
             port: 443
             protocol: TCP
 
+  - it: should allow TCP 3306 egress to the in-namespace mysql-client pod
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+    asserts:
+      - equal:
+          path: spec.egress[2].to[0]
+          value:
+            podSelector:
+              matchLabels:
+                app: mysql-client
+      - contains:
+          path: spec.egress[2].ports
+          content:
+            port: 3306
+            protocol: TCP
+
   - it: should support OpenShift DNS selector override
     set:
       networkPolicy:


### PR DESCRIPTION
## Summary

- Training pods now have a third egress rule to reach the in-namespace `mysql-client` pod on TCP/3306 (`podSelector: {app: mysql-client}`, same-namespace).
- Previously the `training-egress` NetworkPolicy only allowed DNS and external TCP/443, so under an enforcing CNI training Jobs `CrashLoopBackOff`'d at the dataset-load step with errno 111.
- Bumps chart from `1.2.0` → `1.2.1`. No values-schema changes.

## Why

Surfaced on a fresh client install on k3d (k3s enforces NetworkPolicy via the bundled kube-router). `jobs-manager` could reach mysql but every Job spawned with `tracebloc.io/workload=training` could not — observed error in the failing pod:

```
Database connection failed: 2003 (HY000): Can't connect to MySQL server on 'mysql-client:3306' (111)
RuntimeError: Database connection is not available for load_dataframe_from_sql_table
```

The dataset-load path (`core/utils/database.py::load_dataframe_from_sql_table`, called from `core/datasets/loaders/dataset_loader.py:35`) is mandatory for every training run, so the policy as written in v1.1.0 made training non-functional on any enforcing CNI. The new rule is scoped to the chart's own mysql pod via `app: mysql-client` rather than opening the namespace.

## Test plan

- [x] `helm unittest client/` — 99/99 pass (added 1 new assertion for `egress[2]`)
- [x] `helm template` renders the new rule cleanly
- [x] Live verification on k3d cluster: pre-fix `nc -zv mysql-client 3306` from a pod with the training label is refused; post-fix it connects (`mysql-client (10.43.135.100:3306) open`)
- [x] Real training Job that previously CrashLoopBackOff'd now passes the dataset-load step
- [ ] Re-verify on AKS / EKS+Calico / OpenShift if those clusters are available before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated Helm NetworkPolicy change plus a chart version bump; main risk is unintentionally widening or breaking egress rules for training pods in clusters that enforce NetworkPolicy.
> 
> **Overview**
> Fixes training jobs on enforcing CNIs by adding a **new egress allow rule** in `templates/network-policy-training.yaml` permitting TCP/3306 traffic from training pods to the in-namespace `mysql-client` pod (scoped via `podSelector: app=mysql-client`).
> 
> Bumps the Helm chart `version`/`appVersion` to `1.2.1` and extends `client/tests/network_policy_test.yaml` with assertions validating the new `egress[2]` rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 041f4595a1b96d392298124e481cabcd31a4a56f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->