### PR TITLE
chore(client): bump chart 1.3.1 -> 1.3.2 (hourly auto-upgrade)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.3.1
-appVersion: "1.3.1"
+version: 1.3.2
+appVersion: "1.3.2"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/MIGRATION.md
+++ b/client/MIGRATION.md
@@ -5,10 +5,15 @@ This guide explains how to migrate from the legacy per-platform charts (`aks/`, 
 ## Upgrading to 1.3.0 — self-upgrade CronJob lands on by default
 
 Releases of 1.3.0+ install a `<release>-auto-upgrade` CronJob that polls
-`https://tracebloc.github.io/client` daily and runs
+`https://tracebloc.github.io/client` and runs
 `helm upgrade --reset-then-reuse-values` when a newer chart version is
 published. This closes [tracebloc/client#69](https://github.com/tracebloc/client/issues/69) —
 older deployed clients stop drifting from the latest secure / stable release.
+
+The default cadence is **hourly at :23 UTC** as of 1.3.2 (was daily at 02:23
+UTC in 1.3.0 / 1.3.1). The off-hour minute spreads load across the
+`tracebloc.github.io/client` GitHub Pages origin. Operators who want a
+different schedule can override `autoUpgrade.schedule`.
 
 > **Verified end-to-end on `tb-client-dev-templates` during the 1.3.1 release**:
 > a `tracebloc` release at 1.3.0 self-upgraded to 1.3.1 within a single


### PR DESCRIPTION
## Summary
- Bumps `client/Chart.yaml` `version` and `appVersion` from `1.3.1` → `1.3.2`.
- Updates `client/MIGRATION.md` to reflect the new auto-upgrade cadence (hourly at :23 UTC) shipped in #113.
- After merge, tagging `v1.3.2` on the resulting `main` commit triggers `release-helm-chart.yaml`, which packages the chart and publishes to gh-pages so `https://tracebloc.github.io/client` serves 1.3.2.

This is the prod-side bump. A companion PR mirrors the same change onto `develop` so dev does not drift backwards relative to main.

Refs #111.

## Test plan
- [x] `helm lint --strict ./client -f client/ci/eks-values.yaml` clean
- [x] `helm unittest client/` — 116/116 pass at 1.3.2
- [ ] After merge, tag `v1.3.2` and confirm `release-helm-chart.yaml` publishes the new `.tgz` to gh-pages
- [ ] After publish, observe a 1.3.1 client self-upgrade to 1.3.2 within an hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)