### PR TITLE
ci: bootstrap FR-flow callers on main

### DIFF
--- a/.github/workflows/fr-gate-caller.yml
+++ b/.github/workflows/fr-gate-caller.yml
@@ -1,0 +1,15 @@
+name: FR gate
+
+# Per-repo caller. Blocks merges to staging/main/master unless every contained
+# kanban item is in "Ready for staging" or "Ready for prod" respectively.
+# All logic lives in tracebloc/.github/.github/workflows/fr-gate.yml.
+
+on:
+  pull_request:
+    branches: [staging, main, master]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+
+jobs:
+  gate:
+    uses: tracebloc/.github/.github/workflows/fr-gate.yml@main
+    secrets: inherit

--- a/.github/workflows/fr-pass-comment-caller.yml
+++ b/.github/workflows/fr-pass-comment-caller.yml
@@ -1,0 +1,14 @@
+name: FR pass comment
+
+# Per-repo caller. Listens for /fr-pass comments and advances kanban items
+# from "FR on dev" → "Ready for staging" or "FR on staging" → "Ready for prod".
+# All logic lives in tracebloc/.github/.github/workflows/fr-pass-comment.yml.
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  advance:
+    uses: tracebloc/.github/.github/workflows/fr-pass-comment.yml@main
+    secrets: inherit


### PR DESCRIPTION
Bootstrap commit: copies the FR-flow callers onto the protected branch so the FR gate activates on PRs targeting it.

After this lands, opening any PR to this branch will trigger `fr-gate-caller.yml`, which checks that contained items are in `Ready for prod` (or `Ready for staging` for staging-target PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
