### PR TITLE
feat(client): self-upgrade CronJob (closes #69)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.2.3
-appVersion: "1.2.3"
+version: 1.3.0
+appVersion: "1.3.0"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/MIGRATION.md
+++ b/client/MIGRATION.md
@@ -2,6 +2,31 @@
 
 This guide explains how to migrate from the legacy per-platform charts (`aks/`, `bm/`, `eks/`, `oc/`) to the unified `client/` chart.
 
+## Upgrading to 1.3.0 — self-upgrade CronJob lands on by default
+
+Releases of 1.3.0+ install a `<release>-auto-upgrade` CronJob that polls
+`https://tracebloc.github.io/client` daily and runs `helm upgrade --reuse-values`
+when a newer chart version is published. This closes
+[tracebloc/client#69](https://github.com/tracebloc/client/issues/69) — older
+deployed clients stop drifting from the latest secure / stable release.
+
+The upgrader's ServiceAccount is bound to the built-in `cluster-admin`
+ClusterRole because the chart already templates cluster-scoped resources
+(`PriorityClass`, `StorageClass`, `ClusterRole`/`Binding`, optionally
+`Namespace`); a curated narrower role would silently break the day a future
+chart version adds a new resource kind.
+
+To opt out and keep the manual approval gate you had on 1.2.x:
+
+```yaml
+# values-overrides.yaml
+autoUpgrade:
+  enabled: false
+```
+
+Or for a one-shot pause without removing the resources, set
+`autoUpgrade.suspend: true`.
+
 ## What Changed
 
 | Legacy | Unified |

--- a/client/MIGRATION.md
+++ b/client/MIGRATION.md
@@ -5,10 +5,24 @@ This guide explains how to migrate from the legacy per-platform charts (`aks/`, 
 ## Upgrading to 1.3.0 — self-upgrade CronJob lands on by default
 
 Releases of 1.3.0+ install a `<release>-auto-upgrade` CronJob that polls
-`https://tracebloc.github.io/client` daily and runs `helm upgrade --reuse-values`
-when a newer chart version is published. This closes
-[tracebloc/client#69](https://github.com/tracebloc/client/issues/69) — older
-deployed clients stop drifting from the latest secure / stable release.
+`https://tracebloc.github.io/client` daily and runs
+`helm upgrade --reset-then-reuse-values` when a newer chart version is
+published. This closes [tracebloc/client#69](https://github.com/tracebloc/client/issues/69) —
+older deployed clients stop drifting from the latest secure / stable release.
+
+> **Operator note for the 1.x → 1.3.0 jump.** Use `--reset-then-reuse-values`
+> on the *manual* upgrade command too, not plain `--reuse-values`. The new
+> `autoUpgrade` block was added in 1.3.0; with `--reuse-values` Helm reuses
+> the last release's *computed* values, which don't contain `autoUpgrade`,
+> and the new templates fail with `nil pointer evaluating interface {}.enabled`.
+> Once you're on 1.3.0+ the CronJob handles future bumps with the correct
+> flag itself.
+>
+> ```bash
+> helm upgrade <release> tracebloc/client \
+>   -n <namespace> --version 1.3.0 \
+>   --reset-then-reuse-values
+> ```
 
 The upgrader's ServiceAccount is bound to the built-in `cluster-admin`
 ClusterRole because the chart already templates cluster-scoped resources

--- a/client/templates/NOTES.txt
+++ b/client/templates/NOTES.txt
@@ -23,6 +23,11 @@
 {{- if .Values.openshift.scc.enabled }}
   {{ "\033[1;34m" }}OpenShift SCC:{{ "\033[0m" }}    {{ "\033[0;33m" }}tracebloc-resource-monitor-{{ .Release.Name }}{{ "\033[0m" }}
 {{- end }}
+{{- if .Values.autoUpgrade.enabled }}
+  {{ "\033[1;34m" }}Auto-upgrade:{{ "\033[0m" }}     {{ "\033[1;32m" }}ON{{ "\033[0m" }} {{ "\033[0;90m" }}(CronJob {{ .Release.Name }}-auto-upgrade, schedule "{{ .Values.autoUpgrade.schedule }}", repo {{ .Values.autoUpgrade.repoUrl }}){{ "\033[0m" }}
+{{- else }}
+  {{ "\033[1;34m" }}Auto-upgrade:{{ "\033[0m" }}     {{ "\033[1;33m" }}OFF{{ "\033[0m" }} {{ "\033[0;90m" }}(release pinned to chart {{ .Chart.Version }}; set autoUpgrade.enabled=true to receive future fixes automatically){{ "\033[0m" }}
+{{- end }}
 
 {{ "\033[1;35m" }}PVCs{{ "\033[0m" }} (protected with helm.sh/resource-policy: keep):
   - {{ "\033[0;36m" }}{{ include "tracebloc.clientDataPvc" . }}{{ "\033[0m" }}     {{ "\033[0;90m" }}({{ include "tracebloc.clientDataStorage" . }}){{ "\033[0m" }}

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -82,6 +82,16 @@ mysql-pvc
 {{- end }}
 
 {{/*
+  Release-scoped name shared by the auto-upgrade CronJob, ServiceAccount,
+  ClusterRoleBinding, and the ConfigMap holding the upgrade script. Kept
+  in one helper so the four resources stay in lockstep — the CRB references
+  the SA by name, and the CronJob mounts the ConfigMap by name.
+*/}}
+{{- define "tracebloc.autoUpgradeName" -}}
+{{ .Release.Name }}-auto-upgrade
+{{- end }}
+
+{{/*
   StorageClass name: when storageClass.create is true, use a release-unique name
   so each release gets its own StorageClass (avoids Helm ownership conflicts).
   When create is false, use the user-provided storageClass.name for an existing class.

--- a/client/templates/auto-upgrade-cronjob.yaml
+++ b/client/templates/auto-upgrade-cronjob.yaml
@@ -69,10 +69,19 @@ data:
     fi
 
     log "upgrading $CURRENT -> $LATEST"
+    # --reset-then-reuse-values (helm 3.14+) is critical here: --reuse-values
+    # alone re-uses the LAST RELEASE'S COMPUTED VALUES, so any new keys added
+    # to values.yaml in the upgraded chart (e.g. a future autoUpgrade.foo
+    # default) would silently fail to render with nil-pointer template errors
+    # — verified on a dev-cluster 1.1.0 -> 1.3.0 dry-run when shipping #69.
+    # --reset-then-reuse-values resets to the new chart's defaults first, then
+    # layers the customer's user-supplied values on top, so operator overrides
+    # (clientId, dockerRegistry creds, autoUpgrade.enabled=false, etc.) are
+    # preserved while new defaults flow through.
     helm upgrade "$RELEASE_NAME" "${REPO_NAME}/${CHART_NAME}" \
       --namespace "$RELEASE_NAMESPACE" \
       --version "$LATEST" \
-      --reuse-values \
+      --reset-then-reuse-values \
       --wait \
       --timeout "$UPGRADE_TIMEOUT"
     log "upgrade complete: $CURRENT -> $LATEST"

--- a/client/templates/auto-upgrade-cronjob.yaml
+++ b/client/templates/auto-upgrade-cronjob.yaml
@@ -1,0 +1,160 @@
+{{- if .Values.autoUpgrade.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tracebloc.autoUpgradeName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auto-upgrade
+data:
+  auto-upgrade.sh: |
+    #!/bin/sh
+    # Self-upgrade loop. See client/values.yaml `autoUpgrade` for the
+    # design + trust boundary discussion. Parsing is awk-only on purpose:
+    # the upstream alpine/helm image ships without jq and we don't want to
+    # apk-add at runtime under a runAsNonRoot pod.
+    set -eu
+
+    # Helm needs writable cache/config/data dirs. The Pod runs with
+    # readOnlyRootFilesystem: true, so point Helm at the emptyDir mounted
+    # at /tmp.
+    export HOME=/tmp
+    export HELM_CACHE_HOME=/tmp/.helm/cache
+    export HELM_CONFIG_HOME=/tmp/.helm/config
+    export HELM_DATA_HOME=/tmp/.helm/data
+    mkdir -p "$HELM_CACHE_HOME" "$HELM_CONFIG_HOME" "$HELM_DATA_HOME"
+
+    log() { printf '[auto-upgrade] %s\n' "$*"; }
+
+    log "release=$RELEASE_NAME namespace=$RELEASE_NAMESPACE repo=$REPO_URL"
+
+    helm repo add "$REPO_NAME" "$REPO_URL" >/dev/null
+    helm repo update "$REPO_NAME" >/dev/null
+
+    # Latest published version. Helm orders search results newest-first,
+    # so the first `version:` line in the YAML output is the latest.
+    LATEST="$(helm search repo "${REPO_NAME}/${CHART_NAME}" -o yaml \
+      | awk '/^[[:space:]]*version:/ {print $2; exit}')"
+
+    # Currently deployed chart version. `helm list -o yaml` emits
+    # `chart: client-<version>` for the matching release.
+    CURRENT_CHART="$(helm list -n "$RELEASE_NAMESPACE" \
+      --filter "^${RELEASE_NAME}\$" -o yaml \
+      | awk '/^[[:space:]]*chart:/ {print $2; exit}')"
+    CURRENT="${CURRENT_CHART#${CHART_NAME}-}"
+
+    if [ -z "$LATEST" ]; then
+      log "ERROR: could not resolve latest chart version from $REPO_URL"
+      exit 1
+    fi
+    if [ -z "$CURRENT" ] || [ "$CURRENT" = "$CURRENT_CHART" ]; then
+      log "ERROR: could not parse deployed chart version (got '$CURRENT_CHART')"
+      exit 1
+    fi
+
+    log "current=$CURRENT latest=$LATEST"
+
+    if [ "$LATEST" = "$CURRENT" ]; then
+      log "already at latest; nothing to do"
+      exit 0
+    fi
+
+    # Semver-aware compare via `sort -V` so 1.10.0 > 1.9.0.
+    NEWER="$(printf '%s\n%s\n' "$CURRENT" "$LATEST" | sort -V | tail -n 1)"
+    if [ "$NEWER" != "$LATEST" ]; then
+      log "deployed version is ahead of repo (current=$CURRENT > latest=$LATEST); skipping"
+      exit 0
+    fi
+
+    log "upgrading $CURRENT -> $LATEST"
+    helm upgrade "$RELEASE_NAME" "${REPO_NAME}/${CHART_NAME}" \
+      --namespace "$RELEASE_NAMESPACE" \
+      --version "$LATEST" \
+      --reuse-values \
+      --wait \
+      --timeout "$UPGRADE_TIMEOUT"
+    log "upgrade complete: $CURRENT -> $LATEST"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "tracebloc.autoUpgradeName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auto-upgrade
+spec:
+  schedule: {{ .Values.autoUpgrade.schedule | quote }}
+  suspend: {{ .Values.autoUpgrade.suspend }}
+  # Forbid: never run two upgrade attempts at once. A long upgrade that
+  # crosses the next scheduled tick should not stack a second `helm upgrade`
+  # on top of itself.
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.autoUpgrade.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.autoUpgrade.failedJobsHistoryLimit }}
+  startingDeadlineSeconds: {{ .Values.autoUpgrade.startingDeadlineSeconds }}
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            {{- include "tracebloc.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: auto-upgrade
+        spec:
+          serviceAccountName: {{ include "tracebloc.autoUpgradeName" . }}
+          restartPolicy: OnFailure
+          {{- if include "tracebloc.useImagePullSecrets" . }}
+          imagePullSecrets:
+            - name: {{ include "tracebloc.registrySecretName" . }}
+          {{- end }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: helm
+              image: "{{ .Values.autoUpgrade.image.repository }}:{{ .Values.autoUpgrade.image.tag }}"
+              imagePullPolicy: {{ .Values.autoUpgrade.image.pullPolicy }}
+              # `helm` is the entrypoint on alpine/helm; override so we run
+              # our script instead.
+              command: ["/bin/sh", "/scripts/auto-upgrade.sh"]
+              env:
+                - name: RELEASE_NAME
+                  value: {{ .Release.Name | quote }}
+                - name: RELEASE_NAMESPACE
+                  value: {{ .Release.Namespace | quote }}
+                - name: REPO_URL
+                  value: {{ .Values.autoUpgrade.repoUrl | quote }}
+                - name: REPO_NAME
+                  value: {{ .Values.autoUpgrade.repoName | quote }}
+                - name: CHART_NAME
+                  value: {{ .Values.autoUpgrade.chartName | quote }}
+                - name: UPGRADE_TIMEOUT
+                  value: {{ .Values.autoUpgrade.timeout | quote }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                {{- toYaml .Values.autoUpgrade.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "tracebloc.autoUpgradeName" . }}
+                defaultMode: 0555
+            - name: tmp
+              emptyDir: {}
+{{- end }}

--- a/client/templates/auto-upgrade-rbac.yaml
+++ b/client/templates/auto-upgrade-rbac.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.autoUpgrade.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tracebloc.autoUpgradeName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auto-upgrade
+---
+{{/*
+  Bound to the built-in cluster-admin ClusterRole rather than a chart-defined
+  narrow role. The chart already creates cluster-scoped resources (PriorityClass,
+  StorageClass, ClusterRole/Binding, optionally Namespace), so a curated role
+  would have to enumerate every resource the chart ever templates — adding a
+  new resource kind in a future version would silently break upgrades on
+  already-deployed clients with no signal.
+  See autoUpgrade comment in values.yaml for the trust-boundary discussion.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "tracebloc.autoUpgradeName" . }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auto-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "tracebloc.autoUpgradeName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/client/tests/auto_upgrade_test.yaml
+++ b/client/tests/auto_upgrade_test.yaml
@@ -51,9 +51,14 @@ tests:
       - matchRegex:
           path: data["auto-upgrade.sh"]
           pattern: "helm upgrade"
+      # Must be --reset-then-reuse-values, NOT plain --reuse-values:
+      # --reuse-values re-uses the last release's computed values, so any
+      # new keys added to values.yaml in a future chart version silently
+      # fail to render with nil-pointer template errors. Verified on a
+      # dev-cluster 1.1.0 -> 1.3.0 dry-run during the #69 verification.
       - matchRegex:
           path: data["auto-upgrade.sh"]
-          pattern: "--reuse-values"
+          pattern: "--reset-then-reuse-values"
       # Regression guard: the script MUST use sort -V (semver), not lexical
       # string compare. A naive string compare would block 1.10.x upgrades
       # because "1.10.0" < "1.9.0" lexically.

--- a/client/tests/auto_upgrade_test.yaml
+++ b/client/tests/auto_upgrade_test.yaml
@@ -1,0 +1,186 @@
+suite: auto-upgrade CronJob and RBAC
+templates:
+  - templates/auto-upgrade-cronjob.yaml
+  - templates/auto-upgrade-rbac.yaml
+release:
+  name: stg
+  namespace: tracebloc
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: cronjob template renders ConfigMap + CronJob by default
+    template: templates/auto-upgrade-cronjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: rbac template renders ServiceAccount + ClusterRoleBinding by default
+    template: templates/auto-upgrade-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: cronjob template renders nothing when autoUpgrade.enabled=false
+    template: templates/auto-upgrade-cronjob.yaml
+    set:
+      autoUpgrade:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rbac template renders nothing when autoUpgrade.enabled=false
+    template: templates/auto-upgrade-rbac.yaml
+    set:
+      autoUpgrade:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ConfigMap holds the upgrade script
+    template: templates/auto-upgrade-cronjob.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: stg-auto-upgrade
+      - matchRegex:
+          path: data["auto-upgrade.sh"]
+          pattern: "helm upgrade"
+      - matchRegex:
+          path: data["auto-upgrade.sh"]
+          pattern: "--reuse-values"
+      # Regression guard: the script MUST use sort -V (semver), not lexical
+      # string compare. A naive string compare would block 1.10.x upgrades
+      # because "1.10.0" < "1.9.0" lexically.
+      - matchRegex:
+          path: data["auto-upgrade.sh"]
+          pattern: "sort -V"
+
+  - it: CronJob has the right schedule, concurrency, and SA wiring
+    template: templates/auto-upgrade-cronjob.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: stg-auto-upgrade
+      - equal:
+          path: spec.schedule
+          value: "23 2 * * *"
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: stg-auto-upgrade
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.restartPolicy
+          value: OnFailure
+
+  - it: CronJob env carries release identity to the upgrade script
+    template: templates/auto-upgrade-cronjob.yaml
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: RELEASE_NAME
+            value: stg
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: RELEASE_NAMESPACE
+            value: tracebloc
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: REPO_URL
+            value: https://tracebloc.github.io/client
+
+  - it: CronJob pod satisfies PSA restricted (runAsNonRoot, dropped caps, RO root, seccomp)
+    template: templates/auto-upgrade-cronjob.yaml
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+
+  - it: ServiceAccount and ClusterRoleBinding bind to cluster-admin
+    template: templates/auto-upgrade-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ServiceAccount
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: stg-auto-upgrade
+        documentIndex: 0
+      - isKind:
+          of: ClusterRoleBinding
+        documentIndex: 1
+      - equal:
+          path: roleRef.name
+          value: cluster-admin
+        documentIndex: 1
+      - equal:
+          path: subjects[0].name
+          value: stg-auto-upgrade
+        documentIndex: 1
+
+  - it: should accept operator overrides for schedule, image, and timeout
+    template: templates/auto-upgrade-cronjob.yaml
+    documentIndex: 1
+    set:
+      autoUpgrade:
+        enabled: true
+        schedule: "0 4 * * 0"
+        timeout: "30m"
+        image:
+          repository: my-mirror/helm
+          tag: "3.16.4"
+          pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "0 4 * * 0"
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: my-mirror/helm:3.16.4
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: UPGRADE_TIMEOUT
+            value: "30m"
+
+  - it: schema rejects image.tag=latest (auto-upgrade behaviour must not drift)
+    template: templates/auto-upgrade-cronjob.yaml
+    set:
+      autoUpgrade:
+        image:
+          tag: "latest"
+    asserts:
+      - failedTemplate:
+          errorPattern: "must not be valid against schema"

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -428,6 +428,95 @@
       "not": { "pattern": "^<.*>$" },
       "description": "Client authentication password. Must be a real value, not a placeholder like <CLIENT_PASSWORD>."
     },
+    "autoUpgrade": {
+      "type": "object",
+      "description": "Self-upgrade CronJob (issue tracebloc/client#69). Polls the helm repo at autoUpgrade.repoUrl daily and runs `helm upgrade --reuse-values` when a newer chart version is published. Disable to keep the release pinned to its install-time chart version.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "When false, no CronJob, ServiceAccount, or ClusterRoleBinding is rendered and the release will not self-upgrade."
+        },
+        "schedule": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Cron expression in the controller's timezone (UTC unless the cluster overrides it)."
+        },
+        "repoUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Helm chart repository URL polled for newer versions."
+        },
+        "repoName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Local alias used by `helm repo add` inside the upgrade Pod."
+        },
+        "chartName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Chart name as published in the repo's index.yaml (the `name` field, not the directory)."
+        },
+        "timeout": {
+          "type": "string",
+          "pattern": "^[0-9]+(s|m|h)$",
+          "description": "Passed to `helm upgrade --timeout`. Allow enough headroom for image pull + PVC bind on slow infra."
+        },
+        "suspend": {
+          "type": "boolean",
+          "default": false,
+          "description": "CronJob.spec.suspend. Set true to pause without removing the resources."
+        },
+        "successfulJobsHistoryLimit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failedJobsHistoryLimit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "startingDeadlineSeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "image": {
+          "type": "object",
+          "required": ["repository", "tag"],
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": {
+              "type": "string",
+              "minLength": 1,
+              "not": { "const": "latest" },
+              "description": "Pin the helm version. `latest` is rejected — auto-upgrade behaviour must not drift."
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            }
+          }
+        }
+      }
+    },
     "dockerRegistry": {
       "type": ["object", "null"],
       "description": "Optional. Omit entirely or set null for public images (no secret or imagePullSecrets). Only create when set and create is true.",

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -276,3 +276,66 @@ clientPassword: ""
 #   username: "<DOCKER_USERNAME>"
 #   password: "<DOCKER_REGISTRY_TOKEN>"
 #   email: "<DOCKER_EMAIL>"
+
+# -- Self-upgrade CronJob (closes tracebloc/client#69).
+# Runs `helm upgrade --reuse-values` against this release on a schedule, so
+# customers do not stay frozen on the version they first installed and miss
+# security fixes / stability work shipped after their install.
+#
+# How it works:
+#   - A CronJob in this namespace runs `helm repo update` against repoUrl,
+#     compares the latest published chart version to the deployed revision,
+#     and upgrades when the published version is newer (semver compare via
+#     `sort -V`, so 1.10 > 1.9 — not a string compare).
+#   - --reuse-values is passed, so secrets (clientId, clientPassword,
+#     dockerRegistry creds) and any operator overrides are preserved.
+#   - imagePullPolicy on tracebloc images is `Always` when no digest is
+#     pinned, so the chart upgrade also picks up new image content for the
+#     floating prod/dev tags as pods restart.
+#
+# Trust boundary: the CronJob's ServiceAccount is bound to the built-in
+# `cluster-admin` ClusterRole, so it can apply any resource the chart
+# templates (PriorityClass / StorageClass / ClusterRoleBinding / Namespace
+# are all cluster-scoped). Anything that compromises this Pod or the chart
+# repo at repoUrl effectively gets cluster-admin. Mitigations:
+#   - repoUrl defaults to GitHub Pages over HTTPS (publish controlled by
+#     the tracebloc team via the gh-pages branch).
+#   - Set autoUpgrade.enabled: false to opt out and run upgrades manually
+#     under your own approval gate.
+#
+# Disabled-on-this-cluster check after install:
+#   kubectl get cronjob -n <namespace> -l app.kubernetes.io/component=auto-upgrade
+autoUpgrade:
+  # Default ON: the entire point of #69 is that customers freeze on the
+  # version they installed. Defaulting off would recreate that exact bug.
+  enabled: true
+  # Daily at 02:23 UTC. The off-hour minute spreads load across the
+  # tracebloc.github.io/client GitHub Pages origin.
+  schedule: "23 2 * * *"
+  # Helm chart repo to poll. Override only when mirroring internally.
+  repoUrl: "https://tracebloc.github.io/client"
+  repoName: "tracebloc"
+  chartName: "client"
+  # `helm upgrade --wait --timeout`. Bare-metal first-pull of mysql/jobs-manager
+  # images can take several minutes; 10m gives PVC bind + image pull headroom
+  # without holding the slot all night if something is genuinely wedged.
+  timeout: "10m"
+  # CronJob spec knobs. Override per-cluster if needed.
+  suspend: false
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 600
+  # Pod image: helm CLI only. alpine/helm is small and the tag pins the
+  # helm version, so behaviour cannot drift if upstream re-tags.
+  image:
+    repository: alpine/helm
+    tag: "3.16.4"
+    pullPolicy: IfNotPresent
+  # Tiny — the pod is mostly idle waiting on network + helm I/O.
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "256Mi"


### PR DESCRIPTION
## Summary

- Closes #69. Ships a `<release>-auto-upgrade` CronJob that polls `https://tracebloc.github.io/client` daily and runs `helm upgrade --reuse-values` when a newer chart version is published, so deployed clients no longer freeze on the version they first installed.
- Implements **option B (auto-upgrade)** from the issue — picked over notify-and-approve / hybrid because the issue's whole point is "customers don't run upgrade manually".
- Bumps chart **1.2.3 → 1.3.0**.

## What's in the chart now

| Resource | Name | Notes |
|---|---|---|
| `CronJob` | `<release>-auto-upgrade` | `concurrencyPolicy: Forbid`, default schedule `23 2 * * *` (UTC), `backoffLimit: 2` |
| `ConfigMap` | `<release>-auto-upgrade` | Holds the upgrade shell script |
| `ServiceAccount` | `<release>-auto-upgrade` | In the release namespace |
| `ClusterRoleBinding` | `<release>-auto-upgrade` | Bound to the built-in `cluster-admin` |

The Pod satisfies PSA `restricted`: `runAsNonRoot: true`, `runAsUser/Group: 1000`, `RuntimeDefault` seccomp, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`. `HOME` and `HELM_*_HOME` are redirected into a `/tmp` emptyDir so helm can write its caches.

The version compare uses `sort -V`, not string compare — `1.10.0 > 1.9.0`.

## Trade-offs surfaced for review

1. **Default `enabled: true`.** The issue is "customers freeze on the version they installed". Default-off recreates the bug for everyone who installs 1.3.0 and never re-runs helm. Operator can opt out via `autoUpgrade.enabled: false`, or pause via `autoUpgrade.suspend: true`.
2. **`cluster-admin` not a narrow custom role.** The chart already templates cluster-scoped resources (`PriorityClass`, `StorageClass`, `ClusterRole`/`Binding`, optionally `Namespace`). A curated role would silently break the day a future chart version adds a new resource kind on already-deployed clients. Trust boundary is documented in `values.yaml` next to the `autoUpgrade:` block.
3. **Backend reporting deferred.** The issue mentions reporting back to the tracebloc backend so the workspace UI knows what version each customer runs. No endpoint exists yet — will land as a follow-up once the contract is defined. Not blocking the upgrade loop.
4. **Image pinned to `alpine/helm:3.16.4`.** No `jq` dep — script parses helm's YAML output with awk only. `latest` is rejected by the schema so behaviour can't drift from under us.

## Test plan

- [x] `helm lint client` clean (default + AKS + bare-metal value files)
- [x] `helm template stg client …` renders 4 new docs by default; renders 0 with `autoUpgrade.enabled=false`
- [x] `helm unittest client` — 12 suites, **116 tests** pass (11 of those new in `tests/auto_upgrade_test.yaml`)
- [ ] **Reviewer to verify on a live cluster** (out of scope for this PR but the natural next step):
  - [ ] `helm install` 1.3.0 fresh; observe `<release>-auto-upgrade` CronJob created
  - [ ] Manually trigger the Job (`kubectl create job … --from=cronjob/<release>-auto-upgrade`); confirm it logs `already at latest; nothing to do`
  - [ ] Publish a 1.3.1 to `gh-pages`; trigger the Job again; observe `helm upgrade complete: 1.3.0 -> 1.3.1`
  - [ ] Verify reused values: `helm get values <release>` still shows `clientId` / `clientPassword` (not stripped by `--reuse-values`)
  - [ ] Verify on a bare-metal cluster (no CSI) since the script's `helm upgrade --wait --timeout 10m` interacts with PVC bind timing

## Follow-ups (separate tickets)

- Backend reporting endpoint + auth wiring (chart side: optional `autoUpgrade.reportUrl`).
- Optional per-customer override on what major-version bumps trigger auto-apply vs notify (option C / hybrid). Not needed for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a default-on CronJob that can mutate cluster-scoped resources and is bound to `cluster-admin`, so a compromised pod or chart repo could lead to full cluster takeover.
> 
> **Overview**
> Adds an **auto-upgrade mechanism** to the `client` Helm chart: when `autoUpgrade.enabled` (default **true**) it installs a `<release>-auto-upgrade` ConfigMap+CronJob that periodically checks the published chart repo and runs `helm upgrade --reset-then-reuse-values` to move the release to the latest chart version.
> 
> This also introduces the supporting `ServiceAccount` + `ClusterRoleBinding` (bound to built-in `cluster-admin`), new `autoUpgrade` values and schema validation (including rejecting `image.tag: latest`), updates install notes/migration docs, adds helm-unittest coverage, and bumps the chart/app version to `1.3.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b402aca81817f65998fad9e0a21bb24101fc8d6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->