### PR TITLE
fix(client): release-scope SCC SA refs (v1.2.2) — bugbot follow-up to v1.2.0

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.2.1
-appVersion: "1.2.1"
+version: 1.2.2
+appVersion: "1.2.2"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/resource-monitor-scc.yaml
+++ b/client/templates/resource-monitor-scc.yaml
@@ -8,11 +8,11 @@ metadata:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
     kubernetes.io/description: >-
-      Minimal SCC for tracebloc-resource-monitor DaemonSet.
+      Minimal SCC for the tracebloc resource-monitor DaemonSet.
       Allows read-only hostPath mounts to /proc and /sys for node metrics collection.
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
-    app: tracebloc-resource-monitor
+    app: {{ include "tracebloc.resourceMonitorName" . }}
 allowPrivilegedContainer: false
 allowPrivilegeEscalation: false
 allowedCapabilities: []
@@ -44,7 +44,7 @@ seccompProfiles:
   - runtime/default
 readOnlyRootFilesystem: false
 users:
-  - system:serviceaccount:{{ .Values.nodeAgents.namespace.name }}:tracebloc-resource-monitor
+  - system:serviceaccount:{{ .Values.nodeAgents.namespace.name }}:{{ include "tracebloc.resourceMonitorName" . }}
 groups: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -56,7 +56,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
-    app: tracebloc-resource-monitor
+    app: {{ include "tracebloc.resourceMonitorName" . }}
 rules:
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
@@ -72,13 +72,13 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
-    app: tracebloc-resource-monitor
+    app: {{ include "tracebloc.resourceMonitorName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: tracebloc-resource-monitor-scc-{{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
-    name: tracebloc-resource-monitor
+    name: {{ include "tracebloc.resourceMonitorName" . }}
     namespace: {{ .Values.nodeAgents.namespace.name }}
 {{- end }}

--- a/client/tests/node_agents_namespace_test.yaml
+++ b/client/tests/node_agents_namespace_test.yaml
@@ -289,7 +289,11 @@ tests:
     asserts:
       - equal:
           path: users[0]
-          value: system:serviceaccount:tracebloc-node-agents:tracebloc-resource-monitor
+          # v1.2.2: SA in users[] is release-scoped (was the hard-coded
+          # tracebloc-resource-monitor before, which on OpenShift granted
+          # SCC permissions to a SA that no longer existed after the
+          # v1.2.0 rename — DaemonSet pods would not start).
+          value: system:serviceaccount:tracebloc-node-agents:RELEASE-NAME-resource-monitor
         documentIndex: 0
       - equal:
           path: subjects[0].namespace

--- a/client/tests/platform_test.yaml
+++ b/client/tests/platform_test.yaml
@@ -111,6 +111,78 @@ tests:
           of: SecurityContextConstraints
         documentIndex: 0
 
+  # Regression: pre-1.2.2 the SCC template hard-coded "tracebloc-resource-monitor"
+  # in users[0] and the ClusterRoleBinding subjects[0].name, while the
+  # rest of the chart had moved to release-scoped names. On OpenShift this
+  # meant the SCC granted permissions to a non-existent SA and the
+  # DaemonSet pods could not start. These tests lock the rename in place.
+  - it: SCC users[0] points at the release-scoped ServiceAccount
+    template: templates/resource-monitor-scc.yaml
+    release:
+      name: stg
+    set:
+      platform: openshift
+      resourceMonitor: true
+      openshift:
+        scc:
+          enabled: true
+      nodeAgents:
+        namespace:
+          name: tracebloc-node-agents
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: SecurityContextConstraints
+      - equal:
+          path: users[0]
+          value: system:serviceaccount:tracebloc-node-agents:stg-resource-monitor
+
+  - it: SCC ClusterRoleBinding subject points at the release-scoped SA
+    template: templates/resource-monitor-scc.yaml
+    release:
+      name: hasan-prod
+    set:
+      platform: openshift
+      resourceMonitor: true
+      openshift:
+        scc:
+          enabled: true
+      nodeAgents:
+        namespace:
+          name: tracebloc-node-agents
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: subjects[0].name
+          value: hasan-prod-resource-monitor
+      - equal:
+          path: subjects[0].namespace
+          value: tracebloc-node-agents
+
+  - it: two releases produce non-colliding SCC SA references
+    template: templates/resource-monitor-scc.yaml
+    release:
+      name: cisco
+    set:
+      platform: openshift
+      resourceMonitor: true
+      openshift:
+        scc:
+          enabled: true
+      nodeAgents:
+        namespace:
+          name: tracebloc-node-agents
+    documentIndex: 0
+    asserts:
+      # Different release => different SA in users[]; combined with the
+      # two cases above (stg + hasan-prod) this proves uniqueness across
+      # any pair on the same cluster.
+      - equal:
+          path: users[0]
+          value: system:serviceaccount:tracebloc-node-agents:cisco-resource-monitor
+
   - it: should not create SCC when platform is aks
     template: templates/resource-monitor-scc.yaml
     set:


### PR DESCRIPTION
## Summary

[Bugbot](https://cursor.com/bugbot) caught a High-severity miss in v1.2.0's release-scoping work (#72): \`client/templates/resource-monitor-scc.yaml\` was the one file the rename didn't reach. On OpenShift the SCC then granted permissions to a ServiceAccount name that no longer existed (\`tracebloc-resource-monitor\` vs the new \`<Release.Name>-resource-monitor\`), and the resource-monitor DaemonSet pods would fail to launch — no usable SCC means no hostPath \`/proc\` / \`/sys\` mounts means no node metrics.

The SCC's \`metadata.name\` + ClusterRole + ClusterRoleBinding metadata were already release-scoped (\`tracebloc-resource-monitor-<release>\` / \`tracebloc-resource-monitor-scc-<release>\`), so the file looked done at a glance. The literals were on the SA references, not the resource names.

## Changes

In \`client/templates/resource-monitor-scc.yaml\`:

- \`users[0]\` → \`system:serviceaccount:<ns>:{{ include "tracebloc.resourceMonitorName" . }}\`
- ClusterRoleBinding \`subjects[0].name\` → same helper
- All \`app: tracebloc-resource-monitor\` labels → same helper, for consistency with the rest of the chart's resource-monitor templates
- Updated the SCC's \`kubernetes.io/description\` prose so the literal name doesn't appear there either (cosmetic, but lets a future "no literal references" audit be a one-line grep)

Chart bumped \`1.2.1 → 1.2.2\` (patch — restores OpenShift parity that v1.2.0 inadvertently broke).

## Test plan

- [x] \`helm lint\` clean
- [x] \`helm unittest client\` — 102/102 (was 98). New cases in \`platform_test.yaml\`:
  - SCC \`users[0]\` is release-scoped (asserts against \`stg\`)
  - ClusterRoleBinding subject is release-scoped (asserts against \`internal-prod\`)
  - A third release (\`[redacted]\`) produces yet another non-colliding SA — pairwise uniqueness across any cluster combination
- [x] \`node_agents_namespace_test.yaml\` had a regression assertion checking the OLD literal SA name; updated to the new release-scoped form (\`RELEASE-NAME-resource-monitor\`, helm-unittest's default release name when none is set explicitly)
- [x] Side-by-side \`helm template\` for two releases:
  ```
  stg        → users[0] = system:serviceaccount:tracebloc-node-agents:stg-resource-monitor
  internal-prod → users[0] = system:serviceaccount:tracebloc-node-agents:internal-prod-resource-monitor
  ```

## Affected installs

- Any OpenShift install on **client-1.2.0 / 1.2.1** with \`openshift.scc.enabled: true\` is broken right now — the resource-monitor pods can't launch. Upgrade to \`1.2.2\` and they recover automatically (helm three-way merge updates the SCC \`users[]\` and the ClusterRoleBinding subject; both are mutable fields).
- Non-OpenShift installs (EKS / AKS / k3d / bare-metal) are unaffected — \`openshift.scc.enabled\` defaults to \`false\` and the SCC template doesn't render.

## Related

- #72 (merged) — original v1.2.0 release-scoping work that this fixes the gap in

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OpenShift `SecurityContextConstraints`/RBAC wiring; while scoped to resource-monitor, an incorrect name or namespace could still block DaemonSet startup or misapply SCC permissions.
> 
> **Overview**
> Fixes a Helm chart regression on OpenShift where the resource-monitor `SecurityContextConstraints` and related RBAC were still referencing the old hard-coded ServiceAccount name.
> 
> The SCC `users[]`, `ClusterRoleBinding` subject, and `app` labels now use the release-scoped `tracebloc.resourceMonitorName` helper, and the chart version is bumped to `1.2.2`. Tests are updated/added to assert release-scoped SCC/subject naming and prevent cross-release collisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1478c2af986d38b53849a5ba86634e5812175fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->