### PR TITLE
feat(#129)!: ingestor subchart default serviceAccount.create=false (0.2.0)

### DIFF
--- a/ingestor/Chart.yaml
+++ b/ingestor/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   the ingestor Job directly — this chart owns the config + hook
   artifacts, not the resulting Job or its data.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.3.0-rc1"
 keywords:
   - tracebloc

--- a/ingestor/README.md
+++ b/ingestor/README.md
@@ -10,13 +10,27 @@ helm install my-dataset tracebloc/ingestor \
 
 **The ingestor image is managed centrally** by the tracebloc client chart's auto-upgrade flow — you don't need to pin a digest for each install. New ingestor releases roll out automatically when the cluster's daily auto-upgrade cronjob (`autoUpgrade.enabled: true` in the client chart) bumps the chart version. See [Pinning a specific image version](#pinning-a-specific-image-version) below for the override path.
 
+## Prerequisites
+
+> **Install the `tracebloc/client` parent chart (1.3.4 or newer) into the
+> target namespace before installing this chart.** The parent chart
+> creates the `ingestor` ServiceAccount this chart's post-install hook
+> runs as, and renders the `ingestionAuthz` ConfigMap that authorizes
+> it. Without those preconditions the hook either has no SA to mount
+> or fails authentication at jobs-manager.
+
+The SA is shared by every `tracebloc/ingestor` release in the namespace
+— that's the point. Before 0.2.0 this chart created the SA itself,
+which broke as soon as a second ingestor release tried to install
+([tracebloc/client#129](https://github.com/tracebloc/client/issues/129)).
+
 ## What this chart owns
 
 | Resource | Owner | Lifecycle |
 |---|---|---|
 | `ConfigMap/<release>-config` (holds `ingest.yaml`) | this chart | created by `helm install`, deleted by `helm uninstall` |
 | `Job/<release>-submit` (post-install hook that POSTs) | this chart | created post-install, removed before each `helm upgrade` |
-| `ServiceAccount/<serviceAccount.name>` | this chart (optional, default true) | created by `helm install`, deleted by `helm uninstall` |
+| `ServiceAccount/<serviceAccount.name>` | **parent `tracebloc/client` chart** (as of 0.2.0; this chart can still create it via `serviceAccount.create: true` when targeting a pre-1.3.4 parent) | tied to the parent client release |
 | `ConfigMap/ingest-config-<hash>` (per-run, mounted into the ingestor Pod) | **jobs-manager** | created by jobs-manager on accept; not managed by Helm |
 | `Secret/ingest-token-<hash>` (per-run, holds `BACKEND_TOKEN`) | **jobs-manager** | same |
 | `Job/ingest-job-<hash>` (the actual ingestor) | **jobs-manager** | same |
@@ -85,7 +99,7 @@ kubectl -n tracebloc logs -l tracebloc.io/ingestion-run --tail=-1
 helm uninstall my-dataset --namespace tracebloc
 ```
 
-Removes the chart's ConfigMap + hook Job + ServiceAccount. Does **not** remove the running ingestor Job, its outputs, or the metadata posted to the backend — those are owned by jobs-manager and the cluster respectively.
+Removes the chart's ConfigMap + hook Job. The shared `ingestor` ServiceAccount is owned by the parent `tracebloc/client` release (as of 0.2.0) and stays put for other ingestor releases in the namespace. Does **not** remove the running ingestor Job, its outputs, or the metadata posted to the backend — those are owned by jobs-manager and the cluster respectively.
 
 To cancel an in-flight run, work with jobs-manager directly:
 

--- a/ingestor/values.yaml
+++ b/ingestor/values.yaml
@@ -50,10 +50,25 @@ jobsManager:
 # -- ServiceAccount that the post-install hook runs as. Its token is the
 # credential jobs-manager validates via TokenReview, and the SA's name +
 # namespace are matched against the ingestionAuthz policy in the
-# tracebloc client release. Default name matches the chart's default
-# `ingestionAuthz.allowed[0].service_account: ingestor` entry.
+# tracebloc client release.
+#
+# As of 0.2.0 (tracebloc/client#129) the SA is owned by the parent
+# `tracebloc/client` chart (templated as `ingestor` by default, or
+# whatever `ingestionAuthz.serviceAccountName` resolves to). The SA is
+# shared by every ingestor subchart release in the namespace, so per-
+# release ownership here collided with Helm on concurrent installs and
+# made uninstalls rip the SA out from under sibling releases.
+#
+# Default: `create: false`. The chart consumes the existing SA created
+# by the parent client release. The `name` value is still required so
+# the post-install hook Job knows which SA's token to mount.
+#
+# Override `create: true` ONLY when running against a parent client
+# chart older than 1.3.4 that didn't yet own the SA — in that case make
+# sure no other ingestor release in the same namespace also has
+# `create: true`, or you'll reproduce client#129.
 serviceAccount:
-  create: true
+  create: false
   name: ingestor
 
 # -- Image for the post-install hook Job itself (a thin curl wrapper).


### PR DESCRIPTION
## Summary

- Flip `serviceAccount.create` default from `true` → `false`. The parent `tracebloc/client` chart 1.3.4 now owns the `ingestor` ServiceAccount, so this subchart consumes the shared SA instead of trying to create a per-release one. Closes the concurrent-install collision and the uninstall-rips-out-the-SA failure documented in [#129](https://github.com/tracebloc/client/issues/129).
- Keep `serviceAccount.create: true` as an opt-in escape hatch for operators still on a pre-1.3.4 parent chart, with a `values.yaml` comment narrowing the safe use case.
- README: add a Prerequisites section pointing at the parent chart, and update the ownership table + uninstall section to reflect that the SA's lifecycle is now tied to the parent release.
- Bump chart to **0.2.0** (breaking default change).

## Paired PR

[#131](https://github.com/tracebloc/client/pull/131) moves the ServiceAccount into the parent `client` chart and bumps it to 1.3.4. **Merge that PR first** — the SA has to exist before any 0.2.0 ingestor release tries to consume it.

## Test plan

- [x] `helm template tracebloc/ingestor` with defaults — no `ServiceAccount` rendered; hook Job's `serviceAccountName: ingestor` still resolves to the SA owned by the parent.
- [x] `helm template tracebloc/ingestor --set serviceAccount.create=true` still renders the SA (back-compat escape hatch verified).
- [ ] In a fresh kind / k3d namespace: install `tracebloc/client` 1.3.4, then `helm install` this chart twice with different release names. Both succeed, `kubectl get sa ingestor -n <ns> -o jsonpath='{.metadata.annotations}'` shows ownership by the client release, and `helm uninstall <one-ingestor-release>` leaves the SA in place. Run once #131 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking Helm chart behavior change: `serviceAccount.create` now defaults to false and assumes a parent `tracebloc/client` release has provisioned the shared ServiceAccount; misordered installs or older parent versions could cause hook failures unless operators opt back in.
> 
> **Overview**
> Bumps the `tracebloc/ingestor` Helm chart to `0.2.0` and changes the default so it **no longer creates its own ServiceAccount** (`serviceAccount.create: false`), instead consuming a shared `ingestor` SA owned by the parent `tracebloc/client` chart to avoid cross-release install/uninstall collisions.
> 
> Updates docs and values commentary to require a parent client chart (`>=1.3.4`) and to clarify the ServiceAccount lifecycle, while keeping `serviceAccount.create: true` as an opt-in compatibility path for older parent releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87dd9ca820d888ecdb55fbfaae2ed5c5e4a8aa8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->