### PR TITLE
chore(client): bump chart to 1.2.3 for release

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.2.2
-appVersion: "1.2.2"
+version: 1.2.3
+appVersion: "1.2.3"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
## Summary

Captures everything that landed on \`develop\`/\`main\` since v1.1.0 in a single cumulative release. PR #80's \`Chart.yaml\` bump was lost during squash-merge — both branches contain the 1.2.3 changes but \`Chart.yaml\` still reads 1.2.2. This reconciles them.

## Why one cumulative release instead of four sequential tags

| Chart bump | PR | What it shipped |
|---|---|---|
| 1.2.0 | #72 | Release-scoped resource-monitor names |
| 1.2.1 | #76 | Training pod → mysql-client NetworkPolicy egress |
| 1.2.2 | #78 | OpenShift SCC SA refs |
| 1.2.3 | #80 | NOTES.txt rename + generator chart-version drift |

None of 1.2.0/1.2.1/1.2.2 ever made it past develop into a tag — there are no \`v1.2.x\` git tags, the helm repo's \`index.yaml\` has nothing newer than 1.1.0, and customers running \`helm repo add tracebloc ... && helm install\` would still be pulling 1.1.0. Tagging four versions retroactively for charts no one ever installed is busy-work; one cumulative \`v1.2.3\` does the same job.

## Release sequence after this lands

```bash
# 1. Promote develop -> main (this PR ships only the version bump,
#    everything else is already on main)
gh pr create --base main --head develop \
  --title "Promote develop -> main: chart 1.2.3"

# 2. After that merges, tag from main (annotated tag for the release notes)
git checkout main && git pull --ff-only
git tag -a v1.2.3 -m "Release v1.2.3: cumulative 1.2.x — resource-monitor naming, OpenShift SCC, mysql NetworkPolicy egress, NOTES.txt + generator fixes"
git push origin v1.2.3

# 3. .github/workflows/release-helm-chart.yaml fires on the tag and:
#    - lints the chart
#    - helm package ./client -> client-1.2.3.tgz
#    - pushes to gh-pages with merged index.yaml
#    - creates a GitHub Release with the .tgz attached
```

## Test plan

- [x] \`helm lint --strict ./client -f client/ci/eks-values.yaml\` — clean (same invocation the release workflow runs)
- [x] \`helm unittest client\` — 105/105
- [x] \`helm package ./client\` — produces a valid \`client-1.2.3.tgz\`
- [ ] After tag push: verify the workflow run on Actions; verify \`https://tracebloc.github.io/client/index.yaml\` lists 1.2.3; verify the GitHub Release page has \`client-1.2.3.tgz\` attached

## Related

- #77 (merged) — develop → main promotion
- #78 (merged) — v1.2.2 SCC SA-ref fix
- #80 (merged) — v1.2.3 NOTES.txt + generator fix (whose Chart.yaml bump this restores)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Helm chart metadata (`version` and `appVersion`) with no behavioral or runtime changes.
> 
> **Overview**
> Bumps the Helm chart `version` and `appVersion` in `client/Chart.yaml` from `1.2.2` to `1.2.3` to align the chart metadata with the intended release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0823bee625ede2eaaed438388e50992fda8238b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->