### PR TITLE
Reduce dependency on values.yaml file for requests proxy

### DIFF
--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -22,8 +22,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: proxy
-          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.requestsProxy.digest "registry" "docker.io") | quote }}
-          imagePullPolicy: {{ if .Values.images.requestsProxy.digest }}IfNotPresent{{ else }}Always{{ end }}
+          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" (dig "requestsProxy" "digest" "" .Values.images) "registry" "docker.io") | quote }}
+          imagePullPolicy: Always
           workingDir: /app
           command: ["python", "-m", "gunicorn"]
           args:
@@ -50,11 +50,11 @@ spec:
             readOnlyRootFilesystem: true
           resources:
             requests:
-              cpu: {{ .Values.resources.requestsProxy.requests.cpu | default "100m" | quote }}
-              memory: {{ .Values.resources.requestsProxy.requests.memory | default "256Mi" | quote }}
+              cpu: 100m
+              memory: 256Mi
             limits:
-              cpu: {{ .Values.resources.requestsProxy.limits.cpu | default "500m" | quote }}
-              memory: {{ .Values.resources.requestsProxy.limits.memory | default "512Mi" | quote }}
+              cpu: 1000m
+              memory: 512Mi
           env:
             - name: MYSQL_HOST
               value: "mysql-client"

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -232,13 +232,6 @@ resources:
     limits:
       cpu: "500m"
       memory: "512Mi"
-  requestsProxy:
-    requests:
-      cpu: "100m"
-      memory: "256Mi"
-    limits:
-      cpu: "500m"
-      memory: "512Mi"
 
 # -- PriorityClass for the data-plane (mysql).
 # Cluster-scoped resource. Created with helm.sh/resource-policy: keep so a


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `requests-proxy` deployment defaults by hardcoding CPU/memory and forcing `imagePullPolicy: Always`, which can affect scheduling and rollout/pull behavior across clusters.
> 
> **Overview**
> `requests-proxy`’s Helm template now **hardcodes** its CPU/memory requests+limits and sets `imagePullPolicy: Always`, rather than reading resource settings (or pull policy) from `values.yaml`.
> 
> The image digest lookup is also made more defensive by using `dig "requestsProxy" "digest"` against `.Values.images`, and the `resources.requestsProxy` block is removed from `client/values.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60387e11f6dd84b23ecbe1b817c96eb43c2edd1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->