### PR TITLE
Add request proxy url to jobs manager yaml file

### DIFF
--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -73,6 +73,8 @@ spec:
           value: {{ include "tracebloc.clientLogsPvc" . | quote }}
         - name: MYSQL_HOST
           value: "mysql-client"
+        - name: REQUESTS_PROXY_URL
+          value: "http://requests-proxy-service:8888"
         - name: JOB_IMAGE_HOST
           value: "docker.io/"
         - name: CLIENT_ENV


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm template change that only adds a new environment variable to the `jobs-manager` container; main risk is misconfiguration if the service URL is wrong or unavailable at runtime.
> 
> **Overview**
> Adds `REQUESTS_PROXY_URL` (set to `http://requests-proxy-service:8888`) to the `jobs-manager` Deployment Helm template so the manager can be configured to reach the requests-proxy service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 273835a9144d91e14deb497ec8d737089dbc1bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->