### PR TITLE
feat(client): scaffolding for stateless requests-proxy auth (HC-1)

### DIFF
--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -51,6 +51,9 @@ spec:
             mountPath: "/data/shared"
           - name: logs-volume
             mountPath: "/data/logs"
+          - name: requests-proxy-keys
+            mountPath: "/etc/proxy/keys"
+            readOnly: true
         env:
         - name: CLIENT_ID
           valueFrom:
@@ -67,6 +70,19 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-requests-proxy-admin
               key: token
+        # Stateless requests-proxy auth (CR-2). The runtime path is enabled
+        # by REQUESTS_PROXY_STATELESS=1; otherwise legacy register-token
+        # behaviour is unchanged.
+        - name: REQUESTS_PROXY_STATELESS
+          value: {{ ternary "1" "" .Values.requestsProxy.statelessTokens | quote }}
+        - name: RELEASE_NAME
+          value: {{ .Release.Name | quote }}
+        - name: NAMESPACE
+          value: {{ .Release.Namespace | quote }}
+        - name: REQUESTS_PROXY_TOKEN_TTL_SECONDS
+          value: {{ .Values.requestsProxy.tokenTtlSeconds | default 7776000 | int | quote }}
+        - name: REVOKED_CONFIGMAP_NAME
+          value: {{ printf "%s-requests-proxy-revoked" .Release.Name | quote }}
         - name: CLIENT_PVC
           value: {{ include "tracebloc.clientDataPvc" . | quote }}
         - name: CLIENT_LOGS_PVC
@@ -154,4 +170,8 @@ spec:
         - name: logs-volume
           persistentVolumeClaim:
             claimName: {{ include "tracebloc.clientLogsPvc" . }}
+        - name: requests-proxy-keys
+          secret:
+            secretName: {{ .Release.Name }}-requests-proxy-keys
+            defaultMode: 0400
       restartPolicy: Always

--- a/client/templates/rbac.yaml
+++ b/client/templates/rbac.yaml
@@ -30,6 +30,17 @@ rules:
   - apiGroups: ["metrics.k8s.io"]
     resources: ["pods"]
     verbs: ["get", "list"]
+  # requests-proxy stateless auth (CR-2): jobs-manager appends/prunes
+  # entries in the revoked ConfigMap and reads the keys Secret to sign JWTs.
+  # Scoped via resourceNames so this Role can't touch unrelated objects.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: [{{ printf "%s-requests-proxy-revoked" .Release.Name | quote }}]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ printf "%s-requests-proxy-keys" .Release.Name | quote }}]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -73,6 +84,17 @@ rules:
   - apiGroups: ["metrics.k8s.io"]
     resources: ["pods"]
     verbs: ["get", "list"]
+  # requests-proxy stateless auth (CR-2): jobs-manager appends/prunes
+  # entries in the revoked ConfigMap and reads the keys Secret to sign JWTs.
+  # Scoped via resourceNames so this Role can't touch unrelated objects.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: [{{ printf "%s-requests-proxy-revoked" .Release.Name | quote }}]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ printf "%s-requests-proxy-keys" .Release.Name | quote }}]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -41,6 +41,13 @@ spec:
             - "requests_proxy_server:create_app()"
           ports:
             - containerPort: 8888
+          volumeMounts:
+            - name: requests-proxy-keys
+              mountPath: "/etc/proxy/keys"
+              readOnly: true
+            - name: requests-proxy-revoked
+              mountPath: "/etc/proxy/revoked"
+              readOnly: true
           securityContext:
             runAsNonRoot: true
             runAsUser: 1001
@@ -61,6 +68,16 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-requests-proxy-admin
                   key: token
+            # Stateless requests-proxy auth (CR-1). When REQUESTS_PROXY_STATELESS=1
+            # the proxy verifies HMAC-signed JWTs from /etc/proxy/keys/ and reads
+            # /etc/proxy/revoked/revoked.json instead of using its in-memory
+            # registered-token map. Otherwise legacy behaviour is unchanged.
+            - name: REQUESTS_PROXY_STATELESS
+              value: {{ ternary "1" "" .Values.requestsProxy.statelessTokens | quote }}
+            - name: RELEASE_NAME
+              value: {{ .Release.Name | quote }}
+            - name: NAMESPACE
+              value: {{ .Release.Namespace | quote }}
             - name: EXPERIMENTS_QUEUE_NAME
               value: "experiments"
             - name: FLOPS_QUEUE_NAME
@@ -69,4 +86,12 @@ spec:
       imagePullSecrets:
         - name: {{ include "tracebloc.registrySecretName" . }}
       {{- end }}
+      volumes:
+        - name: requests-proxy-keys
+          secret:
+            secretName: {{ .Release.Name }}-requests-proxy-keys
+            defaultMode: 0400
+        - name: requests-proxy-revoked
+          configMap:
+            name: {{ .Release.Name }}-requests-proxy-revoked
       restartPolicy: Always

--- a/client/templates/requests-proxy-keys-secret.yaml
+++ b/client/templates/requests-proxy-keys-secret.yaml
@@ -1,0 +1,47 @@
+{{/*
+  HMAC keys used by the requests-proxy stateless auth path (CR-1) and signed by
+  jobs-manager (CR-2). Mounted as a directory on both pods at /etc/proxy/keys/,
+  one file per kid plus an `active` file naming the current signing kid.
+
+  Why a separate secret from <release>-requests-proxy-admin: when projected as
+  a volume, every key becomes a file. Mixing the legacy admin token in this
+  mount would expose it where the stateless code path doesn't need it.
+
+  resource-policy: keep — losing this Secret invalidates every JWT currently
+  held by running training pods (env vars are immutable; pods can't refresh).
+  See docs/MIGRATIONS.md: the annotation is read from the stored manifest, so
+  it MUST render here, not just be applied to the live resource.
+*/}}
+{{- $keysSecretName := printf "%s-requests-proxy-keys" .Release.Name -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $keysSecretName -}}
+{{- $keys := dict -}}
+{{- $activeKid := "v1" -}}
+{{- if $existing -}}
+  {{- range $k, $v := $existing.data -}}
+    {{- if regexMatch "^v[0-9]+$" $k -}}
+      {{- $_ := set $keys $k ($v | b64dec) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if and $existing.data (index $existing.data "active") -}}
+    {{- $activeKid = index $existing.data "active" | b64dec -}}
+  {{- end -}}
+{{- end -}}
+{{- if not (index $keys "v1") -}}
+  {{- $_ := set $keys "v1" (randAlphaNum 64) -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $keysSecretName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: requests-proxy
+type: Opaque
+data:
+  active: {{ $activeKid | b64enc | quote }}
+  {{- range $kid, $key := $keys }}
+  {{ $kid }}: {{ $key | b64enc | quote }}
+  {{- end }}

--- a/client/templates/requests-proxy-revoked-configmap.yaml
+++ b/client/templates/requests-proxy-revoked-configmap.yaml
@@ -1,0 +1,31 @@
+{{/*
+  Revoked-jti list for the requests-proxy stateless auth path. Jobs-manager
+  appends entries on stop_job and prunes entries whose K8s Job no longer
+  exists (CR-2). The proxy mounts this ConfigMap and polls revoked.json
+  every 10s to refresh its in-memory revocation set (CR-1).
+
+  Lookup pattern preserves the existing data on chart upgrade — without it,
+  every `helm upgrade` would reset the list to [] and silently re-authorize
+  every previously-revoked job until its key rotation cycle expires.
+
+  resource-policy: keep — same reasoning as the keys Secret. A stray
+  uninstall must not wipe outstanding revocations.
+*/}}
+{{- $cmName := printf "%s-requests-proxy-revoked" .Release.Name -}}
+{{- $existing := lookup "v1" "ConfigMap" .Release.Namespace $cmName -}}
+{{- $revoked := "[]" -}}
+{{- if and $existing $existing.data (index $existing.data "revoked.json") -}}
+{{- $revoked = index $existing.data "revoked.json" -}}
+{{- end -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $cmName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: requests-proxy
+data:
+  revoked.json: {{ $revoked | quote }}

--- a/client/tests/requests_proxy_stateless_test.yaml
+++ b/client/tests/requests_proxy_stateless_test.yaml
@@ -1,0 +1,188 @@
+suite: Requests-proxy stateless auth (HC-1)
+templates:
+  - templates/requests-proxy-keys-secret.yaml
+  - templates/requests-proxy-revoked-configmap.yaml
+  - templates/rbac.yaml
+  - templates/jobs-manager-deployment.yaml
+  - templates/requests-proxy-deployment.yaml
+set:
+  clientId: "test-client"
+  clientPassword: "test-pass"
+  storageClass:
+    create: false
+    name: "existing-sc"
+tests:
+  # ---------- keys Secret ----------
+  - it: should render keys Secret with active=v1 and a v1 key on first install
+    template: templates/requests-proxy-keys-secret.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-requests-proxy-keys
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: requests-proxy
+      - equal:
+          path: data.active
+          value: djE=  # b64("v1")
+      - isNotEmpty:
+          path: data.v1
+      - matchRegex:
+          path: data.v1
+          # 64 raw chars → 88 b64 chars (no padding when len%3==1; here 64%3==1 → ends with =)
+          pattern: "^[A-Za-z0-9+/]+=*$"
+
+  # ---------- revoked ConfigMap ----------
+  - it: should render revoked ConfigMap with empty list on first install
+    template: templates/requests-proxy-revoked-configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-requests-proxy-revoked
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+      - equal:
+          path: data["revoked.json"]
+          value: "[]"
+
+  # ---------- RBAC ----------
+  - it: should grant jobs-manager get/update/patch on the revoked ConfigMap (clusterScope=true)
+    template: templates/rbac.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["configmaps"]
+            resourceNames: ["RELEASE-NAME-requests-proxy-revoked"]
+            verbs: ["get", "update", "patch"]
+        documentIndex: 1  # ClusterRole
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            resourceNames: ["RELEASE-NAME-requests-proxy-keys"]
+            verbs: ["get"]
+        documentIndex: 1
+
+  - it: should grant the same rules in namespace-scoped Role when clusterScope=false
+    template: templates/rbac.yaml
+    set:
+      clusterScope: false
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["configmaps"]
+            resourceNames: ["RELEASE-NAME-requests-proxy-revoked"]
+            verbs: ["get", "update", "patch"]
+        documentIndex: 1  # Role
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            resourceNames: ["RELEASE-NAME-requests-proxy-keys"]
+            verbs: ["get"]
+        documentIndex: 1
+
+  # ---------- jobs-manager deployment ----------
+  - it: should mount keys volume and inject stateless env vars on jobs-manager
+    template: templates/jobs-manager-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: requests-proxy-keys
+            mountPath: "/etc/proxy/keys"
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: requests-proxy-keys
+            secret:
+              secretName: RELEASE-NAME-requests-proxy-keys
+              defaultMode: 0400
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REVOKED_CONFIGMAP_NAME
+            value: "RELEASE-NAME-requests-proxy-revoked"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REQUESTS_PROXY_TOKEN_TTL_SECONDS
+            value: "7776000"
+
+  - it: should set REQUESTS_PROXY_STATELESS=1 on jobs-manager when flag is true
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      requestsProxy:
+        statelessTokens: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REQUESTS_PROXY_STATELESS
+            value: "1"
+
+  - it: should leave REQUESTS_PROXY_STATELESS empty on jobs-manager by default
+    template: templates/jobs-manager-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REQUESTS_PROXY_STATELESS
+            value: ""
+
+  # ---------- proxy deployment ----------
+  - it: should mount keys + revoked volumes and inject env on the proxy
+    template: templates/requests-proxy-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: requests-proxy-keys
+            mountPath: "/etc/proxy/keys"
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: requests-proxy-revoked
+            mountPath: "/etc/proxy/revoked"
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: requests-proxy-keys
+            secret:
+              secretName: RELEASE-NAME-requests-proxy-keys
+              defaultMode: 0400
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: requests-proxy-revoked
+            configMap:
+              name: RELEASE-NAME-requests-proxy-revoked
+
+  - it: should set REQUESTS_PROXY_STATELESS=1 on the proxy when flag is true
+    template: templates/requests-proxy-deployment.yaml
+    set:
+      requestsProxy:
+        statelessTokens: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REQUESTS_PROXY_STATELESS
+            value: "1"

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -460,6 +460,23 @@
       "type": "string",
       "description": "Optional admin token override for the requests-proxy service."
     },
+    "requestsProxy": {
+      "type": "object",
+      "description": "Requests-proxy stateless auth (HC-1 + CR-1/CR-2). The keys Secret, revoked ConfigMap, and RBAC always render; statelessTokens controls whether the runtime path is enabled.",
+      "properties": {
+        "statelessTokens": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, jobs-manager mints HMAC-signed JWTs and the proxy verifies them. When false, legacy register-token behaviour is preserved."
+        },
+        "tokenTtlSeconds": {
+          "type": "integer",
+          "minimum": 60,
+          "default": 7776000,
+          "description": "JWT exp lifetime in seconds. Default 7776000 (90d) aligns with the quarterly key-rotation cadence."
+        }
+      }
+    },
     "autoUpgrade": {
       "type": "object",
       "description": "Self-upgrade CronJob (issue tracebloc/client#69). Polls the helm repo at autoUpgrade.repoUrl daily and runs `helm upgrade --reuse-values` when a newer chart version is published. Disable to keep the release pinned to its install-time chart version.",

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -283,6 +283,19 @@ clientPassword: ""
 # Do NOT commit real tokens to version control.
 requestsProxyAdminToken: ""
 
+# -- Requests-proxy stateless auth (HC-1 + CR-1 / CR-2).
+# When statelessTokens is true, jobs-manager mints HMAC-signed JWTs and the
+# proxy verifies them against the keys mounted from <release>-requests-proxy-keys.
+# Default false during the rollout window — the chart still renders the
+# keys Secret, revoked ConfigMap, and RBAC even when disabled, so flipping
+# this flag is a one-line `helm upgrade --set` operation.
+# tokenTtlSeconds is the JWT `exp` lifetime; 7776000s (90d) aligns with the
+# quarterly key-rotation cadence so `exp` only fires before rotation if a
+# rotation is skipped (defence-in-depth).
+requestsProxy:
+  statelessTokens: false
+  tokenTtlSeconds: 7776000
+
 # -- Docker registry credentials (optional; only used when dockerRegistry is set and create is true)
 # Omit dockerRegistry entirely, or set create: false, for public images (no imagePullSecrets).
 # When create is true, secret name is {{ .Release.Name }}-regcred.


### PR DESCRIPTION
## Summary

Chart-side scaffolding for the stateless requests-proxy auth path. Companion to client-runtime#26 (CR-1, proxy verify) and client-runtime#27 (CR-2, jobs-manager mint). Cutover is tracked in #99 (OPS-1).

- New `<release>-requests-proxy-keys` Secret holds HMAC keys (`active`, `v1`, …). `lookup`-preserved across upgrades and `helm.sh/resource-policy: keep` — losing it invalidates every JWT held by running training pods.
- New `<release>-requests-proxy-revoked` ConfigMap holds the revoked-jti list. Same preservation pattern; without `lookup`, every `helm upgrade` would silently re-authorize previously-stopped jobs.
- RBAC rules (added to both `clusterScope` paths in `rbac.yaml`) are `resourceNames`-scoped to those two specific objects so jobs-manager can't touch unrelated configmaps/secrets in the namespace.
- Both deployments mount the keys Secret at `/etc/proxy/keys/`. The proxy also mounts the revoked ConfigMap at `/etc/proxy/revoked/`. New env vars: `REQUESTS_PROXY_STATELESS`, `RELEASE_NAME`, `NAMESPACE`, plus `REQUESTS_PROXY_TOKEN_TTL_SECONDS` and `REVOKED_CONFIGMAP_NAME` on jobs-manager.
- New values: `requestsProxy.statelessTokens` (default `false`) and `requestsProxy.tokenTtlSeconds` (default `7776000` = 90d, aligned to the quarterly key-rotation cadence).

The runtime path is gated entirely by the `requestsProxy.statelessTokens` env var on the pods — chart-side resources always render so OPS-1 is a one-line `helm upgrade --set` operation, not a chart-shape change.

## Test plan

- [x] `helm template` clean against default values and `--set requestsProxy.statelessTokens=true`
- [x] `helm lint` clean
- [x] `helm unittest ./client` — **127/127 passing**, including 9 new cases in `requests_proxy_stateless_test.yaml` covering the keys Secret, revoked ConfigMap, RBAC under both `clusterScope=true` and `clusterScope=false`, and both deployments.
- [ ] After CR-1 + CR-2 merge in client-runtime: end-to-end smoke in staging — `helm upgrade --set requestsProxy.statelessTokens=true`, kill the proxy pod, verify in-flight training pods continue without 401s. Tracked under OPS-1 (#99).

Closes #96

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Helm-managed Secret/ConfigMap plus new RBAC and pod mounts/env vars; while gated by a flag, mistakes could break proxy authentication or leave behind persistent auth artifacts due to `resource-policy: keep`. Changes touch deployment manifests and permissions but not application logic.
> 
> **Overview**
> Introduces **chart scaffolding for stateless `requests-proxy` auth** by adding a persistent `<release>-requests-proxy-keys` Secret (lookup-preserved, `helm.sh/resource-policy: keep`) and a `<release>-requests-proxy-revoked` ConfigMap to store revoked token IDs.
> 
> Updates `jobs-manager` and `requests-proxy` Deployments to mount these resources and inject new env vars (including `REQUESTS_PROXY_STATELESS` gated by `requestsProxy.statelessTokens`, plus release/namespace metadata and JWT TTL/revoked ConfigMap name). RBAC is extended (both cluster- and namespace-scoped paths) with resourceName-scoped access to read the keys Secret and update the revoked ConfigMap.
> 
> Adds `requestsProxy.statelessTokens` and `requestsProxy.tokenTtlSeconds` to `values.yaml`/schema and includes Helm unittest coverage for the new templates and wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4974fb5a3152ada46cda01f727ab4f806d7b0176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->