### PR TITLE
feat(requests-proxy): register requests-proxy in Helm chart

### DIFF
--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -62,6 +62,11 @@ spec:
             secretKeyRef:
               name: {{ include "tracebloc.secretName" . }}
               key: CLIENT_PASSWORD
+        - name: REQUESTS_PROXY_ADMIN_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-requests-proxy-admin
+              key: token
         - name: CLIENT_PVC
           value: {{ include "tracebloc.clientDataPvc" . | quote }}
         - name: CLIENT_LOGS_PVC

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-requests-proxy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: requests-proxy
+  template:
+    metadata:
+      labels:
+        app: requests-proxy
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: proxy
+          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.requestsProxy.digest "registry" "docker.io") | quote }}
+          imagePullPolicy: {{ if .Values.images.requestsProxy.digest }}IfNotPresent{{ else }}Always{{ end }}
+          workingDir: /app
+          command: ["python", "-m", "gunicorn"]
+          args:
+            - "--bind=0.0.0.0:8888"
+            # The proxy stores registered pod tokens in process-local memory,
+            # so it must run as a single worker unless the registry moves to
+            # shared storage.
+            - "--workers=1"
+            - "--worker-tmp-dir=/dev/shm"
+            - "--threads=4"
+            - "--graceful-timeout=30"
+            - "--timeout=60"
+            - "--access-logfile=-"
+            - "--error-logfile=-"
+            - "requests_proxy_server:create_app()"
+          ports:
+            - containerPort: 8888
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requestsProxy.requests.cpu | default "100m" | quote }}
+              memory: {{ .Values.resources.requestsProxy.requests.memory | default "256Mi" | quote }}
+            limits:
+              cpu: {{ .Values.resources.requestsProxy.limits.cpu | default "500m" | quote }}
+              memory: {{ .Values.resources.requestsProxy.limits.memory | default "512Mi" | quote }}
+          env:
+            - name: REQUESTS_PROXY_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-requests-proxy-admin
+                  key: token
+            - name: EXPERIMENTS_QUEUE_NAME
+              value: "experiments"
+            - name: FLOPS_QUEUE_NAME
+              value: "flops"
+      {{- if include "tracebloc.useImagePullSecrets" . }}
+      imagePullSecrets:
+        - name: {{ include "tracebloc.registrySecretName" . }}
+      {{- end }}
+      restartPolicy: Always

--- a/client/templates/requests-proxy-service.yaml
+++ b/client/templates/requests-proxy-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: requests-proxy-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app: requests-proxy
+spec:
+  selector:
+    app: requests-proxy
+  ports:
+    - name: http
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+  type: ClusterIP

--- a/client/templates/secrets.yaml
+++ b/client/templates/secrets.yaml
@@ -14,13 +14,13 @@ data:
   CLIENT_ID: {{ $clientId | b64enc | quote }}
   CLIENT_PASSWORD: {{ $clientPassword | b64enc | quote }}
 ---
-{{- $proxySecretName := printf "%s-requests-proxy-admin" .Release.Name -}}
+{{ $proxySecretName := printf "%s-requests-proxy-admin" .Release.Name -}}
 {{- $existingProxySecret := lookup "v1" "Secret" .Release.Namespace $proxySecretName -}}
 {{- $proxyAdminToken := "" -}}
-{{- if and $existingProxySecret $existingProxySecret.data (index $existingProxySecret.data "token") -}}
-{{- $proxyAdminToken = index $existingProxySecret.data "token" | b64dec -}}
-{{- else if .Values.requestsProxyAdminToken -}}
+{{- if .Values.requestsProxyAdminToken -}}
 {{- $proxyAdminToken = .Values.requestsProxyAdminToken -}}
+{{- else if and $existingProxySecret $existingProxySecret.data (index $existingProxySecret.data "token") -}}
+{{- $proxyAdminToken = index $existingProxySecret.data "token" | b64dec -}}
 {{- else -}}
 {{- $proxyAdminToken = randAlphaNum 64 -}}
 {{- end -}}

--- a/client/templates/secrets.yaml
+++ b/client/templates/secrets.yaml
@@ -13,6 +13,27 @@ type: Opaque
 data:
   CLIENT_ID: {{ $clientId | b64enc | quote }}
   CLIENT_PASSWORD: {{ $clientPassword | b64enc | quote }}
+---
+{{- $proxySecretName := printf "%s-requests-proxy-admin" .Release.Name -}}
+{{- $existingProxySecret := lookup "v1" "Secret" .Release.Namespace $proxySecretName -}}
+{{- $proxyAdminToken := "" -}}
+{{- if and $existingProxySecret $existingProxySecret.data (index $existingProxySecret.data "token") -}}
+{{- $proxyAdminToken = index $existingProxySecret.data "token" | b64dec -}}
+{{- else if .Values.requestsProxyAdminToken -}}
+{{- $proxyAdminToken = .Values.requestsProxyAdminToken -}}
+{{- else -}}
+{{- $proxyAdminToken = randAlphaNum 64 -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $proxySecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+type: Opaque
+data:
+  token: {{ $proxyAdminToken | b64enc | quote }}
 {{- if and (ne .Values.resourceMonitor false) (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
 ---
 # Mirrored into the node-agents namespace so the resource-monitor DaemonSet

--- a/client/tests/node_agents_namespace_test.yaml
+++ b/client/tests/node_agents_namespace_test.yaml
@@ -186,7 +186,7 @@ tests:
     template: templates/secrets.yaml
     asserts:
       - hasDocuments:
-          count: 2
+          count: 3
       - isKind:
           of: Secret
         documentIndex: 0
@@ -196,21 +196,21 @@ tests:
         documentIndex: 0
       - isKind:
           of: Secret
-        documentIndex: 1
+        documentIndex: 2
       - equal:
           path: metadata.namespace
           value: tracebloc-node-agents
-        documentIndex: 1
+        documentIndex: 2
       - equal:
           path: metadata.name
           value: RELEASE-NAME-secrets
-        documentIndex: 1
+        documentIndex: 2
       - isNotEmpty:
           path: data.CLIENT_ID
-        documentIndex: 1
+        documentIndex: 2
       - isNotEmpty:
           path: data.CLIENT_PASSWORD
-        documentIndex: 1
+        documentIndex: 2
 
   - it: should not mirror the tracebloc Secret when resourceMonitor is disabled
     template: templates/secrets.yaml
@@ -218,8 +218,9 @@ tests:
       resourceMonitor: false
     asserts:
       - hasDocuments:
-          count: 1
+          count: 2
       - equal:
+          documentIndex: 0
           path: metadata.namespace
           value: tracebloc-templates
 
@@ -232,8 +233,9 @@ tests:
           name: tracebloc-templates
     asserts:
       - hasDocuments:
-          count: 1
+          count: 2
       - equal:
+          documentIndex: 0
           path: metadata.namespace
           value: tracebloc-templates
 

--- a/client/tests/node_agents_namespace_test.yaml
+++ b/client/tests/node_agents_namespace_test.yaml
@@ -220,9 +220,9 @@ tests:
       - hasDocuments:
           count: 2
       - equal:
-          documentIndex: 0
           path: metadata.namespace
           value: tracebloc-templates
+        documentIndex: 0
 
   - it: should not mirror the tracebloc Secret when node-agents namespace equals release namespace
     template: templates/secrets.yaml
@@ -235,9 +235,9 @@ tests:
       - hasDocuments:
           count: 2
       - equal:
-          documentIndex: 0
           path: metadata.namespace
           value: tracebloc-templates
+        documentIndex: 0
 
   - it: should mirror the docker registry Secret into the node-agents namespace when in use
     template: templates/docker-registry-secret.yaml

--- a/client/tests/secrets_test.yaml
+++ b/client/tests/secrets_test.yaml
@@ -11,19 +11,55 @@ tests:
     asserts:
       - isKind:
           of: Secret
+        documentIndex: 0
       - equal:
           path: metadata.name
           value: RELEASE-NAME-secrets
+        documentIndex: 0
       - equal:
           path: type
           value: Opaque
+        documentIndex: 0
       - isNotEmpty:
           path: data.CLIENT_ID
+        documentIndex: 0
       - isNotEmpty:
           path: data.CLIENT_PASSWORD
+        documentIndex: 0
       - matchRegex:
           path: metadata.labels["app.kubernetes.io/managed-by"]
           pattern: Helm
+        documentIndex: 0
+
+  - it: should use explicit requests-proxy admin token override
+    template: templates/secrets.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
+      requestsProxyAdminToken: "override-token"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-requests-proxy-admin
+        documentIndex: 1
+      - equal:
+          path: data.token
+          value: b3ZlcnJpZGUtdG9rZW4=
+        documentIndex: 1
+
+  - it: should generate requests-proxy admin token when no override is provided
+    template: templates/secrets.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-requests-proxy-admin
+        documentIndex: 1
+      - isNotEmpty:
+          path: data.token
+        documentIndex: 1
 
   - it: should create docker registry secret when create is true
     template: templates/docker-registry-secret.yaml

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -284,6 +284,15 @@
             }
           }
         },
+        "requestsProxy": {
+          "type": "object",
+          "properties": {
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$"
+            }
+          }
+        },
         "mysqlClient": {
           "type": "object",
           "properties": {
@@ -374,6 +383,25 @@
               }
             }
           }
+        },
+        "requestsProxy": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            }
+          }
         }
       }
     },
@@ -427,6 +455,10 @@
       "minLength": 1,
       "not": { "pattern": "^<.*>$" },
       "description": "Client authentication password. Must be a real value, not a placeholder like <CLIENT_PASSWORD>."
+    },
+    "requestsProxyAdminToken": {
+      "type": "string",
+      "description": "Optional admin token override for the requests-proxy service."
     },
     "autoUpgrade": {
       "type": "object",

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -183,6 +183,8 @@ images:
     digest: ""
   resourceMonitor:
     digest: ""
+  requestsProxy:
+    digest: ""
   mysqlClient:
     # mysql-client is only published under the "prod" tag — it has no dev/
     # staging variants, so we decouple it from env.CLIENT_ENV. Override only
@@ -230,6 +232,13 @@ resources:
     limits:
       cpu: "500m"
       memory: "512Mi"
+  requestsProxy:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
 
 # -- PriorityClass for the data-plane (mysql).
 # Cluster-scoped resource. Created with helm.sh/resource-policy: keep so a
@@ -266,6 +275,13 @@ podDisruptionBudget:
 # overridden. Do NOT commit real credentials to version control.
 clientId: ""
 clientPassword: ""
+
+# -- Admin token for the requests-proxy service.
+# Auto-generated on first install (equivalent to `openssl rand -hex 32`) and
+# preserved across upgrades via lookup. Override with --set requestsProxyAdminToken=...
+# only when you need a specific value (e.g. restoring a known token).
+# Do NOT commit real tokens to version control.
+requestsProxyAdminToken: ""
 
 # -- Docker registry credentials (optional; only used when dockerRegistry is set and create is true)
 # Omit dockerRegistry entirely, or set create: false, for public images (no imagePullSecrets).

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -277,9 +277,9 @@ clientId: ""
 clientPassword: ""
 
 # -- Admin token for the requests-proxy service.
-# Auto-generated on first install (equivalent to `openssl rand -hex 32`) and
-# preserved across upgrades via lookup. Override with --set requestsProxyAdminToken=...
-# only when you need a specific value (e.g. restoring a known token).
+# Optional. If set, this value overrides any existing requests-proxy admin
+# secret on install or upgrade. When left empty, the chart reuses the current
+# secret if present or generates a new token on first install.
 # Do NOT commit real tokens to version control.
 requestsProxyAdminToken: ""
 


### PR DESCRIPTION
## Summary

- Add `requests-proxy-deployment.yaml` and `requests-proxy-service.yaml` Helm templates, converted from the raw manifests in `client-runtime`
- Auto-generate `requests-proxy-admin` Secret on first install (64-char random token equivalent to `openssl rand -hex 32`); preserved across `helm upgrade` via `lookup`; operator can override with `--set requestsProxyAdminToken=...`
- Inject `REQUESTS_PROXY_ADMIN_TOKEN` into the `jobs-manager` container from the same secret
- Add `images.requestsProxy.digest` and `resources.requestsProxy` to `values.yaml`

## Test plan

- [ ] `helm template` renders both new templates with correct namespace and release-scoped names
- [ ] Fresh install: `requests-proxy-admin` Secret is created with a non-empty auto-generated token
- [ ] `helm upgrade` on existing install: token in Secret is unchanged (lookup preserves it)
- [ ] `jobs-manager` pod has `REQUESTS_PROXY_ADMIN_TOKEN` env var matching the secret value
- [ ] `requests-proxy` pod starts and listens on port 8888

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new in-cluster `requests-proxy` workload plus a new admin-token Secret that is generated/reused via Helm `lookup`, which can affect upgrade behavior and secret management if misconfigured.
> 
> **Overview**
> Adds a new `requests-proxy` Deployment and ClusterIP Service to the Helm chart, running a Gunicorn-based proxy on port `8888` with configurable image digest and resource requests/limits.
> 
> Introduces a release-scoped `requests-proxy-admin` Secret that *persists across upgrades* by reusing an existing token (or generating a new 64-char token on first install), with an optional `requestsProxyAdminToken` values override; the same token is also injected into `jobs-manager` via `REQUESTS_PROXY_ADMIN_TOKEN`. 
> 
> Updates chart schema/values and Helm unit tests to cover the new templates, values, and the additional Secret documents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac98550fe855a1c1431a3439dace69443618124e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->