### PR TITLE
fix(#127): ingestor chart auto-resolves jobs-manager endpoint to release namespace

### DIFF
--- a/ingestor/README.md
+++ b/ingestor/README.md
@@ -58,7 +58,7 @@ When set, the digest must be the full canonical form (`sha256:` + 64 lowercase h
 
 | Value | Default | When to override |
 |---|---|---|
-| `jobsManager.endpoint` | `http://jobs-manager.tracebloc.svc.cluster.local:8080` | The parent `tracebloc/client` release isn't in the `tracebloc` namespace, or you're testing against a port-forward. |
+| `jobsManager.endpoint` | `http://jobs-manager.<release-namespace>.svc.cluster.local:8080` (auto-resolved) | The ingestor release and the parent `tracebloc/client` release live in different namespaces, or you're testing against a port-forward. |
 | `serviceAccount.name` | `ingestor` | The cluster's `ingestionAuthz` policy expects a different SA name. (Default matches the parent chart's default.) |
 | `image.repository` | `ghcr.io/tracebloc/ingestor` | Air-gapped mirror. |
 | `idempotencyKey` | `<release>-<revision>` | You want strict at-most-once semantics across re-installs under the same release name. |

--- a/ingestor/templates/post-install-job.yaml
+++ b/ingestor/templates/post-install-job.yaml
@@ -54,8 +54,15 @@ spec:
           resources:
             {{- toYaml .Values.hookResources | nindent 12 }}
           env:
+            # client#127: default to the jobs-manager Service in this
+            # release's own namespace rather than hardcoding "tracebloc".
+            # Releases in any other namespace would otherwise hit
+            # `curl: Could not resolve host` at the hook. Customers
+            # whose ingestor release sits in a different namespace from
+            # the tracebloc release set `jobsManager.endpoint`
+            # explicitly to override.
             - name: JOBS_MANAGER_ENDPOINT
-              value: {{ .Values.jobsManager.endpoint | quote }}
+              value: {{ .Values.jobsManager.endpoint | default (printf "http://jobs-manager.%s.svc.cluster.local:8080" .Release.Namespace) | quote }}
             - name: SUBMIT_PATH
               value: {{ .Values.jobsManager.submitPath | quote }}
           command: ["/bin/sh", "-c"]

--- a/ingestor/values.yaml
+++ b/ingestor/values.yaml
@@ -38,11 +38,15 @@ image:
   # is currently rolling". When set must be sha256:<64 lowercase hex>.
   digest: ""
 
-# -- jobs-manager Service hostname + port to POST to. Defaults assume
-# the tracebloc client chart's release name is "tracebloc". Override if
-# you've named it differently (e.g., "my-tracebloc.<namespace>.svc...").
+# -- jobs-manager Service hostname + port to POST to. When left empty
+# (default), the post-install hook resolves the endpoint to
+# `http://jobs-manager.<release-namespace>.svc.cluster.local:8080`,
+# which is correct for the common case where the ingestor release is
+# installed in the same namespace as the tracebloc client release.
+# Override only when the two releases live in different namespaces, or
+# when you need a non-standard port/host (e.g., port-forward testing).
 jobsManager:
-  endpoint: http://jobs-manager.tracebloc.svc.cluster.local:8080
+  endpoint: ""
   # The path on jobs-manager that accepts ingestion submissions. Stable
   # API; only change if you're testing against a forked jobs-manager.
   submitPath: /internal/submit-ingestion-run


### PR DESCRIPTION
## Bug surfaced during real-cluster validation

Test cluster's release lives in \`tracebloc-templates\`, but the ingestor subchart's \`values.yaml\` defaulted \`jobsManager.endpoint\` to \`http://jobs-manager.tracebloc.svc.cluster.local:8080\` — a hardcoded namespace. Post-install hook failed:

\`\`\`
curl: (6) Could not resolve host: jobs-manager.tracebloc.svc.cluster.local
\`\`\`

## Fix

Empty the hardcoded default in \`values.yaml\`; have the post-install Job template the endpoint to use \`.Release.Namespace\` when no value is set. Override path (set \`jobsManager.endpoint\` explicitly) keeps working.

\`\`\`diff
-              value: {{ .Values.jobsManager.endpoint | quote }}
+              value: {{ .Values.jobsManager.endpoint | default (printf "http://jobs-manager.%s.svc.cluster.local:8080" .Release.Namespace) | quote }}
\`\`\`

## Verified

| Scenario | Resolved endpoint |
|---|---|
| Release in \`tracebloc-templates\` (no override) | \`http://jobs-manager.tracebloc-templates.svc.cluster.local:8080\` |
| Release in \`some-other-ns\` (no override) | \`http://jobs-manager.some-other-ns.svc.cluster.local:8080\` |
| Release with \`--set jobsManager.endpoint=http://port-forward.localhost:8888\` | \`http://port-forward.localhost:8888\` (override wins) |

\`helm lint\` clean.

## How to merge w.r.t. ongoing testing

The workaround is one \`--set jobsManager.endpoint=…\`, so this isn't blocking validation — just removing the workaround. Land at your convenience.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk templating change confined to the post-install hook’s target URL; main risk is mis-targeting jobs-manager only in nonstandard cluster DNS setups, with explicit overrides still supported.
> 
> **Overview**
> Fixes cross-namespace installs of the `ingestor` Helm chart by **removing the hardcoded `jobsManager.endpoint` default** and having the post-install hook **default the `JOBS_MANAGER_ENDPOINT` to `jobs-manager.<.Release.Namespace>:8080` when unset**.
> 
> Updates `values.yaml` and the README to document the new auto-resolved default and when to explicitly override `jobsManager.endpoint` (different namespaces / port-forwarding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318c5f2194cc16d1ca2b3045efd1f1bfb4e65aaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->