### PR TITLE
Add MySQL Host to request proxy yaml file

### DIFF
--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -61,6 +61,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-requests-proxy-admin
                   key: token
+            - name: MYSQL_HOST
+              value: "mysql-client"
             - name: EXPERIMENTS_QUEUE_NAME
               value: "experiments"
             - name: FLOPS_QUEUE_NAME


### PR DESCRIPTION
## Summary
Adds `MYSQL_HOST=mysql-client` to the `requests-proxy` Deployment template so the container has an explicit MySQL host configured at runtime. Previously the host was either hardcoded in the image or falling back to a default, which made it implicit and cluster-specific.

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
Deployed to cluster; requests-proxy pod started cleanly and connected to `mysql-client` without errors.

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [x] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested