### PR TITLE
fix(#130): default idempotency key to install-time stamp, not release revision

### DIFF
--- a/ingestor/Chart.yaml
+++ b/ingestor/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   the ingestor Job directly — this chart owns the config + hook
   artifacts, not the resulting Job or its data.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.3.0-rc1"
 keywords:
   - tracebloc

--- a/ingestor/README.md
+++ b/ingestor/README.md
@@ -61,7 +61,7 @@ When set, the digest must be the full canonical form (`sha256:` + 64 lowercase h
 | `jobsManager.endpoint` | `http://jobs-manager.<release-namespace>.svc.cluster.local:8080` (auto-resolved) | The ingestor release and the parent `tracebloc/client` release live in different namespaces, or you're testing against a port-forward. |
 | `serviceAccount.name` | `ingestor` | The cluster's `ingestionAuthz` policy expects a different SA name. (Default matches the parent chart's default.) |
 | `image.repository` | `ghcr.io/tracebloc/ingestor` | Air-gapped mirror. |
-| `idempotencyKey` | `<release>-<revision>` | You want strict at-most-once semantics across re-installs under the same release name. |
+| `idempotencyKey` | `<release>-<unix-epoch>` (regenerated every install) | You want strict at-most-once semantics across reinstalls of the same release name — pass a stable UUID so jobs-manager replays the original run instead of starting a new one. |
 | `hookTimeoutSeconds` | `30` | Slow networks or large schemas. |
 
 See `values.yaml` for the full set.

--- a/ingestor/templates/_helpers.tpl
+++ b/ingestor/templates/_helpers.tpl
@@ -31,15 +31,19 @@ Naming:
 {{- end -}}
 
 {{- /*
-Resolved idempotency key. Defaults to "<release>-<revision>" so each
-helm install / upgrade submits a fresh run; explicit override is
-honored verbatim.
+Resolved idempotency key. Defaults to "<release>-<unix-epoch>" so each
+install is a fresh run — including reinstalls under the same release
+name, where Helm restarts revisions at 1 and a revision-derived key
+would collide with the previous attempt and trip jobs-manager's
+"already used with a different image_digest or table" guard. Explicit
+override is honored verbatim; set it to a stable UUID only when you
+want at-most-once semantics across reinstalls.
 */ -}}
 {{- define "ingestor.idempotencyKey" -}}
 {{- if .Values.idempotencyKey -}}
 {{ .Values.idempotencyKey }}
 {{- else -}}
-{{ printf "%s-%d" .Release.Name .Release.Revision }}
+{{ printf "%s-%s" .Release.Name (now | unixEpoch) }}
 {{- end -}}
 {{- end -}}
 

--- a/ingestor/values.yaml
+++ b/ingestor/values.yaml
@@ -79,11 +79,14 @@ hookResources:
     cpu: "100m"
     memory: "64Mi"
 
-# -- Idempotency key used by jobs-manager to dedupe submissions. Derived
-# from the Helm release name + revision by default so a `helm upgrade`
-# under the same release submits a fresh run. Override to a stable UUID
-# if you want strict at-most-once semantics across reinstalls of the
-# same release name.
+# -- Idempotency key used by jobs-manager to dedupe submissions.
+# Defaults to `<release>-<unix-epoch>` so each install is a fresh run —
+# including reinstalls under the same release name. (A revision-derived
+# default would collide on `helm uninstall && helm install`, because
+# Helm resets revisions to 1 on the next install; jobs-manager would
+# then reject the second attempt with a 409 if anything dedupe-relevant
+# changed in between.) Override to a stable UUID only when you want
+# at-most-once semantics across reinstalls of the same release name.
 idempotencyKey: ""
 
 # -- How long the post-install hook waits for the POST to return before


### PR DESCRIPTION
Closes #130.

## Summary

- `ingestor/templates/_helpers.tpl`: when `.Values.idempotencyKey` is unset, derive the key from `<release>-<unix-epoch>` instead of `<release>-<revision>`. Helm resets revisions to 1 after `helm uninstall`, so the old default collided on the very common "uninstall → fix something → reinstall" loop and tripped jobs-manager's 409 guard.
- `ingestor/values.yaml`: doc-comment flipped to describe the new default and call out *why* a revision-derived default is the wrong shape here. Override path is reframed as opt-in for at-most-once semantics.
- `ingestor/README.md`: frequently-overridden table row updated to match.
- `ingestor/Chart.yaml`: bumped 0.1.0 → 0.1.1.

The opt-in path (`--set idempotencyKey=...`) is unchanged — the value is still passed through verbatim, so callers who want stable replays still get them.

### Why `%s-%s`, not `%s-%d`

Sprig's `unixEpoch` returns a **string**, not an int. The first cut of this patch used `%d` and rendered `my-dataset-%!d(string=1779196370)` — caught by the local `helm template` smoke test before commit.

## Test plan

Template-level (run locally, passes):

- [x] `helm lint ./ingestor --set-file ingestConfig=...` → clean.
- [x] Two consecutive `helm template` invocations (default path) produce different `idempotency_key` values. Verified: `my-dataset-1779196406` then `my-dataset-1779196408` two seconds later.
- [x] Render with a different release name picks up the new name: `other-name-1779196408`.
- [x] Override path is verbatim: `--set idempotencyKey=stable-uuid-abc` → `"idempotency_key":"stable-uuid-abc"`.

Cluster-level (owner of jobs-manager runtime needs to validate against a live cluster — I can't reach one from this branch):

- [ ] `helm install my-dataset ./ingestor --set-file ingestConfig=./test.yaml` → uninstall → reinstall with the same release name + same `ingest.yaml` → second install creates a fresh ingestor Job (different `ingest-job-<hash>`), not a 409.
- [ ] `helm install my-dataset ./ingestor --set-file ingestConfig=./test.yaml --set idempotencyKey=foo` → uninstall → reinstall with the same key + same config → jobs-manager returns 200 replay, no second Job created.

## Refs

- Sibling to [#125](https://github.com/tracebloc/client/issues/125) / [#126](https://github.com/tracebloc/client/pull/126) and [#127](https://github.com/tracebloc/client/issues/127) / [#128](https://github.com/tracebloc/client/pull/128), which together with this PR finish polishing the customer-facing ingestor install loop.
- The 409 itself is enforced by jobs-manager in client-runtime — that behavior is correct and unchanged; this PR only changes what the chart hands to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm-template change that only affects the default `idempotencyKey` generation; primary risk is behavior change for users who relied on revision-based dedupe semantics implicitly.
> 
> **Overview**
> Updates the `ingestor` Helm chart so the default `idempotencyKey` is derived from `<release>-<unix-epoch>` (via `now | unixEpoch`) instead of `<release>-<revision>`, preventing collisions when a release is uninstalled and reinstalled under the same name.
> 
> Documentation is aligned to the new default and the override semantics (stable UUID for at-most-once replay), and the chart version is bumped to `0.1.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b9ae1abd491009a61a54977f54489f0892a2284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->