### PR TITLE
feat(#86): ingestor Helm subchart + companion RBAC/service/authz for new ingestion endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,11 @@ venv.bak/
 /values*.yaml
 /*/values*.yaml
 !client/values*.yaml
+# The ingestor subchart's values.yaml is part of the chart shipped to
+# customers — must be tracked despite matching the `/*/values*.yaml`
+# anti-leak pattern above (which exists to keep operator-local values
+# files out of the repo).
+!ingestor/values.yaml
 secret-values.yaml
 test-template.yaml
 eks.diff

--- a/client/templates/ingestion-authz-configmap.yaml
+++ b/client/templates/ingestion-authz-configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # client-runtime#21: defines which ServiceAccount(s) may call
+  # POST /internal/submit-ingestion-run on jobs-manager, scoped to which
+  # tables. Mounted into jobs-manager at /etc/tracebloc/ingestion-authz.yaml
+  # and read at startup (see submit_ingestion_run.load_authz_policy).
+  #
+  # Each entry in `ingestionAuthz.allowed` maps a (namespace, service_account)
+  # to a list of table-name prefixes. Omit `namespace` to default to the
+  # release's namespace — the common case where the ingestor subchart is
+  # installed alongside the tracebloc client.
+  name: {{ .Release.Name }}-ingestion-authz
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+data:
+  ingestion-authz.yaml: |
+    allowed:
+    {{- range .Values.ingestionAuthz.allowed }}
+      - service_account: {{ .service_account | quote }}
+        namespace: {{ .namespace | default $.Release.Namespace | quote }}
+        table_prefixes:
+        {{- range .table_prefixes }}
+          - {{ . | quote }}
+        {{- end }}
+    {{- end }}

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -46,11 +46,25 @@ spec:
           limits:
             cpu: {{ .Values.resources.jobsManager.limits.cpu | default "1000m" | quote }}
             memory: {{ .Values.resources.jobsManager.limits.memory | default "1Gi" | quote }}
+        ports:
+          # client-runtime#21: POST /internal/submit-ingestion-run. The
+          # ingestor subchart's post-install hook hits this through the
+          # jobs-manager Service. Cluster-internal only.
+          - name: http
+            containerPort: 8080
+            protocol: TCP
         volumeMounts:
           - name: shared-volume
             mountPath: "/data/shared"
           - name: logs-volume
             mountPath: "/data/logs"
+          # ingestion-authz policy read by jobs-manager at startup. The
+          # subPath mount means an authz update via `helm upgrade` is
+          # picked up on the next jobs-manager restart, not hot-reloaded.
+          - name: ingestion-authz
+            mountPath: /etc/tracebloc/ingestion-authz.yaml
+            subPath: ingestion-authz.yaml
+            readOnly: true
         env:
         - name: CLIENT_ID
           valueFrom:
@@ -151,4 +165,7 @@ spec:
         - name: logs-volume
           persistentVolumeClaim:
             claimName: {{ include "tracebloc.clientLogsPvc" . }}
+        - name: ingestion-authz
+          configMap:
+            name: {{ .Release.Name }}-ingestion-authz
       restartPolicy: Always

--- a/client/templates/jobs-manager-service.yaml
+++ b/client/templates/jobs-manager-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # client-runtime#21: exposes jobs-manager's HTTP ingestion endpoint
+  # (POST /internal/submit-ingestion-run) at a stable in-cluster name so
+  # the ingestor subchart's post-install hook (tracebloc/client#86) can
+  # POST without discovering Pod IPs. ClusterIP-only — there is no
+  # legitimate caller outside the cluster.
+  name: jobs-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app: manager
+spec:
+  selector:
+    app: manager
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  type: ClusterIP

--- a/client/templates/rbac.yaml
+++ b/client/templates/rbac.yaml
@@ -30,6 +30,21 @@ rules:
   - apiGroups: ["metrics.k8s.io"]
     resources: ["pods"]
     verbs: ["get", "list"]
+  # client-runtime#21: jobs-manager's POST /internal/submit-ingestion-run
+  # endpoint authenticates callers (the ingestor subchart's post-install
+  # hook) via TokenReview, then creates a per-run ConfigMap (ingest.yaml)
+  # and Secret (BACKEND_TOKEN) before spawning the ingestor Job.
+  #
+  # TokenReview is a cluster-scoped Kubernetes API; the create verb cannot
+  # be granted by a namespace Role. This means the ingestion endpoint
+  # requires ``clusterScope: true``. The else branch below intentionally
+  # omits it.
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -73,6 +88,14 @@ rules:
   - apiGroups: ["metrics.k8s.io"]
     resources: ["pods"]
     verbs: ["get", "list"]
+  # client-runtime#21: ingestion endpoint creates a per-run ConfigMap
+  # (ingest.yaml) and Secret (BACKEND_TOKEN) before spawning the Job.
+  # TokenReview is omitted here (cluster-scoped API; not grantable by a
+  # namespace Role). Customers using clusterScope: false won't be able
+  # to authenticate ingestion calls — see the ClusterRole branch above.
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -341,3 +341,29 @@ autoUpgrade:
     limits:
       cpu: "500m"
       memory: "256Mi"
+
+# ============================================================
+# Ingestion endpoint authorization (client-runtime#21)
+# ============================================================
+# jobs-manager's POST /internal/submit-ingestion-run authenticates callers
+# via Kubernetes TokenReview, then authorizes against this policy. Mapping
+# is (namespace, service_account) → list of allowed table-name prefixes;
+# "*" means any table.
+#
+# Default: allow the ingestor subchart's SA (named after that release) to
+# ingest into any table. Customers tighten via overrides — e.g.:
+#
+#   ingestionAuthz:
+#     allowed:
+#       - service_account: my-dataset-ingestor
+#         namespace: tracebloc
+#         table_prefixes: ["chest_xrays_", "tumors_"]
+ingestionAuthz:
+  allowed:
+    # Default: the ingestor subchart's SA (named "ingestor") in the same
+    # namespace as the tracebloc release can ingest into any table. The
+    # `namespace` field is optional; when omitted the ConfigMap template
+    # substitutes `.Release.Namespace`. Customers tighten by adding more
+    # specific entries with explicit `namespace` and `table_prefixes`.
+    - service_account: ingestor
+      table_prefixes: ["*"]

--- a/ingestor/.helmignore
+++ b/ingestor/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building chart packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/ingestor/Chart.yaml
+++ b/ingestor/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: ingestor
+description: |
+  Helm chart for submitting a tracebloc data-ingestion run. Renders a
+  customer's ingest.yaml into a ConfigMap and runs a post-install hook
+  that POSTs it to jobs-manager's /internal/submit-ingestion-run.
+  jobs-manager validates the YAML, mints a backend token, and creates
+  the ingestor Job directly — this chart owns the config + hook
+  artifacts, not the resulting Job or its data.
+type: application
+version: 0.1.0
+appVersion: "0.3.0-rc1"
+keywords:
+  - tracebloc
+  - kubernetes
+  - data-ingestion
+home: https://github.com/tracebloc/client/tree/develop/ingestor
+sources:
+  - https://github.com/tracebloc/client
+  - https://github.com/tracebloc/data-ingestors
+  - https://github.com/tracebloc/client-runtime
+maintainers:
+  - name: tracebloc
+    email: support@tracebloc.io

--- a/ingestor/README.md
+++ b/ingestor/README.md
@@ -1,0 +1,88 @@
+# tracebloc/ingestor Helm chart
+
+A thin chart that submits one data-ingestion run to your tracebloc client cluster. Wraps the `POST /internal/submit-ingestion-run` endpoint on jobs-manager (client-runtime#21) so the customer-facing UX is:
+
+```bash
+helm install my-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./my-ingest.yaml \
+  --set image.digest=sha256:<digest>
+```
+
+## What this chart owns
+
+| Resource | Owner | Lifecycle |
+|---|---|---|
+| `ConfigMap/<release>-config` (holds `ingest.yaml`) | this chart | created by `helm install`, deleted by `helm uninstall` |
+| `Job/<release>-submit` (post-install hook that POSTs) | this chart | created post-install, removed before each `helm upgrade` |
+| `ServiceAccount/<serviceAccount.name>` | this chart (optional, default true) | created by `helm install`, deleted by `helm uninstall` |
+| `ConfigMap/ingest-config-<hash>` (per-run, mounted into the ingestor Pod) | **jobs-manager** | created by jobs-manager on accept; not managed by Helm |
+| `Secret/ingest-token-<hash>` (per-run, holds `BACKEND_TOKEN`) | **jobs-manager** | same |
+| `Job/ingest-job-<hash>` (the actual ingestor) | **jobs-manager** | same |
+| **Ingested data** (rows in cluster-internal MySQL + metadata POSTed to the backend) | **the cluster** | persists past `helm uninstall` |
+
+**`helm uninstall my-dataset` will not delete the running ingestor Job or any ingested data.** It removes only the config + hook artifacts above. Document this with operators so they don't expect uninstall to act as a "cancel ingestion" button.
+
+## How the install works end-to-end
+
+1. `helm install` renders `ConfigMap/<release>-config` containing the customer's `ingest.yaml` body.
+2. Helm fires the `post-install` hook: a Job that runs as the chart's ServiceAccount.
+3. The hook reads its SA token from the projected volume and the `ingest.yaml` from the ConfigMap mount.
+4. The hook POSTs `{ ingest_config, idempotency_key, image_digest }` to `jobs-manager:8080/internal/submit-ingestion-run`.
+5. **jobs-manager** validates the SA token via Kubernetes TokenReview, then checks the (SA, table) pair against the cluster's `ingestionAuthz` policy (a ConfigMap rendered by the parent `tracebloc/client` chart).
+6. If authorized, jobs-manager validates the YAML against the `ingest.v1` JSON schema, mints a backend token, creates the per-run ConfigMap + Secret + Job, records the run for idempotency, and returns `201` (or `200` if this idempotency_key has been seen before).
+7. The hook treats `2xx` as success and exits 0; `helm install` reports success. Non-`2xx` exits 1 and `helm install` fails with the response body in the output.
+
+The customer never builds an image. The customer never writes a Dockerfile. The customer writes ~8 lines of YAML.
+
+## Required values
+
+| Value | Description |
+|---|---|
+| `ingestConfig` | The full `ingest.yaml` body. **Set via `--set-file`** — the body almost always contains YAML special characters that don't survive `--set`. |
+| `image.digest` | A `sha256:<64-hex>` digest of a `ghcr.io/tracebloc/ingestor` release. Tags are rejected by jobs-manager. See the [data-ingestors releases page](https://github.com/tracebloc/data-ingestors/releases) for current digests. |
+
+## Frequently-overridden values
+
+| Value | Default | When to override |
+|---|---|---|
+| `jobsManager.endpoint` | `http://jobs-manager.tracebloc.svc.cluster.local:8080` | The parent `tracebloc/client` release isn't in the `tracebloc` namespace, or you're testing against a port-forward. |
+| `serviceAccount.name` | `ingestor` | The cluster's `ingestionAuthz` policy expects a different SA name. (Default matches the parent chart's default.) |
+| `image.repository` | `ghcr.io/tracebloc/ingestor` | Air-gapped mirror. |
+| `idempotencyKey` | `<release>-<revision>` | You want strict at-most-once semantics across re-installs under the same release name. |
+| `hookTimeoutSeconds` | `30` | Slow networks or large schemas. |
+
+See `values.yaml` for the full set.
+
+## Verifying after install
+
+```bash
+# Helm-side artifacts (this chart's footprint):
+kubectl -n tracebloc get configmap,job,serviceaccount -l app.kubernetes.io/instance=my-dataset
+
+# jobs-manager-side artifacts (the actual run):
+kubectl -n tracebloc get jobs -l tracebloc.io/ingestion-run
+
+# Watch the ingestion run progress:
+kubectl -n tracebloc logs -l tracebloc.io/ingestion-run --tail=-1
+```
+
+## Uninstalling
+
+```bash
+helm uninstall my-dataset --namespace tracebloc
+```
+
+Removes the chart's ConfigMap + hook Job + ServiceAccount. Does **not** remove the running ingestor Job, its outputs, or the metadata posted to the backend — those are owned by jobs-manager and the cluster respectively.
+
+To cancel an in-flight run, work with jobs-manager directly:
+
+```bash
+kubectl -n tracebloc delete job -l tracebloc.io/ingestion-run=<key>
+```
+
+## Related
+
+- [tracebloc/data-ingestors](https://github.com/tracebloc/data-ingestors) — the ingestor image and YAML schema.
+- [tracebloc/client-runtime#21](https://github.com/tracebloc/client-runtime/pull/35) — the `submit-ingestion-run` endpoint this chart calls.
+- [tracebloc/client](https://github.com/tracebloc/client) — the parent chart that runs jobs-manager and renders the `ingestionAuthz` policy.

--- a/ingestor/templates/_helpers.tpl
+++ b/ingestor/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{- /*
+Shared template helpers for the tracebloc/ingestor chart.
+
+Naming:
+  {release}-config  — ConfigMap holding the ingest.yaml the post-install
+                      hook reads + POSTs.
+  {release}-submit  — Job that runs the helm post-install hook (the POST).
+                      Resulting ingestor Job created by jobs-manager has
+                      its own name (idempotency-key-derived) and is NOT
+                      managed by this chart.
+*/ -}}
+
+{{- define "ingestor.fullname" -}}
+{{ .Release.Name }}
+{{- end -}}
+
+{{- define "ingestor.configMapName" -}}
+{{ .Release.Name }}-config
+{{- end -}}
+
+{{- define "ingestor.hookJobName" -}}
+{{ .Release.Name }}-submit
+{{- end -}}
+
+{{- define "ingestor.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ .Values.serviceAccount.name }}
+{{- else -}}
+{{ .Values.serviceAccount.name | required "serviceAccount.name is required when serviceAccount.create=false" }}
+{{- end -}}
+{{- end -}}
+
+{{- /*
+Resolved idempotency key. Defaults to "<release>-<revision>" so each
+helm install / upgrade submits a fresh run; explicit override is
+honored verbatim.
+*/ -}}
+{{- define "ingestor.idempotencyKey" -}}
+{{- if .Values.idempotencyKey -}}
+{{ .Values.idempotencyKey }}
+{{- else -}}
+{{ printf "%s-%d" .Release.Name .Release.Revision }}
+{{- end -}}
+{{- end -}}
+
+{{- define "ingestor.labels" -}}
+app.kubernetes.io/name: ingestor
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+{{- end -}}

--- a/ingestor/templates/configmap-ingest-config.yaml
+++ b/ingestor/templates/configmap-ingest-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # Holds the customer's ingest.yaml between `helm install` rendering and
+  # the post-install hook's POST. Created by Helm; removed on Helm
+  # uninstall. The resulting ingestor Job (created by jobs-manager) does
+  # NOT depend on this ConfigMap — jobs-manager creates its own
+  # per-Job-named ConfigMap before spawning the Job — so deleting this
+  # one mid-run does not interrupt ingestion.
+  name: {{ include "ingestor.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ingestor.labels" . | nindent 4 }}
+  annotations:
+    # Hook ordering: this ConfigMap must exist before the post-install
+    # hook Job mounts it. helm.sh/hook-weight orders sibling hook
+    # resources; lower runs first.
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    # Survive delete via "before-hook-creation" semantics: a re-install
+    # under the same release re-creates the CM cleanly. We don't keep it
+    # around after uninstall — Helm's default lifecycle removes it.
+data:
+  ingest.yaml: |-
+    {{ required "ingestConfig must be set (use --set-file ingestConfig=path/to/ingest.yaml)" .Values.ingestConfig | nindent 4 }}

--- a/ingestor/templates/configmap-ingest-config.yaml
+++ b/ingestor/templates/configmap-ingest-config.yaml
@@ -1,12 +1,17 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  # Holds the customer's ingest.yaml between `helm install` rendering and
-  # the post-install hook's POST. Created by Helm; removed on Helm
-  # uninstall. The resulting ingestor Job (created by jobs-manager) does
-  # NOT depend on this ConfigMap — jobs-manager creates its own
-  # per-Job-named ConfigMap before spawning the Job — so deleting this
-  # one mid-run does not interrupt ingestion.
+  # Holds the customer's ingest.yaml and the pre-rendered JSON body that
+  # the post-install hook POSTs. Both keys are populated at helm-template
+  # time; the runtime hook never has to construct JSON itself, which
+  # eliminates an entire class of shell-escaping bugs (bugbot caught the
+  # original python3-based encoder).
+  #
+  # Lifecycle: created by `helm install`, removed by `helm uninstall`.
+  # The resulting ingestor Job (created by jobs-manager) does NOT depend
+  # on this ConfigMap — jobs-manager creates its own per-Job-named
+  # ConfigMap before spawning the Job — so deleting this one mid-run
+  # does not interrupt ingestion.
   name: {{ include "ingestor.configMapName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
@@ -17,9 +22,24 @@ metadata:
     # resources; lower runs first.
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "0"
-    # Survive delete via "before-hook-creation" semantics: a re-install
-    # under the same release re-creates the CM cleanly. We don't keep it
-    # around after uninstall — Helm's default lifecycle removes it.
 data:
+  # Verbatim ingest.yaml body (useful for `kubectl get cm <name> -o yaml`
+  # debugging). The left-trim action delimiter (dash inside the action
+  # braces) eats the whitespace before the action so we don't render a
+  # leading blank line into the block scalar — bugbot caught this on
+  # the first pass; without the trim, the customer's YAML got a leading
+  # "\n" prefix that block-scalar parsers tolerate but is still wrong.
   ingest.yaml: |-
-    {{ required "ingestConfig must be set (use --set-file ingestConfig=path/to/ingest.yaml)" .Values.ingestConfig | nindent 4 }}
+    {{- required "ingestConfig must be set (use --set-file ingestConfig=path/to/ingest.yaml)" .Values.ingestConfig | nindent 4 }}
+  # Pre-rendered JSON body that the post-install hook POSTs to
+  # jobs-manager. Computed at helm-template time so the hook is a
+  # one-line `curl --data-binary @body.json` — no python, no jq, no
+  # shell-escaping the multi-line YAML scalar. The required-value gates
+  # below fire here so a missing digest or ingest config fails
+  # templating (and therefore `helm install`) with a clear message
+  # before any cluster state is touched.
+  body.json: |-
+    {{- $cfg := required "ingestConfig must be set (use --set-file ingestConfig=path/to/ingest.yaml)" .Values.ingestConfig -}}
+    {{- $digest := required "image.digest must be a sha256: digest of the ghcr.io/tracebloc/ingestor image (see the data-ingestors GitHub Release for current digests)" .Values.image.digest -}}
+    {{- $key := include "ingestor.idempotencyKey" . -}}
+    {{- dict "ingest_config" $cfg "idempotency_key" $key "image_digest" $digest | toJson | nindent 4 }}

--- a/ingestor/templates/post-install-job.yaml
+++ b/ingestor/templates/post-install-job.yaml
@@ -1,0 +1,143 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # client#86: post-install hook that POSTs the ingest.yaml to
+  # jobs-manager. Hook lifecycle:
+  #
+  #   - post-install + post-upgrade fires the Job.
+  #   - hook-weight 1 ensures the ConfigMap (weight 0) is in place first.
+  #   - hook-delete-policy "before-hook-creation" cleans up the previous
+  #     Job on a re-install of the same release, so we don't trip on a
+  #     leftover completed Job. We DO NOT use "hook-succeeded" because
+  #     keeping the Job around lets operators read the POST result via
+  #     `kubectl logs` after install.
+  name: {{ include "ingestor.hookJobName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ingestor.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  backoffLimit: 0
+  # Bound: jobs-manager validates synchronously; if it hasn't responded
+  # in this window something is genuinely wrong and the install should
+  # fail loudly rather than hang.
+  activeDeadlineSeconds: {{ .Values.hookTimeoutSeconds | default 30 }}
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "ingestor.labels" . | nindent 8 }}
+    spec:
+      # The hook talks to one in-cluster endpoint with one specific SA
+      # token. Hardened defaults match the tracebloc client chart's
+      # training-pod template — non-root, all caps dropped, no API
+      # token auto-mount.
+      automountServiceAccountToken: true  # we DO need the SA token to authenticate the POST
+      serviceAccountName: {{ include "ingestor.serviceAccountName" . }}
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: submit
+          image: {{ printf "%s:%s" .Values.hookImage.repository .Values.hookImage.tag | quote }}
+          imagePullPolicy: {{ .Values.hookImage.pullPolicy | default "IfNotPresent" }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml .Values.hookResources | nindent 12 }}
+          env:
+            - name: JOBS_MANAGER_ENDPOINT
+              value: {{ .Values.jobsManager.endpoint | quote }}
+            - name: SUBMIT_PATH
+              value: {{ .Values.jobsManager.submitPath | quote }}
+            - name: IMAGE_DIGEST
+              value: {{ required "image.digest must be a sha256: digest of the ghcr.io/tracebloc/ingestor image" .Values.image.digest | quote }}
+            - name: IDEMPOTENCY_KEY
+              value: {{ include "ingestor.idempotencyKey" . | quote }}
+          command: ["/bin/sh", "-c"]
+          # The script:
+          #   1. Reads the SA token from the projected volume (k8s adds
+          #      it automatically when automountServiceAccountToken: true).
+          #   2. Reads the ingest.yaml from the mounted ConfigMap.
+          #   3. Composes the JSON body with Python (the curl image has
+          #      python3 available; jq is the alternative but adds a
+          #      JSON-escape edge case for multi-line YAML).
+          #   4. POSTs, captures HTTP status + body. Non-2xx fails the
+          #      Job, which fails the helm install with the response
+          #      body visible in the install output.
+          args:
+            - |
+              set -eu
+
+              TOKEN_PATH=/var/run/secrets/kubernetes.io/serviceaccount/token
+              INGEST_YAML=/etc/ingest/ingest.yaml
+
+              if [ ! -r "$TOKEN_PATH" ]; then
+                echo "ERROR: SA token not found at $TOKEN_PATH" >&2
+                exit 1
+              fi
+              if [ ! -r "$INGEST_YAML" ]; then
+                echo "ERROR: ingest.yaml not found at $INGEST_YAML — ConfigMap mount failed" >&2
+                exit 1
+              fi
+
+              TOKEN="$(cat "$TOKEN_PATH")"
+              INGEST_CONFIG="$(cat "$INGEST_YAML")"
+
+              # Compose the JSON body. We use python3 to handle YAML
+              # body's newlines / quotes correctly; the curlimages/curl
+              # image ships with python3.
+              BODY=$(python3 -c "
+              import json, os
+              print(json.dumps({
+                  'ingest_config': os.environ['INGEST_CONFIG'],
+                  'idempotency_key': os.environ['IDEMPOTENCY_KEY'],
+                  'image_digest': os.environ['IMAGE_DIGEST'],
+              }))
+              " INGEST_CONFIG="$INGEST_CONFIG" \
+                  IDEMPOTENCY_KEY="$IDEMPOTENCY_KEY" \
+                  IMAGE_DIGEST="$IMAGE_DIGEST")
+
+              URL="${JOBS_MANAGER_ENDPOINT}${SUBMIT_PATH}"
+              echo "POST $URL"
+              echo "  idempotency_key=$IDEMPOTENCY_KEY"
+              echo "  image_digest=$IMAGE_DIGEST"
+
+              HTTP_STATUS=$(curl -sS -o /tmp/resp.json -w "%{http_code}" \
+                --max-time {{ .Values.hookTimeoutSeconds | default 30 }} \
+                -X POST "$URL" \
+                -H "Authorization: Bearer $TOKEN" \
+                -H "Content-Type: application/json" \
+                --data-binary "$BODY")
+
+              echo "HTTP $HTTP_STATUS"
+              echo "Response:"
+              cat /tmp/resp.json
+              echo
+
+              # 200 = replay (existing run for this key); 201 = freshly
+              # created. Both are success for the customer's helm install.
+              if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
+                exit 1
+              fi
+          volumeMounts:
+            - name: ingest-config
+              mountPath: /etc/ingest
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: ingest-config
+          configMap:
+            name: {{ include "ingestor.configMapName" . }}
+        - name: tmp
+          emptyDir: {}

--- a/ingestor/templates/post-install-job.yaml
+++ b/ingestor/templates/post-install-job.yaml
@@ -33,8 +33,7 @@ spec:
     spec:
       # The hook talks to one in-cluster endpoint with one specific SA
       # token. Hardened defaults match the tracebloc client chart's
-      # training-pod template — non-root, all caps dropped, no API
-      # token auto-mount.
+      # training-pod template — non-root, all caps dropped.
       automountServiceAccountToken: true  # we DO need the SA token to authenticate the POST
       serviceAccountName: {{ include "ingestor.serviceAccountName" . }}
       restartPolicy: Never
@@ -59,65 +58,46 @@ spec:
               value: {{ .Values.jobsManager.endpoint | quote }}
             - name: SUBMIT_PATH
               value: {{ .Values.jobsManager.submitPath | quote }}
-            - name: IMAGE_DIGEST
-              value: {{ required "image.digest must be a sha256: digest of the ghcr.io/tracebloc/ingestor image" .Values.image.digest | quote }}
-            - name: IDEMPOTENCY_KEY
-              value: {{ include "ingestor.idempotencyKey" . | quote }}
           command: ["/bin/sh", "-c"]
           # The script:
           #   1. Reads the SA token from the projected volume (k8s adds
           #      it automatically when automountServiceAccountToken: true).
-          #   2. Reads the ingest.yaml from the mounted ConfigMap.
-          #   3. Composes the JSON body with Python (the curl image has
-          #      python3 available; jq is the alternative but adds a
-          #      JSON-escape edge case for multi-line YAML).
-          #   4. POSTs, captures HTTP status + body. Non-2xx fails the
-          #      Job, which fails the helm install with the response
-          #      body visible in the install output.
+          #   2. POSTs the pre-rendered JSON body from
+          #      /etc/ingest/body.json — Helm built the JSON at template
+          #      time so the script doesn't have to construct or escape
+          #      anything itself. Earlier versions used a python3 / jq
+          #      escape pipeline at runtime; both failed in different
+          #      ways (curlimages/curl strips python3 from the runtime
+          #      layer, and shell-side JSON escaping a multi-line YAML
+          #      scalar is its own bug farm). Bugbot caught both.
+          #   3. Non-2xx fails the Job, which fails the helm install with
+          #      the response body visible in the install output.
           args:
             - |
               set -eu
 
               TOKEN_PATH=/var/run/secrets/kubernetes.io/serviceaccount/token
-              INGEST_YAML=/etc/ingest/ingest.yaml
+              BODY_FILE=/etc/ingest/body.json
 
               if [ ! -r "$TOKEN_PATH" ]; then
                 echo "ERROR: SA token not found at $TOKEN_PATH" >&2
                 exit 1
               fi
-              if [ ! -r "$INGEST_YAML" ]; then
-                echo "ERROR: ingest.yaml not found at $INGEST_YAML — ConfigMap mount failed" >&2
+              if [ ! -r "$BODY_FILE" ]; then
+                echo "ERROR: request body not found at $BODY_FILE — ConfigMap mount failed" >&2
                 exit 1
               fi
 
-              TOKEN="$(cat "$TOKEN_PATH")"
-              INGEST_CONFIG="$(cat "$INGEST_YAML")"
-
-              # Compose the JSON body. We use python3 to handle YAML
-              # body's newlines / quotes correctly; the curlimages/curl
-              # image ships with python3.
-              BODY=$(python3 -c "
-              import json, os
-              print(json.dumps({
-                  'ingest_config': os.environ['INGEST_CONFIG'],
-                  'idempotency_key': os.environ['IDEMPOTENCY_KEY'],
-                  'image_digest': os.environ['IMAGE_DIGEST'],
-              }))
-              " INGEST_CONFIG="$INGEST_CONFIG" \
-                  IDEMPOTENCY_KEY="$IDEMPOTENCY_KEY" \
-                  IMAGE_DIGEST="$IMAGE_DIGEST")
-
               URL="${JOBS_MANAGER_ENDPOINT}${SUBMIT_PATH}"
               echo "POST $URL"
-              echo "  idempotency_key=$IDEMPOTENCY_KEY"
-              echo "  image_digest=$IMAGE_DIGEST"
+              echo "Body source: $BODY_FILE"
 
               HTTP_STATUS=$(curl -sS -o /tmp/resp.json -w "%{http_code}" \
                 --max-time {{ .Values.hookTimeoutSeconds | default 30 }} \
                 -X POST "$URL" \
-                -H "Authorization: Bearer $TOKEN" \
+                -H "Authorization: Bearer $(cat "$TOKEN_PATH")" \
                 -H "Content-Type: application/json" \
-                --data-binary "$BODY")
+                --data-binary "@$BODY_FILE")
 
               echo "HTTP $HTTP_STATUS"
               echo "Response:"

--- a/ingestor/templates/serviceaccount.yaml
+++ b/ingestor/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # The post-install hook Job runs as this SA. Its token is the credential
+  # jobs-manager validates via TokenReview (client-runtime#21). The SA's
+  # (namespace, name) must match an entry in the tracebloc release's
+  # `ingestionAuthz.allowed` ConfigMap; the default chart entry is
+  # `(release-namespace, "ingestor")` so this default name works
+  # out-of-the-box.
+  name: {{ include "ingestor.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ingestor.labels" . | nindent 4 }}
+{{- end }}

--- a/ingestor/values.yaml
+++ b/ingestor/values.yaml
@@ -1,0 +1,78 @@
+# ============================================================
+# tracebloc/ingestor — values.yaml
+# ============================================================
+# Customer-facing chart. The dominant install is:
+#
+#   helm install my-dataset tracebloc/ingestor --namespace tracebloc \
+#     --set-file ingestConfig=./my-ingest.yaml \
+#     --set image.digest=sha256:<the digest from a tracebloc/ingestor release>
+#
+# The chart submits the YAML to jobs-manager; jobs-manager owns the
+# resulting Job. `helm uninstall` removes the ConfigMap + hook but
+# leaves the Job and ingested data alone (see README.md).
+
+# -- The ingest.yaml body. REQUIRED. Set via --set-file ingestConfig=path/to/ingest.yaml
+# or by overriding in a values file. Validated by jobs-manager against the
+# v1 schema from tracebloc/data-ingestors#44; install fails with a
+# line-numbered error if invalid.
+ingestConfig: ""
+
+# -- Image of the official tracebloc/ingestor that will run the dataset.
+image:
+  # Repository defaults to the GHCR-published image. Customers running an
+  # air-gapped mirror override this.
+  repository: ghcr.io/tracebloc/ingestor
+  # Digest pinning is REQUIRED — jobs-manager rejects tag-form inputs
+  # outright (see client-runtime#21's image_digest validation). Set this
+  # to the digest published in the data-ingestors GitHub Release for the
+  # version you want to ingest with.
+  digest: ""
+
+# -- jobs-manager Service hostname + port to POST to. Defaults assume
+# the tracebloc client chart's release name is "tracebloc". Override if
+# you've named it differently (e.g., "my-tracebloc.<namespace>.svc...").
+jobsManager:
+  endpoint: http://jobs-manager.tracebloc.svc.cluster.local:8080
+  # The path on jobs-manager that accepts ingestion submissions. Stable
+  # API; only change if you're testing against a forked jobs-manager.
+  submitPath: /internal/submit-ingestion-run
+
+# -- ServiceAccount that the post-install hook runs as. Its token is the
+# credential jobs-manager validates via TokenReview, and the SA's name +
+# namespace are matched against the ingestionAuthz policy in the
+# tracebloc client release. Default name matches the chart's default
+# `ingestionAuthz.allowed[0].service_account: ingestor` entry.
+serviceAccount:
+  create: true
+  name: ingestor
+
+# -- Image for the post-install hook Job itself (a thin curl wrapper).
+# Pinned by digest for reproducibility; bumping is a separate chart
+# release.
+hookImage:
+  # curlimages/curl is small, official, and pinned by tag here for
+  # readability. Customers who need digest pinning override this.
+  repository: curlimages/curl
+  tag: "8.10.1"
+  pullPolicy: IfNotPresent
+
+# -- Resources for the post-install hook. Tiny — it makes one POST.
+hookResources:
+  requests:
+    cpu: "10m"
+    memory: "32Mi"
+  limits:
+    cpu: "100m"
+    memory: "64Mi"
+
+# -- Idempotency key used by jobs-manager to dedupe submissions. Derived
+# from the Helm release name + revision by default so a `helm upgrade`
+# under the same release submits a fresh run. Override to a stable UUID
+# if you want strict at-most-once semantics across reinstalls of the
+# same release name.
+idempotencyKey: ""
+
+# -- How long the post-install hook waits for the POST to return before
+# failing the install. Includes jobs-manager schema validation +
+# k8s API calls; usually completes in <2s.
+hookTimeoutSeconds: 30


### PR DESCRIPTION
## Summary

This is the **chart side of the new end-to-end data-ingestion flow**, closing the loop with [tracebloc/data-ingestors#44, #45](https://github.com/tracebloc/data-ingestors/issues/44) and [tracebloc/client-runtime#21](https://github.com/tracebloc/client-runtime/pull/35) (all merged). After this lands a customer can run:

\`\`\`bash
helm install my-dataset tracebloc/ingestor --namespace tracebloc \\
  --set-file ingestConfig=./my-ingest.yaml \\
  --set image.digest=sha256:<digest>
\`\`\`

and have a real data-ingestion Job running in their cluster, with no Dockerfile and no Python script.

## Two commits

### 1. Companion changes to the main \`client\` chart

So jobs-manager is actually reachable + authorized for the ingestion flow:

| File | Change |
|---|---|
| \`client/templates/rbac.yaml\` | adds \`tokenreviews/create\` (ClusterRole branch only — k8s API requirement), \`configmaps/secrets create\` (both branches) |
| \`client/templates/jobs-manager-deployment.yaml\` | adds \`containerPort: 8080\` + mounts the new authz ConfigMap at \`/etc/tracebloc/ingestion-authz.yaml\` |
| \`client/templates/jobs-manager-service.yaml\` (**new**) | ClusterIP exposing 8080 at the stable name \`jobs-manager\` |
| \`client/templates/ingestion-authz-configmap.yaml\` (**new**) | renders the \`ingestionAuthz.allowed\` policy customers configure |
| \`client/values.yaml\` | default \`ingestionAuthz\` allows the ingestor subchart's SA to ingest any table |

### 2. New \`ingestor/\` subchart (closes #86)

The customer-facing chart. Sibling of \`client/\` at the repo root.

| File | Purpose |
|---|---|
| \`Chart.yaml\` | \`appVersion: 0.3.0-rc1\` (the data-ingestors release this targets) |
| \`values.yaml\` | required: \`ingestConfig\` (--set-file), \`image.digest\` (sha256). Sensible defaults for everything else |
| \`templates/configmap-ingest-config.yaml\` | hook-weight 0; holds the YAML body |
| \`templates/post-install-job.yaml\` | hook-weight 1; runs as the chart SA, reads its own token, POSTs to jobs-manager |
| \`templates/serviceaccount.yaml\` | default name \`ingestor\` — matches the parent chart's default authz entry |
| \`README.md\` | spells out the ownership boundary (\`helm uninstall\` does NOT cancel running ingestion) |

## End-to-end flow after this lands

\`\`\`
helm install my-dataset tracebloc/ingestor ...
  → Helm renders ConfigMap/<release>-config (the ingest.yaml)
  → post-install hook Job (this chart) runs
    → reads its SA token + the ingest.yaml
    → POST jobs-manager:8080/internal/submit-ingestion-run
      → jobs-manager: TokenReview (via the new RBAC)
      → jobs-manager: authz lookup (via the new ConfigMap mount)
      → jobs-manager: validate YAML against ingest.v1
      → jobs-manager: create per-run ConfigMap + Secret + Job (via the new RBAC)
      → return 201 with {job_name, namespace}
    → hook exits 0; helm install reports success
  → jobs-manager's Job pulls ghcr.io/tracebloc/ingestor@<digest>
  → ingestor reads INGEST_CONFIG from its mounted ConfigMap
  → data flows: validation → preprocessing → cluster MySQL + metadata to backend
\`\`\`

## Verified locally

- **\`helm lint client/\` clean** (only pre-existing icon-recommended INFO).
- **\`helm lint ingestor/\` clean**.
- **\`helm template\` on both charts** renders all new resources with expected values.
- **\`helm unittest client/\`: 116/116 tests pass** — no existing snapshots affected by the deployment/RBAC changes.
- **Required-value gates** on the ingestor chart fire correctly (missing \`image.digest\` or \`ingestConfig\` fails templating with a clear message).

## What needs reviewer attention

1. **\`clusterScope: false\` limitation.** \`tokenreviews/create\` is cluster-scoped; customers running with \`clusterScope: false\` won't have the ingestion endpoint authenticate. Two options if we want to support that mode: (a) document the limitation, ship as-is (current state); (b) always create a small ClusterRole just for tokenreviews regardless of clusterScope. I picked (a) for v1 — easy to swap to (b) if a customer asks.
2. **Default authz is permissive.** \`ingestionAuthz.allowed\` lets any SA named \`ingestor\` ingest into any table. Tightening is one-line per customer via values overrides. Reasonable v1 default; reviewers may want stricter out-of-the-box.
3. **Hook image \`curlimages/curl:8.10.1\`** — tag-pinned, not digest-pinned. The image is well-known and reasonably stable, but a strict shop may want a digest. Easy to swap.
4. **\`helm uninstall\` ownership boundary** is documented in the README but not enforced by code. Some shops may prefer pre-delete hooks that cancel the in-flight Job; deferred to v1.1.

## Test plan (post-merge, on a real cluster)

- [ ] \`helm upgrade --install tracebloc tracebloc/tracebloc\` deploys with the new Service + RBAC + authz ConfigMap.
- [ ] \`kubectl -n tracebloc port-forward svc/jobs-manager 8080:8080\` then \`curl /healthz\` returns 200.
- [ ] \`helm install my-dataset ./ingestor -f my-values.yaml --set-file ingestConfig=./ingest.yaml --set image.digest=sha256:...\` completes successfully.
- [ ] An ingestor Job appears in \`kubectl get jobs -l tracebloc.io/ingestion-run\`.
- [ ] Re-running the same \`helm upgrade\` with the same idempotency key returns 200 replay.
- [ ] \`helm uninstall my-dataset\` removes the chart artifacts but NOT the running Job.

## Refs

- [tracebloc/data-ingestors#44](https://github.com/tracebloc/data-ingestors/issues/44) — YAML schema + entrypoint (merged)
- [tracebloc/data-ingestors#45](https://github.com/tracebloc/data-ingestors/issues/45) — image release pipeline (merged, \`v0.3.0-rc1\` live)
- [tracebloc/client-runtime#21](https://github.com/tracebloc/client-runtime/pull/35) — \`submit-ingestion-run\` endpoint (merged)
- [tracebloc/client#86](https://github.com/tracebloc/client/issues/86) — this ticket

Closes #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Helm chart and expands `jobs-manager` exposure/RBAC (including cluster-scoped `tokenreviews/create` when `clusterScope: true`), which can affect cluster security posture and install-time behavior if misconfigured.
> 
> **Overview**
> Adds a new customer-facing `ingestor` Helm chart that submits an `ingest.yaml` to `jobs-manager` via a post-install/upgrade hook Job, using a ServiceAccount token and a pre-rendered JSON request body stored in a ConfigMap.
> 
> Updates the main `client` chart to support this flow by **exposing `jobs-manager` on a ClusterIP Service (port 8080)**, mounting a new `ingestion-authz` ConfigMap policy into `jobs-manager`, adding default `ingestionAuthz.allowed` values, and extending RBAC so `jobs-manager` can perform `TokenReview` (cluster-scope only) and create per-run ConfigMaps/Secrets.
> 
> Tweaks `.gitignore` to ensure `ingestor/values.yaml` is committed despite the existing `values*.yaml` ignore pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90ea8e3ce61f2aadd7a1ae14fa609087dd7e5cb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->