### PR TITLE
Prod: Revert CODEOWNERS to maintain narrow security rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,6 @@
-# Default reviewer: each PR auto-requests the squad lead listed here.
-# Either reviewer can approve to satisfy branch protection (1 approval required).
-# Specific paths below override this default for security-sensitive code.
+# Narrow CODEOWNERS — security backstop only.
+# Author picks reviewers for everything else.
 
-*    @saadqbal @saqlainsyed007
-
-# === Narrow security CODEOWNERS (preserved from prior PRs) ===
 /client/templates/                                      @saadqbal
 /client/values.schema.json                              @saadqbal
 /client/values.yaml                                     @saadqbal

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.3.0
-appVersion: "1.3.0"
+version: 1.3.1
+appVersion: "1.3.1"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/MIGRATION.md
+++ b/client/MIGRATION.md
@@ -10,6 +10,10 @@ Releases of 1.3.0+ install a `<release>-auto-upgrade` CronJob that polls
 published. This closes [tracebloc/client#69](https://github.com/tracebloc/client/issues/69) —
 older deployed clients stop drifting from the latest secure / stable release.
 
+> **Verified end-to-end on `tb-client-dev-templates` during the 1.3.1 release**:
+> a `tracebloc` release at 1.3.0 self-upgraded to 1.3.1 within a single
+> CronJob tick after publish, with no operator intervention.
+
 > **Operator note for the 1.x → 1.3.0 jump.** Use `--reset-then-reuse-values`
 > on the *manual* upgrade command too, not plain `--reuse-values`. The new
 > `autoUpgrade` block was added in 1.3.0; with `--reuse-values` Helm reuses


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to review ownership rules plus a Helm chart version bump and a small documentation update, with no functional template/value changes in this diff.
> 
> **Overview**
> **Narrowed `CODEOWNERS` to act only as a security backstop**, removing the repo-wide default owners so authors must explicitly pick reviewers for non-sensitive changes.
> 
> Bumps the unified Helm chart `version`/`appVersion` to `1.3.1` and updates `MIGRATION.md` with a note confirming the `auto-upgrade` CronJob successfully self-upgraded from `1.3.0` to `1.3.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0a69258bba407d7bb5fb770e986f8246c3546a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->