### PR TITLE
docs: fix README Deploy section (Helm not docker), surface in-repo docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,18 +50,29 @@ For the threat model, defense layers, per-platform caveats, operator responsibil
 
 ## Deploy
 
+This repo ships the **tracebloc** unified Helm chart (currently `v1.3.1`) — one chart for AKS, EKS, bare-metal, and OpenShift.
+
 ```bash
-docker pull tracebloc/client:latest
+helm repo add tracebloc https://tracebloc.github.io/client
+helm repo update
+helm install my-tracebloc tracebloc/tracebloc \
+  --namespace tracebloc --create-namespace \
+  -f my-values.yaml
 ```
 
-Deployment varies by infrastructure. Follow the guide for your setup:
+Full deployment guide → **[docs/INSTALL.md](docs/INSTALL.md)** (prerequisites, required values, upgrade & rollback, air-gapped install).
 
-- [Deployment overview](https://docs.tracebloc.io/environment-setup/deployment-overview)
-- [Local — Linux](https://docs.tracebloc.io/environment-setup/local-linux)
-- [Local — macOS](https://docs.tracebloc.io/environment-setup/local-macos)
-- [AWS](https://docs.tracebloc.io/environment-setup/aws)
+| Topic | Where to look |
+|---|---|
+| Production install + required values | [docs/INSTALL.md](docs/INSTALL.md) |
+| Threat model & operator responsibilities | [docs/SECURITY.md](docs/SECURITY.md) |
+| Migrating from `eks-1.0.x` / `aks-*` charts to `client-1.x` | [docs/MIGRATIONS.md](docs/MIGRATIONS.md) |
+| Per-tenant migration runbook | [docs/migration-tools/README.md](docs/migration-tools/README.md) |
+| Per-platform value mapping | [client/MIGRATION.md](client/MIGRATION.md) |
 
-Full documentation → [docs.tracebloc.io](https://docs.tracebloc.io/)
+Platform-specific walkthroughs: [Linux](https://docs.tracebloc.io/environment-setup/local-deployment-guide-linux) · [macOS](https://docs.tracebloc.io/environment-setup/local-deployment-guide-macos) · [EKS](https://docs.tracebloc.io/environment-setup/eks-client-deployment-guide) · [Azure / AKS](https://docs.tracebloc.io/environment-setup/azure-deployment-guide)
+
+> **NetworkPolicy required.** The chart's training-pod egress lockdown only takes effect on a CNI that enforces NetworkPolicy. See [SECURITY.md § Per-platform caveats](docs/SECURITY.md#5-per-platform-caveats).
 
 ## Links
 


### PR DESCRIPTION
## Summary
- Replaces `docker pull tracebloc/client:latest` with the correct `helm repo add` + `helm install` flow — this repo ships a Helm chart (`client/Chart.yaml` v1.3.1), not a Docker image.
- Calls out the chart version and supported platforms (AKS / EKS / bare-metal / OpenShift) front-and-center.
- New table linking every operational doc in this repo: `docs/INSTALL.md`, `docs/SECURITY.md`, `docs/MIGRATIONS.md`, `docs/migration-tools/README.md`, `client/MIGRATION.md`. Previously none of these were discoverable from the README.
- Fixes broken external walkthrough URLs to match actual paths in the [tracebloc/docs](https://github.com/tracebloc/docs) tree (`local-deployment-guide-linux`, `local-deployment-guide-macos`, `eks-client-deployment-guide`, `azure-deployment-guide`).
- Surfaces the NetworkPolicy/CNI prerequisite as a callout under Deploy — currently it's only mentioned deep inside SECURITY.md.

Surgical change: tagline, architecture diagram, "What the client manages" list, Security section, Links, and License all stay as-is.

Closes #101

## Test plan
- [ ] Skim rendered README on the PR diff
- [ ] Click each link in the new doc-pointer table — confirm all resolve
- [ ] Click each external walkthrough link — confirm they resolve to real pages on docs.tracebloc.io
- [ ] Verify `helm repo add tracebloc https://tracebloc.github.io/client` actually serves a chart index (filed as a separate follow-up if not)

## Out of scope (separate follow-ups worth filing)
- `docs/INSTALL.md:203,220,229` still reference the old `tracebloc-helm-charts` repo name
- Empty legacy `aks/`, `bm/`, `eks/` directories at repo root
- Verify GitHub Pages config for `https://tracebloc.github.io/client`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes updating Helm install guidance and links; no runtime or configuration behavior is modified.
> 
> **Overview**
> Updates the README **Deploy** section to reflect Helm-based installation (adds `helm repo add`/`helm install` commands), calls out the unified chart version and supported platforms, and adds a table linking to key in-repo operational docs (install, security, migrations, and runbooks).
> 
> Fixes and consolidates platform-specific walkthrough links and adds a prominent NetworkPolicy/CNI prerequisite callout pointing to `docs/SECURITY.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a610d2f35c4100dd241ad1b769e8639ae8cb3060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->