### PR TITLE
docs: surface standalone installer in README and INSTALL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ For the threat model, defense layers, per-platform caveats, operator responsibil
 
 This repo ships the **tracebloc** unified Helm chart (currently `v1.3.1`) — one chart for AKS, EKS, bare-metal, and OpenShift.
 
+### Quick install
+
+A single command provisions a local Kubernetes cluster, auto-detects and installs GPU drivers (NVIDIA or AMD), and deploys the tracebloc client. Best for evaluation, local dev, and first-time installs.
+
+**macOS / Linux**
+
+```bash
+bash <(curl -fsSL tracebloc.io/i.sh)
+```
+
+**Windows** *(PowerShell as Administrator)*
+
+```powershell
+irm tracebloc.io/i.ps1 | iex
+```
+
+The installer pulls helper scripts from this repo at runtime — see [`scripts/install-k8s.sh`](scripts/install-k8s.sh) and [`scripts/install-k8s.ps1`](scripts/install-k8s.ps1).
+
+### Helm install (production)
+
+For existing production clusters:
+
 ```bash
 helm repo add tracebloc https://tracebloc.github.io/client
 helm repo update

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ A single command provisions a Kubernetes cluster, auto-detects and installs GPU 
 **macOS / Linux**
 
 ```bash
-bash <(curl -fsSL tracebloc.io/i.sh)
+bash <(curl -fsSL https://tracebloc.io/i.sh)
 ```
 
 **Windows** *(PowerShell as Administrator)*
 
 ```powershell
-irm tracebloc.io/i.ps1 | iex
+irm https://tracebloc.io/i.ps1 | iex
 ```
 
 The installer pulls helper scripts from this repo at runtime — see [`scripts/install-k8s.sh`](scripts/install-k8s.sh) and [`scripts/install-k8s.ps1`](scripts/install-k8s.ps1).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This repo ships the **tracebloc** unified Helm chart (currently `v1.3.1`) — on
 
 ### Quick install
 
-A single command provisions a local Kubernetes cluster, auto-detects and installs GPU drivers (NVIDIA or AMD), and deploys the tracebloc client. Best for evaluation, local dev, and first-time installs.
+A single command provisions a Kubernetes cluster, auto-detects and installs GPU drivers (NVIDIA or AMD), and deploys the tracebloc client. Use this when you don't already have a cluster — the result is a full client install, not a demo.
 
 **macOS / Linux**
 
@@ -70,9 +70,9 @@ irm tracebloc.io/i.ps1 | iex
 
 The installer pulls helper scripts from this repo at runtime — see [`scripts/install-k8s.sh`](scripts/install-k8s.sh) and [`scripts/install-k8s.ps1`](scripts/install-k8s.ps1).
 
-### Helm install (production)
+### Helm install
 
-For existing production clusters:
+For existing Kubernetes clusters:
 
 ```bash
 helm repo add tracebloc https://tracebloc.github.io/client

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,8 +4,8 @@ This guide covers installing the **tracebloc** unified Helm chart (AKS, EKS, bar
 
 > **Don't have a Kubernetes cluster yet?** The standalone installer provisions a cluster, installs GPU drivers, and deploys a full tracebloc client in a single command:
 >
-> - **macOS / Linux:** `bash <(curl -fsSL tracebloc.io/i.sh)`
-> - **Windows:** `irm tracebloc.io/i.ps1 | iex` *(PowerShell as Administrator)*
+> - **macOS / Linux:** `bash <(curl -fsSL https://tracebloc.io/i.sh)`
+> - **Windows:** `irm https://tracebloc.io/i.ps1 | iex` *(PowerShell as Administrator)*
 >
 > See the [README's Quick install section](../README.md#quick-install) for what it does. Continue here if you're deploying into an existing cluster.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,12 +2,12 @@
 
 This guide covers installing the **tracebloc** unified Helm chart (AKS, EKS, bare-metal, OpenShift) in a production-ready way.
 
-> **Just trying it out?** For local dev or a quick evaluation, the standalone installer provisions a cluster, GPU drivers, and the client in a single command:
+> **Don't have a Kubernetes cluster yet?** The standalone installer provisions a cluster, installs GPU drivers, and deploys a full tracebloc client in a single command:
 >
 > - **macOS / Linux:** `bash <(curl -fsSL tracebloc.io/i.sh)`
 > - **Windows:** `irm tracebloc.io/i.ps1 | iex` *(PowerShell as Administrator)*
 >
-> See the [README's Quick install section](../README.md#quick-install) for what it does. Continue here if you're deploying into an existing production cluster.
+> See the [README's Quick install section](../README.md#quick-install) for what it does. Continue here if you're deploying into an existing cluster.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,6 +2,13 @@
 
 This guide covers installing the **tracebloc** unified Helm chart (AKS, EKS, bare-metal, OpenShift) in a production-ready way.
 
+> **Just trying it out?** For local dev or a quick evaluation, the standalone installer provisions a cluster, GPU drivers, and the client in a single command:
+>
+> - **macOS / Linux:** `bash <(curl -fsSL tracebloc.io/i.sh)`
+> - **Windows:** `irm tracebloc.io/i.ps1 | iex` *(PowerShell as Administrator)*
+>
+> See the [README's Quick install section](../README.md#quick-install) for what it does. Continue here if you're deploying into an existing production cluster.
+
 ---
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
The standalone installer (`bash <(curl -fsSL tracebloc.io/i.sh)` / `irm tracebloc.io/i.ps1 | iex`) is the one-command path for evaluation, local dev, and first-time installs — it provisions a cluster, auto-detects GPU drivers (NVIDIA / AMD), and deploys the client. Today it isn't documented anywhere reachable from this repo, so readers only see the multi-step `helm install` flow.

**README** — adds a `Quick install` subsection at the top of the Deploy section with macOS/Linux and Windows one-liners, plus a pointer to the local `scripts/install-k8s.sh` / `scripts/install-k8s.ps1` helpers. The existing helm flow is relabeled `Helm install (production)` and reframed as the option for existing production clusters.

**docs/INSTALL.md** — top-of-doc callout pointing non-production readers at the standalone installer. The rest of the production-focused content is untouched.

Closes #103

## Test plan
- [ ] Skim rendered README and INSTALL.md on the PR diff
- [ ] Click `scripts/install-k8s.sh` and `scripts/install-k8s.ps1` links — confirm they resolve
- [ ] Verify `tracebloc.io/i.sh` and `tracebloc.io/i.ps1` still resolve (currently both serve the bootstrap script)
- [ ] Run `bash <(curl -fsSL tracebloc.io/i.sh)` end-to-end on a fresh macOS or Linux machine — confirm it lands a healthy client install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds install guidance and links; no code or configuration behavior is modified.
> 
> **Overview**
> Adds a **Quick install** path to the README, documenting one-command macOS/Linux and Windows bootstrap installers and linking to the repo’s helper scripts (`scripts/install-k8s.sh`/`scripts/install-k8s.ps1`).
> 
> Updates `docs/INSTALL.md` with an upfront callout pointing users without an existing cluster to the standalone installer, while keeping the rest of the Helm-based production install instructions unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f10e8d4e0b3366036635147b60a522325f1701d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->