### PR TITLE
chore(auto-upgrade): run cronjob hourly at :23

### DIFF
--- a/client/tests/auto_upgrade_test.yaml
+++ b/client/tests/auto_upgrade_test.yaml
@@ -77,7 +77,7 @@ tests:
           value: stg-auto-upgrade
       - equal:
           path: spec.schedule
-          value: "23 2 * * *"
+          value: "23 * * * *"
       - equal:
           path: spec.concurrencyPolicy
           value: Forbid

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -325,9 +325,9 @@ autoUpgrade:
   # Default ON: the entire point of #69 is that customers freeze on the
   # version they installed. Defaulting off would recreate that exact bug.
   enabled: true
-  # Daily at 02:23 UTC. The off-hour minute spreads load across the
+  # Hourly at :23. The off-hour minute spreads load across the
   # tracebloc.github.io/client GitHub Pages origin.
-  schedule: "23 2 * * *"
+  schedule: "23 * * * *"
   # Helm chart repo to poll. Override only when mirroring internally.
   repoUrl: "https://tracebloc.github.io/client"
   repoName: "tracebloc"


### PR DESCRIPTION
## Summary
- Switches default `autoUpgrade.schedule` from `"23 2 * * *"` (daily 02:23 UTC) to `"23 * * * *"` (hourly at :23) so deployed clients converge on the latest chart within ~1h instead of ~24h.
- Companion PR will cherry-pick this single commit onto a branch off `main` so prod gets only this change without pulling unshipped `develop` commits along with it.

Closes #111 (dev side — the prod-side PR will reference the same ticket).

## Test plan
- [ ] `helm template ... | grep -A1 schedule:` shows `23 * * * *` on a fresh render
- [ ] `client/tests/auto_upgrade_test.yaml` still passes (`helm unittest client/`)
- [ ] After deploy, `kubectl get cronjob -n <ns> -l app.kubernetes.io/component=auto-upgrade` shows the hourly schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the default `CronJob` schedule and its unit test expectation, with no changes to the upgrade logic itself. The main impact is increased upgrade/check frequency (more cluster activity and repo polling).
> 
> **Overview**
> Switches the default `autoUpgrade.schedule` from daily `"23 2 * * *"` to hourly `"23 * * * *"`, so the self-upgrade `CronJob` checks/applies chart updates up to once per hour.
> 
> Updates the Helm unittest (`client/tests/auto_upgrade_test.yaml`) to assert the new default schedule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66252c7dc806e4317e78a08215dd25a17d1416fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->