### PR TITLE
feat(#129): parent client chart owns the shared ingestor ServiceAccount (1.3.4)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.3.3
-appVersion: "1.3.3"
+version: 1.3.4
+appVersion: "1.3.4"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/MIGRATION.md
+++ b/client/MIGRATION.md
@@ -2,6 +2,76 @@
 
 This guide explains how to migrate from the legacy per-platform charts (`aks/`, `bm/`, `eks/`, `oc/`) to the unified `client/` chart.
 
+## Upgrading to 1.3.4 — parent chart owns the shared ingestor ServiceAccount
+
+[#129](https://github.com/tracebloc/client/issues/129): the ingestor
+ServiceAccount has moved from the `tracebloc/ingestor` subchart into this
+parent chart. Background: the SA is shared by every ingestor subchart
+release in a namespace, but per-release Helm ownership meant two concurrent
+`helm install tracebloc/ingestor` calls collided with "cannot import into
+current release", and uninstalling the first release ripped the SA out
+from under all the others. With the SA in the parent chart, every
+ingestor release in the namespace shares it cleanly and `helm uninstall`
+of any individual ingestor release leaves it alone.
+
+> **The matching ingestor subchart change** ships as
+> `tracebloc/ingestor` **0.2.0** — `serviceAccount.create` default
+> flipped from `true` to `false`. Upgrade the subchart releases in
+> lockstep with the parent so they stop trying to own the SA.
+
+### When you need to adopt an existing SA
+
+If you already have a `tracebloc/ingestor` 0.1.0 release installed in the
+same namespace as this `tracebloc/client` release, `kubectl get sa
+ingestor -n <ns> -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}'`
+returns that subchart release's name. Plain `helm upgrade tracebloc/client`
+to 1.3.4 will fail with `Unable to continue with update: ServiceAccount
+"ingestor" ... exists and cannot be imported into the current release`.
+
+Transfer Helm ownership before upgrading:
+
+```bash
+# 1. Identify the values you need.
+NAMESPACE=<your-tracebloc-namespace>
+CLIENT_RELEASE=<your-client-release-name>          # e.g. "tracebloc"
+SA_NAME=ingestor                                    # or ingestionAuthz.serviceAccountName if overridden
+
+# 2. Re-annotate the SA so Helm sees the parent client release as its owner.
+kubectl annotate sa "$SA_NAME" -n "$NAMESPACE" \
+  meta.helm.sh/release-name="$CLIENT_RELEASE" \
+  meta.helm.sh/release-namespace="$NAMESPACE" \
+  --overwrite
+
+kubectl label sa "$SA_NAME" -n "$NAMESPACE" \
+  app.kubernetes.io/managed-by=Helm \
+  --overwrite
+
+# 3. Now run the upgrade — Helm adopts the SA on next reconcile.
+helm upgrade "$CLIENT_RELEASE" tracebloc/client \
+  -n "$NAMESPACE" --version 1.3.4 --reset-then-reuse-values
+
+# 4. Upgrade each ingestor subchart release to 0.2.0 so it stops trying
+#    to create the SA itself. The flipped default does this for you, but
+#    use --reset-then-reuse-values so pre-0.2.0 stored values don't
+#    re-apply serviceAccount.create=true.
+helm upgrade <ingestor-release> tracebloc/ingestor \
+  -n "$NAMESPACE" --version 0.2.0 --reset-then-reuse-values
+```
+
+If no ingestor 0.1.0 release exists in the namespace yet, you don't have
+to do anything — the parent chart creates the SA on first install of
+1.3.4 and subsequent ingestor 0.2.0 releases consume it.
+
+### `--reuse-values` upgrade path
+
+Operators using plain `--reuse-values` (or the auto-upgrade cronjob
+prior to 1.3.0, which used that flag) won't get the new
+`ingestionAuthz.serviceAccountName` default. The chart's template
+defaults the value to `"ingestor"` when absent, so the SA is created
+with the expected name and existing `allowed` entries keep matching.
+No template-level breakage; this is the same nil-guard pattern as
+[#124](https://github.com/tracebloc/client/pull/124).
+
 ## Upgrading to 1.3.0 — self-upgrade CronJob lands on by default
 
 Releases of 1.3.0+ install a `<release>-auto-upgrade` CronJob that polls

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -26,6 +26,20 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+  Name of the shared ServiceAccount the parent chart creates for ingestor
+  subchart releases. Single source of truth — used by:
+    - templates/ingestor-serviceaccount.yaml (creates the SA)
+    - templates/ingestion-authz-configmap.yaml (default authz entry)
+  The ingestor subchart's post-install hook runs as this SA; jobs-manager
+  validates its token via TokenReview against `ingestionAuthz.allowed`.
+  Nil-guarded: pre-#129 stored values from `--reuse-values` upgrades won't
+  have `ingestionAuthz.serviceAccountName`, so default to "ingestor".
+*/}}
+{{- define "tracebloc.ingestorServiceAccountName" -}}
+{{- (default dict .Values.ingestionAuthz).serviceAccountName | default "ingestor" -}}
+{{- end }}
+
+{{/*
   Release-scoped name for the resource-monitor DaemonSet, ServiceAccount,
   ClusterRoleBinding subject, and selector/pod labels. Multiple releases
   on the same cluster share the tracebloc-node-agents namespace; before

--- a/client/templates/ingestion-authz-configmap.yaml
+++ b/client/templates/ingestion-authz-configmap.yaml
@@ -26,9 +26,15 @@ data:
         missing child to an empty list, which renders as `allowed: []`
         — fail-safe (the authz policy then denies every caller, which
         is correct: there's no policy until the operator sets one).
+
+        Per-entry `service_account` is nil-guarded to fall back to
+        `ingestionAuthz.serviceAccountName` (#129) so the default
+        values.yaml entry doesn't need to repeat the SA name — change
+        the name in one place and both the SA template + this policy
+        pick it up.
     */ -}}
     {{- range default list (default dict .Values.ingestionAuthz).allowed }}
-      - service_account: {{ .service_account | quote }}
+      - service_account: {{ .service_account | default (include "tracebloc.ingestorServiceAccountName" $) | quote }}
         namespace: {{ .namespace | default $.Release.Namespace | quote }}
         table_prefixes:
         {{- range .table_prefixes }}

--- a/client/templates/ingestor-serviceaccount.yaml
+++ b/client/templates/ingestor-serviceaccount.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # Shared ServiceAccount that every ingestor subchart release in this
+  # namespace runs its post-install hook as. Owned by the parent chart
+  # (not the subchart) because:
+  #   - multiple concurrent ingestor releases need to share it — per-release
+  #     ownership made the second `helm install tracebloc/ingestor` fail
+  #     with Helm's "cannot import into current release" error (#129);
+  #   - the matching `ingestionAuthz` ConfigMap is already owned here, so
+  #     the SA and the policy referencing it have the same lifecycle.
+  #
+  # The subchart's `serviceAccount.create` defaults to `false` as of
+  # ingestor 0.2.0 — it consumes this SA rather than creating its own.
+  name: {{ include "tracebloc.ingestorServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}

--- a/client/tests/ingestor_serviceaccount_test.yaml
+++ b/client/tests/ingestor_serviceaccount_test.yaml
@@ -1,0 +1,45 @@
+suite: Ingestor ServiceAccount
+templates:
+  - templates/ingestor-serviceaccount.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: renders the shared ingestor SA with the default name
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: ingestor
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: respects an overridden ingestionAuthz.serviceAccountName
+    set:
+      ingestionAuthz:
+        serviceAccountName: my-ingestor
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-ingestor
+
+  - it: nil-guards when ingestionAuthz is absent from --reuse-values
+    # Simulates a pre-#129 stored values dict — the helper falls back to
+    # the literal default "ingestor" rather than panicking on a nil access.
+    set:
+      ingestionAuthz: null
+    asserts:
+      - equal:
+          path: metadata.name
+          value: ingestor
+
+  - it: stamps the standard tracebloc labels
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: client
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -365,8 +365,9 @@ autoUpgrade:
 # is (namespace, service_account) → list of allowed table-name prefixes;
 # "*" means any table.
 #
-# Default: allow the ingestor subchart's SA (named after that release) to
-# ingest into any table. Customers tighten via overrides — e.g.:
+# Default: allow the ingestor subchart's SA (created below by this chart,
+# named `ingestionAuthz.serviceAccountName`) to ingest into any table.
+# Customers tighten via overrides — e.g.:
 #
 #   ingestionAuthz:
 #     allowed:
@@ -374,11 +375,18 @@ autoUpgrade:
 #         namespace: tracebloc
 #         table_prefixes: ["chest_xrays_", "tumors_"]
 ingestionAuthz:
+  # -- Name of the shared ServiceAccount this chart creates for ingestor
+  # subchart releases (client#129). Single source of truth: the SA
+  # template and the default `allowed` entry below both read this value.
+  # Override only if the name "ingestor" collides with something in your
+  # namespace; the matching ingestor subchart's `serviceAccount.name`
+  # must be updated to the same value.
+  serviceAccountName: ingestor
   allowed:
-    # Default: the ingestor subchart's SA (named "ingestor") in the same
-    # namespace as the tracebloc release can ingest into any table. The
-    # `namespace` field is optional; when omitted the ConfigMap template
+    # Default: the SA named `ingestionAuthz.serviceAccountName` above, in
+    # the same namespace as this release, can ingest into any table. When
+    # `service_account` is omitted the ConfigMap template substitutes
+    # `ingestionAuthz.serviceAccountName`; when `namespace` is omitted it
     # substitutes `.Release.Namespace`. Customers tighten by adding more
-    # specific entries with explicit `namespace` and `table_prefixes`.
-    - service_account: ingestor
-      table_prefixes: ["*"]
+    # specific entries with explicit fields.
+    - table_prefixes: ["*"]


### PR DESCRIPTION
## Summary

- Move the `ingestor` ServiceAccount out of the `tracebloc/ingestor` subchart and into this parent chart, so multiple concurrent ingestor subchart releases in a namespace can share it cleanly. Fixes the "cannot import into current release" failure we hit during local validation in `tracebloc-templates` ([#129](https://github.com/tracebloc/client/issues/129)).
- Plumb the SA name through `ingestionAuthz.serviceAccountName` as the single source of truth; both the new `templates/ingestor-serviceaccount.yaml` and the default entry of `templates/ingestion-authz-configmap.yaml` dereference it via the new `tracebloc.ingestorServiceAccountName` helper.
- Nil-guard the helper for `--reuse-values` upgrades from 1.3.3 (the stored values won't have the new key) — defaults to the literal `"ingestor"`.
- Document SA adoption in `client/MIGRATION.md` for clusters that already have an `ingestor` SA owned by a 0.1.0 subchart release.
- Bump `client` chart to **1.3.4**.

## Paired PR

This change pairs with [#133](https://github.com/tracebloc/client/pull/133), which flips the `tracebloc/ingestor` subchart default `serviceAccount.create` from `true` to `false` and bumps it to **0.2.0**. **Merge order: this PR first** — the SA must exist before any 0.2.0 ingestor release tries to consume it.

## Test plan

- [x] `helm unittest .` passes (13 suites, 120 tests, including a new `ingestor_serviceaccount_test.yaml`).
- [x] `helm template` renders the new `ServiceAccount/ingestor` once in the release namespace, and the `ingestion-authz` ConfigMap continues to render `service_account: "ingestor"` from the now-templated default.
- [x] `--set ingestionAuthz.serviceAccountName=alt-ingestor` propagates to both the SA name and the default `allowed[0].service_account`.
- [x] `--set ingestionAuthz=null` (simulating a `--reuse-values` upgrade from 1.3.3) still renders the SA with name `ingestor` and an empty `allowed: []` — same fail-safe behavior as #124.
- [ ] In a fresh kind / k3d namespace: `helm install` this chart, then `helm install tracebloc/ingestor` twice with different release names — both succeed, `kubectl get sa ingestor` returns one SA owned by the client release, `helm uninstall <ingestor-release>` does not delete it. Run this against #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)