### PR TITLE
feat(#125): wire INGESTOR_IMAGE_DIGEST; drop digest requirement from ingestor subchart

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.3.2
-appVersion: "1.3.2"
+version: 1.3.3
+appVersion: "1.3.3"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -82,6 +82,15 @@ spec:
           value: {{ include "tracebloc.clientLogsPvc" . | quote }}
         - name: MYSQL_HOST
           value: "mysql-client"
+        # client-runtime#40: default ingestor image digest for the
+        # POST /internal/submit-ingestion-run endpoint. Auto-upgrade
+        # keeps this current; the ingestor subchart no longer requires
+        # the customer to pin a digest. Nil-guarded so `--reuse-values`
+        # from a pre-this-PR release doesn't crash templating on the
+        # missing `images.ingestor` key — empty value means jobs-manager
+        # accepts only request-body overrides and returns 503 if absent.
+        - name: INGESTOR_IMAGE_DIGEST
+          value: {{ (default dict .Values.images.ingestor).digest | default "" | quote }}
         - name: REQUESTS_PROXY_URL
           value: "http://requests-proxy-service:8888"
         - name: JOB_IMAGE_HOST

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -186,8 +186,14 @@ images:
   # current. Customers can override per-install via the ingestor
   # subchart's `image.digest` (for pinning / debugging), but the
   # dominant path uses this value.
+  #
+  # Initial value: ghcr.io/tracebloc/ingestor@<v0.3.0-rc1 digest>. Bump
+  # this on each ingestor release; chart `version` in Chart.yaml must
+  # also bump so the auto-upgrade cronjob detects the change. Future
+  # automation in tracebloc/data-ingestors (release-image.yml) can
+  # raise a PR to this file when a new image is published.
   ingestor:
-    digest: ""
+    digest: "sha256:e6639b084d0d377072dc908db376050914ebd49c730ddaa13f838d10f5482ea9"
   podsMonitor:
     digest: ""
   resourceMonitor:

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -179,6 +179,15 @@ networkPolicy:
 images:
   jobsManager:
     digest: ""
+  # client-runtime#40 / client#125: the ingestor image is spawned by
+  # jobs-manager at ingestion-submission time, not as a long-lived pod.
+  # Setting `digest` here surfaces it into jobs-manager as the
+  # `INGESTOR_IMAGE_DIGEST` env; the auto-upgrade flow then keeps it
+  # current. Customers can override per-install via the ingestor
+  # subchart's `image.digest` (for pinning / debugging), but the
+  # dominant path uses this value.
+  ingestor:
+    digest: ""
   podsMonitor:
     digest: ""
   resourceMonitor:

--- a/ingestor/README.md
+++ b/ingestor/README.md
@@ -5,9 +5,10 @@ A thin chart that submits one data-ingestion run to your tracebloc client cluste
 ```bash
 helm install my-dataset tracebloc/ingestor \
   --namespace tracebloc \
-  --set-file ingestConfig=./my-ingest.yaml \
-  --set image.digest=sha256:<digest>
+  --set-file ingestConfig=./my-ingest.yaml
 ```
+
+**The ingestor image is managed centrally** by the tracebloc client chart's auto-upgrade flow — you don't need to pin a digest for each install. New ingestor releases roll out automatically when the cluster's daily auto-upgrade cronjob (`autoUpgrade.enabled: true` in the client chart) bumps the chart version. See [Pinning a specific image version](#pinning-a-specific-image-version) below for the override path.
 
 ## What this chart owns
 
@@ -28,9 +29,9 @@ helm install my-dataset tracebloc/ingestor \
 1. `helm install` renders `ConfigMap/<release>-config` containing the customer's `ingest.yaml` body.
 2. Helm fires the `post-install` hook: a Job that runs as the chart's ServiceAccount.
 3. The hook reads its SA token from the projected volume and the `ingest.yaml` from the ConfigMap mount.
-4. The hook POSTs `{ ingest_config, idempotency_key, image_digest }` to `jobs-manager:8080/internal/submit-ingestion-run`.
+4. The hook POSTs `{ ingest_config, idempotency_key }` (and `image_digest` if you explicitly pinned one) to `jobs-manager:8080/internal/submit-ingestion-run`.
 5. **jobs-manager** validates the SA token via Kubernetes TokenReview, then checks the (SA, table) pair against the cluster's `ingestionAuthz` policy (a ConfigMap rendered by the parent `tracebloc/client` chart).
-6. If authorized, jobs-manager validates the YAML against the `ingest.v1` JSON schema, mints a backend token, creates the per-run ConfigMap + Secret + Job, records the run for idempotency, and returns `201` (or `200` if this idempotency_key has been seen before).
+6. If authorized, jobs-manager validates the YAML against the `ingest.v1` JSON schema, resolves the image digest (the body's value if you pinned one, otherwise the cluster's configured default from `INGESTOR_IMAGE_DIGEST`), mints a backend token, creates the per-run ConfigMap + Secret + Job, records the run for idempotency, and returns `201` (or `200` if this idempotency_key has been seen before).
 7. The hook treats `2xx` as success and exits 0; `helm install` reports success. Non-`2xx` exits 1 and `helm install` fails with the response body in the output.
 
 The customer never builds an image. The customer never writes a Dockerfile. The customer writes ~8 lines of YAML.
@@ -40,7 +41,18 @@ The customer never builds an image. The customer never writes a Dockerfile. The 
 | Value | Description |
 |---|---|
 | `ingestConfig` | The full `ingest.yaml` body. **Set via `--set-file`** — the body almost always contains YAML special characters that don't survive `--set`. |
-| `image.digest` | A `sha256:<64-hex>` digest of a `ghcr.io/tracebloc/ingestor` release. Tags are rejected by jobs-manager. See the [data-ingestors releases page](https://github.com/tracebloc/data-ingestors/releases) for current digests. |
+
+## Pinning a specific image version
+
+The dominant install path leaves `image.digest` empty and lets jobs-manager pick the cluster's current ingestor version (set by the parent client chart's `images.ingestor.digest`, kept current by the auto-upgrade cronjob). Override only when you have a specific reason:
+
+| Scenario | What to do |
+|---|---|
+| Reproducing an older ingestion run for audit / debugging | `--set image.digest=sha256:<old-digest>` |
+| Testing a new ingestor release before cluster-wide rollout | `--set image.digest=sha256:<new-digest>` ahead of the auto-upgrade tick |
+| Air-gapped mirror with frozen versions | Use both `--set image.repository=...` and `--set image.digest=sha256:...` |
+
+When set, the digest must be the full canonical form (`sha256:` + 64 lowercase hex chars). Tags like `v0.3.0` are rejected by jobs-manager. See the [data-ingestors releases page](https://github.com/tracebloc/data-ingestors/releases) for current digests.
 
 ## Frequently-overridden values
 

--- a/ingestor/templates/configmap-ingest-config.yaml
+++ b/ingestor/templates/configmap-ingest-config.yaml
@@ -34,12 +34,20 @@ data:
   # Pre-rendered JSON body that the post-install hook POSTs to
   # jobs-manager. Computed at helm-template time so the hook is a
   # one-line `curl --data-binary @body.json` — no python, no jq, no
-  # shell-escaping the multi-line YAML scalar. The required-value gates
-  # below fire here so a missing digest or ingest config fails
-  # templating (and therefore `helm install`) with a clear message
-  # before any cluster state is touched.
+  # shell-escaping the multi-line YAML scalar.
+  #
+  # `image_digest` is OPTIONAL in the POST body (client-runtime#40):
+  # when omitted, jobs-manager uses the cluster's configured default
+  # (set by the tracebloc client chart's `images.ingestor.digest`,
+  # kept current by the auto-upgrade flow). Including it here only
+  # when the customer explicitly pinned via `--set image.digest=...`
+  # means the dominant install path tracks the cluster's current
+  # version automatically; the override path is preserved.
   body.json: |-
     {{- $cfg := required "ingestConfig must be set (use --set-file ingestConfig=path/to/ingest.yaml)" .Values.ingestConfig -}}
-    {{- $digest := required "image.digest must be a sha256: digest of the ghcr.io/tracebloc/ingestor image (see the data-ingestors GitHub Release for current digests)" .Values.image.digest -}}
     {{- $key := include "ingestor.idempotencyKey" . -}}
-    {{- dict "ingest_config" $cfg "idempotency_key" $key "image_digest" $digest | toJson | nindent 4 }}
+    {{- $body := dict "ingest_config" $cfg "idempotency_key" $key -}}
+    {{- if .Values.image.digest -}}
+      {{- $_ := set $body "image_digest" .Values.image.digest -}}
+    {{- end -}}
+    {{- $body | toJson | nindent 4 }}

--- a/ingestor/values.yaml
+++ b/ingestor/values.yaml
@@ -18,14 +18,24 @@
 ingestConfig: ""
 
 # -- Image of the official tracebloc/ingestor that will run the dataset.
+#
+# Default behaviour (client-runtime#40 / client#125): leave `digest`
+# empty and let the cluster's auto-upgrade flow pick the version.
+# jobs-manager reads `INGESTOR_IMAGE_DIGEST` (set by the tracebloc
+# client chart's `images.ingestor.digest` value) and uses it when
+# spawning the ingestor Job. New ingestor releases roll out
+# automatically when the cluster's daily auto-upgrade cronjob bumps the
+# chart — no per-dataset chart change needed.
+#
+# Set `digest` here ONLY when you need to pin a specific version, e.g.
+# reproducing an older run or testing a new release before cluster-wide
+# rollout. Must be the full canonical sha256 digest; tags are rejected.
 image:
   # Repository defaults to the GHCR-published image. Customers running an
   # air-gapped mirror override this.
   repository: ghcr.io/tracebloc/ingestor
-  # Digest pinning is REQUIRED — jobs-manager rejects tag-form inputs
-  # outright (see client-runtime#21's image_digest validation). Set this
-  # to the digest published in the data-ingestors GitHub Release for the
-  # version you want to ingest with.
+  # Optional override. Empty (default) means "use whatever the cluster
+  # is currently rolling". When set must be sha256:<64 lowercase hex>.
   digest: ""
 
 # -- jobs-manager Service hostname + port to POST to. Defaults assume


### PR DESCRIPTION
## Why

The ingestor image should fit the same auto-update model every other component already uses in the tracebloc chart: cluster manages the digest centrally via `images.<component>.digest`, the daily auto-upgrade cronjob keeps it current, customer charts don't have to pin it. The current ingestor subchart (post-[#123](https://github.com/tracebloc/client/pull/123)) made digest pinning mandatory at install time, which doesn't compose with auto-update.

## What

Three file groups:

### 1. Main `client` chart wiring

- `client/values.yaml`: add `images.ingestor.digest: ""` to the existing `images:` block. The auto-upgrade cronjob bumps this when a new chart version is published.
- `client/templates/jobs-manager-deployment.yaml`: inject `INGESTOR_IMAGE_DIGEST` env on the `api` container, nil-guarded for `--reuse-values` from a pre-this-PR release. Empty value renders cleanly; the endpoint then accepts only request-body overrides until the operator sets the chart value.

### 2. `ingestor` subchart

- `ingestor/values.yaml`: `image.digest` becomes **optional override**, not required.
- `ingestor/templates/configmap-ingest-config.yaml`: body JSON renders without `image_digest` when none is set; key is included only when the customer explicitly pinned via `--set image.digest=…`.
- `ingestor/README.md`: removes `image.digest` from "Required values"; adds a "Pinning a specific image version" section that explains the override use cases (reproducing old runs, testing pre-rollout versions, air-gapped mirrors).

## Verified

All four render paths covered:

```text
images.ingestor.digest=sha256:abcd  →  env "sha256:abcd"
images.ingestor.digest unset        →  env "" (nil-guard works for --reuse-values)
body without image.digest override  →  body.json = {"idempotency_key": "...", "ingest_config": "..."}
body with image.digest override     →  body.json = {..., "image_digest": "sha256:..."}
```

- `helm lint`: clean on both charts.
- `helm unittest client/`: 116/116 pass (no snapshot regressions).

## Bootstrap step after merge

One-line bump of `client/values.yaml`'s `images.ingestor.digest` to the current published digest (`sha256:e6639b…` for `v0.3.0-rc1`), plus a chart version bump so the auto-upgrade cronjob promotes it. Future ingestor releases follow the same pattern.

## Companion PR

[tracebloc/client-runtime#41](https://github.com/tracebloc/client-runtime/pull/41) makes the endpoint accept the env-driven default. Either order is safe to merge:

- This PR first: env is wired but endpoint still requires body digest → existing flow unchanged.
- That PR first: endpoint can use env default → this PR enables it.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ingestion submission behavior by introducing a cluster-wide default ingestor image digest and relaxing per-install requirements, which could affect ingestion runs if the default digest is missing or incorrect.
> 
> **Overview**
> Updates the `client` Helm chart to manage a cluster-wide default ingestor image digest: bumps chart version to `1.3.3`, adds `images.ingestor.digest` to `values.yaml`, and injects `INGESTOR_IMAGE_DIGEST` into the `jobs-manager` Deployment (nil-guarded for `--reuse-values`).
> 
> Adjusts the `ingestor` subchart so dataset installs no longer require `--set image.digest=...`: `body.json` now omits `image_digest` unless explicitly provided, and the README/values documentation is updated to describe the new default-vs-pin behavior and override scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c80da27fe34aff152153c0a3dadc14276cdd0e87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->