### PR TITLE
Remove REQUESTS_PROXY_ADMIN_TOKEN

### DIFF
--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -62,11 +62,6 @@ spec:
             secretKeyRef:
               name: {{ include "tracebloc.secretName" . }}
               key: CLIENT_PASSWORD
-        - name: REQUESTS_PROXY_ADMIN_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-requests-proxy-admin
-              key: token
         - name: CLIENT_PVC
           value: {{ include "tracebloc.clientDataPvc" . | quote }}
         - name: CLIENT_LOGS_PVC

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -56,11 +56,6 @@ spec:
               cpu: {{ .Values.resources.requestsProxy.limits.cpu | default "500m" | quote }}
               memory: {{ .Values.resources.requestsProxy.limits.memory | default "512Mi" | quote }}
           env:
-            - name: REQUESTS_PROXY_ADMIN_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Release.Name }}-requests-proxy-admin
-                  key: token
             - name: MYSQL_HOST
               value: "mysql-client"
             - name: EXPERIMENTS_QUEUE_NAME

--- a/client/templates/secrets.yaml
+++ b/client/templates/secrets.yaml
@@ -13,27 +13,6 @@ type: Opaque
 data:
   CLIENT_ID: {{ $clientId | b64enc | quote }}
   CLIENT_PASSWORD: {{ $clientPassword | b64enc | quote }}
----
-{{ $proxySecretName := printf "%s-requests-proxy-admin" .Release.Name -}}
-{{- $existingProxySecret := lookup "v1" "Secret" .Release.Namespace $proxySecretName -}}
-{{- $proxyAdminToken := "" -}}
-{{- if .Values.requestsProxyAdminToken -}}
-{{- $proxyAdminToken = .Values.requestsProxyAdminToken -}}
-{{- else if and $existingProxySecret $existingProxySecret.data (index $existingProxySecret.data "token") -}}
-{{- $proxyAdminToken = index $existingProxySecret.data "token" | b64dec -}}
-{{- else -}}
-{{- $proxyAdminToken = randAlphaNum 64 -}}
-{{- end -}}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ $proxySecretName }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "tracebloc.labels" . | nindent 4 }}
-type: Opaque
-data:
-  token: {{ $proxyAdminToken | b64enc | quote }}
 {{- if and (ne .Values.resourceMonitor false) (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
 ---
 # Mirrored into the node-agents namespace so the resource-monitor DaemonSet

--- a/client/tests/node_agents_namespace_test.yaml
+++ b/client/tests/node_agents_namespace_test.yaml
@@ -186,7 +186,7 @@ tests:
     template: templates/secrets.yaml
     asserts:
       - hasDocuments:
-          count: 3
+          count: 2
       - isKind:
           of: Secret
         documentIndex: 0
@@ -196,21 +196,21 @@ tests:
         documentIndex: 0
       - isKind:
           of: Secret
-        documentIndex: 2
+        documentIndex: 1
       - equal:
           path: metadata.namespace
           value: tracebloc-node-agents
-        documentIndex: 2
+        documentIndex: 1
       - equal:
           path: metadata.name
           value: RELEASE-NAME-secrets
-        documentIndex: 2
+        documentIndex: 1
       - isNotEmpty:
           path: data.CLIENT_ID
-        documentIndex: 2
+        documentIndex: 1
       - isNotEmpty:
           path: data.CLIENT_PASSWORD
-        documentIndex: 2
+        documentIndex: 1
 
   - it: should not mirror the tracebloc Secret when resourceMonitor is disabled
     template: templates/secrets.yaml
@@ -218,7 +218,7 @@ tests:
       resourceMonitor: false
     asserts:
       - hasDocuments:
-          count: 2
+          count: 1
       - equal:
           path: metadata.namespace
           value: tracebloc-templates
@@ -233,7 +233,7 @@ tests:
           name: tracebloc-templates
     asserts:
       - hasDocuments:
-          count: 2
+          count: 1
       - equal:
           path: metadata.namespace
           value: tracebloc-templates

--- a/client/tests/secrets_test.yaml
+++ b/client/tests/secrets_test.yaml
@@ -31,36 +31,6 @@ tests:
           pattern: Helm
         documentIndex: 0
 
-  - it: should use explicit requests-proxy admin token override
-    template: templates/secrets.yaml
-    set:
-      clientId: "my-client-id"
-      clientPassword: "my-secret-pass"
-      requestsProxyAdminToken: "override-token"
-    asserts:
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-requests-proxy-admin
-        documentIndex: 1
-      - equal:
-          path: data.token
-          value: b3ZlcnJpZGUtdG9rZW4=
-        documentIndex: 1
-
-  - it: should generate requests-proxy admin token when no override is provided
-    template: templates/secrets.yaml
-    set:
-      clientId: "my-client-id"
-      clientPassword: "my-secret-pass"
-    asserts:
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-requests-proxy-admin
-        documentIndex: 1
-      - isNotEmpty:
-          path: data.token
-        documentIndex: 1
-
   - it: should create docker registry secret when create is true
     template: templates/docker-registry-secret.yaml
     set:

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -456,10 +456,6 @@
       "not": { "pattern": "^<.*>$" },
       "description": "Client authentication password. Must be a real value, not a placeholder like <CLIENT_PASSWORD>."
     },
-    "requestsProxyAdminToken": {
-      "type": "string",
-      "description": "Optional admin token override for the requests-proxy service."
-    },
     "autoUpgrade": {
       "type": "object",
       "description": "Self-upgrade CronJob (issue tracebloc/client#69). Polls the helm repo at autoUpgrade.repoUrl daily and runs `helm upgrade --reuse-values` when a newer chart version is published. Disable to keep the release pinned to its install-time chart version.",

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -276,13 +276,6 @@ podDisruptionBudget:
 clientId: ""
 clientPassword: ""
 
-# -- Admin token for the requests-proxy service.
-# Optional. If set, this value overrides any existing requests-proxy admin
-# secret on install or upgrade. When left empty, the chart reuses the current
-# secret if present or generates a new token on first install.
-# Do NOT commit real tokens to version control.
-requestsProxyAdminToken: ""
-
 # -- Docker registry credentials (optional; only used when dockerRegistry is set and create is true)
 # Omit dockerRegistry entirely, or set create: false, for public images (no imagePullSecrets).
 # When create is true, secret name is {{ .Release.Name }}-regcred.


### PR DESCRIPTION
## Summary
Removes `REQUESTS_PROXY_ADMIN_TOKEN` — a Kubernetes Secret, env var injection, and chart value that were never consumed by any runtime code. The requests-proxy server has no admin HTTP API (only pod-facing `/v1/result` and `/v1/flops` routes); token validation is handled via per-job Bearer tokens from MySQL. The jobs-manager similarly never reads this env var.

## Related
Ref tracebloc/client-runtime#33

## Type of change
- [x] Tech-debt / refactor
- [x] Security / hardening

## Test plan
- `helm unittest client/` — 116/116 passing (updated document-count assertions in `node_agents_namespace_test.yaml` to reflect the removed secret)
- Verified in `tracebloc/client-runtime` that `requests_proxy_server.py` and `jobs_manager.py` have no references to `REQUESTS_PROXY_ADMIN_TOKEN`

## Deployment notes
The `{{ .Release.Name }}-requests-proxy-admin` Secret will no longer be created on fresh installs. On existing clusters, the orphaned Secret can be deleted manually:
```
kubectl delete secret <release-name>-requests-proxy-admin -n <namespace>
```
No rollout order dependency — neither container reads this env var.

## Checklist
- [x] Tests added / updated and passing locally
- [x] Docs updated if behavior or config changed
- [x] No secrets / credentials in the diff
- [x] For security-sensitive paths: appropriate reviewer requested