### PR TITLE
chore(client): bump chart 1.3.1 -> 1.3.2 (develop sync)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.3.1
-appVersion: "1.3.1"
+version: 1.3.2
+appVersion: "1.3.2"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/MIGRATION.md
+++ b/client/MIGRATION.md
@@ -5,10 +5,15 @@ This guide explains how to migrate from the legacy per-platform charts (`aks/`, 
 ## Upgrading to 1.3.0 — self-upgrade CronJob lands on by default
 
 Releases of 1.3.0+ install a `<release>-auto-upgrade` CronJob that polls
-`https://tracebloc.github.io/client` daily and runs
+`https://tracebloc.github.io/client` and runs
 `helm upgrade --reset-then-reuse-values` when a newer chart version is
 published. This closes [tracebloc/client#69](https://github.com/tracebloc/client/issues/69) —
 older deployed clients stop drifting from the latest secure / stable release.
+
+The default cadence is **hourly at :23 UTC** as of 1.3.2 (was daily at 02:23
+UTC in 1.3.0 / 1.3.1). The off-hour minute spreads load across the
+`tracebloc.github.io/client` GitHub Pages origin. Operators who want a
+different schedule can override `autoUpgrade.schedule`.
 
 > **Verified end-to-end on `tb-client-dev-templates` during the 1.3.1 release**:
 > a `tracebloc` release at 1.3.0 self-upgraded to 1.3.1 within a single


### PR DESCRIPTION
## Summary
- Cherry-pick of [#114](https://github.com/tracebloc/client/pull/114) onto `develop` so the dev branch tracks the chart version published from `main`.
- Same single commit as the prod-side bump: `client/Chart.yaml` 1.3.1→1.3.2 and the matching `MIGRATION.md` cadence note.

The actual release tag (`v1.3.2`) is cut from `main` after #114 merges; this PR exists purely to keep `develop`'s `Chart.yaml` from drifting backwards.

Refs #111.

## Test plan
- [x] `helm lint --strict ./client -f client/ci/eks-values.yaml` clean
- [x] `helm unittest client/` — 116/116 pass at 1.3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)