### PR TITLE
docs(claude): require @saadqbal as PR assignee

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,3 +17,7 @@ If the annotation is missing from the stored manifest for any resource you need 
 ## Default branch
 
 Integration branch for this repo (and all tracebloc repos) is `develop`, not `main`. Target PRs at `develop`.
+
+## PR conventions
+
+Every PR you create must be assigned to `saadqbal` (Asad). Pass `--assignee @me` on `gh pr create`, or `--assignee saadqbal` if running unauthenticated. No exceptions — orphaned PRs without an assignee fall through the review queue.


### PR DESCRIPTION
## Summary

Capture the "always assign me on PRs you create" rule directly in \`CLAUDE.md\` so it survives session boundaries. Future Claude runs in this repo will pick this up automatically when planning PRs.

## Changes

- \`CLAUDE.md\` gains a one-paragraph "PR conventions" section: every PR is assigned to \`saadqbal\`. \`--assignee @me\` on \`gh pr create\` is the canonical form.

## Test plan

- [x] This PR is itself assigned via \`--assignee @me\` — proof-of-life that the convention works in practice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that does not affect runtime behavior or infrastructure.
> 
> **Overview**
> Adds a new **PR conventions** section to `CLAUDE.md` requiring that all newly created PRs be assigned to `saadqbal`, with the recommended `gh pr create --assignee @me` (or `--assignee saadqbal` when unauthenticated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3c1af9c3eb7efb28217704abef791bc15dc213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->