### PR TITLE
fix: nil-guard ingestionAuthz access for --reuse-values upgrade path

### DIFF
--- a/client/templates/ingestion-authz-configmap.yaml
+++ b/client/templates/ingestion-authz-configmap.yaml
@@ -17,7 +17,17 @@ metadata:
 data:
   ingestion-authz.yaml: |
     allowed:
-    {{- range .Values.ingestionAuthz.allowed }}
+    {{- /*
+        Nil-guarded chain: an upgrade with `--reuse-values` from a
+        pre-#123 release won't have `.Values.ingestionAuthz` in its
+        stored values, and an unguarded `.Values.ingestionAuthz.allowed`
+        crashes with "nil pointer evaluating interface {}.allowed".
+        `default dict` + `default list` collapse the missing parent /
+        missing child to an empty list, which renders as `allowed: []`
+        — fail-safe (the authz policy then denies every caller, which
+        is correct: there's no policy until the operator sets one).
+    */ -}}
+    {{- range default list (default dict .Values.ingestionAuthz).allowed }}
       - service_account: {{ .service_account | quote }}
         namespace: {{ .namespace | default $.Release.Namespace | quote }}
         table_prefixes:


### PR DESCRIPTION
## Bug

Surfaced immediately after [#123](https://github.com/tracebloc/client/pull/123) merged by a real user attempting `helm upgrade --reuse-values`:

\`\`\`
Error: UPGRADE FAILED: template:
  client/templates/ingestion-authz-configmap.yaml:20:21:
  executing "..." at <.Values.ingestionAuthz.allowed>:
  nil pointer evaluating interface {}.allowed
\`\`\`

\`--reuse-values\` preserves the OLD stored values (from a pre-#123 release, which doesn't have \`ingestionAuthz\`) but doesn't pick up new chart defaults. The unguarded \`.Values.ingestionAuthz.allowed\` access then crashes templating before any of the new ingestion resources are created.

## Fix

Collapse the missing-parent and missing-child cases to an empty list:

\`\`\`diff
-    {{- range .Values.ingestionAuthz.allowed }}
+    {{- range default list (default dict .Values.ingestionAuthz).allowed }}
\`\`\`

Plus a comment explaining the failure mode so a future cleanup doesn't undo this. The rendered ConfigMap with no values set becomes \`allowed:\` (empty), which the authz policy parser in jobs-manager treats as "no SAs authorized" — fail-safe, denies all calls until the operator sets a policy.

## Note: \`--reset-then-reuse-values\` is still the recommended upgrade

This template fix unblocks the \`--reuse-values\` path but the right upgrade idiom remains \`--reset-then-reuse-values\` (resets to chart defaults FIRST, then re-applies user overrides on top — picks up the non-empty \`ingestionAuthz.allowed\` default so the endpoint actually works out of the box). The fix here is defense-in-depth: even if someone uses \`--reuse-values\`, the chart renders successfully (just with the endpoint denying everything until configured).

## Verified

- **\`helm template\`** clean across three scenarios: default values, \`--set ingestionAuthz=null\`, \`--set ingestionAuthz.allowed=null\`.
- **\`helm unittest client/\`**: 116/116 pass, no snapshot regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm template change that only affects rendering when `ingestionAuthz`/`allowed` is missing (e.g., `helm upgrade --reuse-values` from older releases). Main risk is behavior change to a fail-closed `allowed: []` policy if values are unintentionally omitted.
> 
> **Overview**
> Fixes Helm upgrade failures when using `--reuse-values` from releases that didn’t store `ingestionAuthz` values by **nil-guarding** the template access to `.Values.ingestionAuthz.allowed`.
> 
> The ConfigMap now ranges over `default list (default dict .Values.ingestionAuthz).allowed` and includes an inline comment documenting the upgrade failure mode; missing values render as an empty `allowed` policy (deny-all) instead of crashing template rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ac5a1acb34240c4187be59acda8cb6e2f26d69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->