### PR TITLE
chore: revert default CODEOWNERS (back to author-picks-reviewer)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,6 @@
-# Default reviewer: each PR auto-requests the squad lead listed here.
-# Either reviewer can approve to satisfy branch protection (1 approval required).
-# Specific paths below override this default for security-sensitive code.
+# Narrow CODEOWNERS — security backstop only.
+# Author picks reviewers for everything else.
 
-*    @saadqbal @saqlainsyed007
-
-# === Narrow security CODEOWNERS (preserved from prior PRs) ===
 /client/templates/                                      @saadqbal
 /client/values.schema.json                              @saadqbal
 /client/values.yaml                                     @saadqbal


### PR DESCRIPTION
Reverts the default `* @squad-leads` rule added yesterday.

Switching back to author-picks-reviewer model: the engineer working on a PR manually requests a code reviewer when marking ready, and a functional reviewer when promoting to functional review. No more auto-assigned shared ownership.

Narrow security CODEOWNERS (Asad on sensitive paths) preserved where they exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)