### PR TITLE
ci: add FR-pass comment + FR gate callers

### DIFF
--- a/.github/workflows/fr-gate-caller.yml
+++ b/.github/workflows/fr-gate-caller.yml
@@ -1,0 +1,15 @@
+name: FR gate
+
+# Per-repo caller. Blocks merges to staging/main/master unless every contained
+# kanban item is in "Ready for staging" or "Ready for prod" respectively.
+# All logic lives in tracebloc/.github/.github/workflows/fr-gate.yml.
+
+on:
+  pull_request:
+    branches: [staging, main, master]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+
+jobs:
+  gate:
+    uses: tracebloc/.github/.github/workflows/fr-gate.yml@main
+    secrets: inherit

--- a/.github/workflows/fr-pass-comment-caller.yml
+++ b/.github/workflows/fr-pass-comment-caller.yml
@@ -1,0 +1,14 @@
+name: FR pass comment
+
+# Per-repo caller. Listens for /fr-pass comments and advances kanban items
+# from "FR on dev" → "Ready for staging" or "FR on staging" → "Ready for prod".
+# All logic lives in tracebloc/.github/.github/workflows/fr-pass-comment.yml.
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  advance:
+    uses: tracebloc/.github/.github/workflows/fr-pass-comment.yml@main
+    secrets: inherit


### PR DESCRIPTION
Adds two thin caller workflows for the multi-stage FR flow:

- `fr-pass-comment-caller.yml` — listens for `/fr-pass` PR comments and advances kanban items one column.
- `fr-gate-caller.yml` — blocks merges to staging/main/master unless contained items are in `Ready for staging` / `Ready for prod`.

All logic lives in `tracebloc/.github/.github/workflows/`. The callers just subscribe this repo to the central reusables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
