### PR TITLE
chore(auto-upgrade): run cronjob hourly at :23 (prod cherry-pick)

### DIFF
--- a/client/tests/auto_upgrade_test.yaml
+++ b/client/tests/auto_upgrade_test.yaml
@@ -77,7 +77,7 @@ tests:
           value: stg-auto-upgrade
       - equal:
           path: spec.schedule
-          value: "23 2 * * *"
+          value: "23 * * * *"
       - equal:
           path: spec.concurrencyPolicy
           value: Forbid

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -309,9 +309,9 @@ autoUpgrade:
   # Default ON: the entire point of #69 is that customers freeze on the
   # version they installed. Defaulting off would recreate that exact bug.
   enabled: true
-  # Daily at 02:23 UTC. The off-hour minute spreads load across the
+  # Hourly at :23. The off-hour minute spreads load across the
   # tracebloc.github.io/client GitHub Pages origin.
-  schedule: "23 2 * * *"
+  schedule: "23 * * * *"
   # Helm chart repo to poll. Override only when mirroring internally.
   repoUrl: "https://tracebloc.github.io/client"
   repoName: "tracebloc"


### PR DESCRIPTION
## Summary
- Cherry-pick of the same commit on [#112](https://github.com/tracebloc/client/pull/112) (dev-side), branched off `main` so this PR contains **only** the schedule change — no other unshipped `develop` commits ride along.
- Switches default `autoUpgrade.schedule` from `"23 2 * * *"` (daily 02:23 UTC) to `"23 * * * *"` (hourly at :23) so deployed clients converge on the latest chart within ~1h instead of ~24h.

Refs #111. Merge alongside #112; either order is fine since both PRs carry the same single-file change.

## Test plan
- [ ] Confirm diff vs `main` is exactly the 2-line `schedule:` change in `client/values.yaml`
- [ ] `helm template ... | grep -A1 schedule:` renders `23 * * * *`
- [ ] `client/tests/auto_upgrade_test.yaml` passes (`helm unittest client/`)
- [ ] Post-deploy: `kubectl get cronjob -n <ns> -l app.kubernetes.io/component=auto-upgrade` shows hourly schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default self-upgrade CronJob cadence from daily to hourly, increasing how often clusters run a `helm upgrade` with cluster-admin privileges and how quickly any bad chart release could roll out.
> 
> **Overview**
> Updates the default `autoUpgrade.schedule` from daily `"23 2 * * *"` to hourly `"23 * * * *"`, so deployed clients check for and apply chart upgrades within ~1 hour instead of ~24 hours.
> 
> Adjusts the Helm unittest (`client/tests/auto_upgrade_test.yaml`) to assert the new rendered CronJob schedule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cafaf2720f0bb71d03790ba8b586de120c8d9139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->