### PR TITLE
Bump ingestor digest to v0.3.0 + chart to 1.3.5

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.3.4
-appVersion: "1.3.4"
+version: 1.3.5
+appVersion: "1.3.5"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -187,13 +187,15 @@ images:
   # subchart's `image.digest` (for pinning / debugging), but the
   # dominant path uses this value.
   #
-  # Initial value: ghcr.io/tracebloc/ingestor@<v0.3.0-rc1 digest>. Bump
-  # this on each ingestor release; chart `version` in Chart.yaml must
+  # Bumped to v0.3.0 (2026-05-20) — first production-ready release of
+  # the declarative-YAML ingestor with schema-packaging, image-validator,
+  # and file-transfer fixes from tracebloc/data-ingestors#106.
+  # Bump this on each ingestor release; chart `version` in Chart.yaml must
   # also bump so the auto-upgrade cronjob detects the change. Future
   # automation in tracebloc/data-ingestors (release-image.yml) can
   # raise a PR to this file when a new image is published.
   ingestor:
-    digest: "sha256:e6639b084d0d377072dc908db376050914ebd49c730ddaa13f838d10f5482ea9"
+    digest: "sha256:463e236748708a5e3564569eec9173ea8cb3bcf515992d4939c5b610f3807a4a"
   podsMonitor:
     digest: ""
   resourceMonitor:


### PR DESCRIPTION
## Summary

Bumps `images.ingestor.digest` to the v0.3.0 release of
ghcr.io/tracebloc/ingestor, and bumps the chart from 1.3.4 → 1.3.5
so the auto-upgrade cronjob (#69) detects the change.

v0.3.0 is the first production-ready ingestor release:
- Cosign-signed + SBOM + SLSA provenance attestations
- Validated end-to-end against EKS on 2026-05-19 — 6 image files
  copied to PVC + 576 records inserted into MySQL via
  `helm install tracebloc/ingestor --set-file ingestConfig=…`.

## What changed in the ingestor between rc1 and v0.3.0

The image digest customers were pinning to before this PR was the rc1
build (`sha256:e6639b08…2ea9`), which had three real-cluster bugs that
shipped as tracebloc/data-ingestors#106:

- **#103** — schema/ingest.v1.json was missing from the wheel/sdist
  (package_data was a silent no-op without a `schema/__init__.py`)
- **#104** — image-resolution validator falsely rejected images at the
  configured target_size due to tuple-vs-list `==` comparison
- **#105** — `_has_extension` always returned False, producing
  `cat1.jpeg.jpeg` source paths and silently failing every
  file_transfer

v0.3.0 includes those fixes plus the lazy-Config refactor (#97/#98),
the summary-surfaces-failures fix (#99/#100), and the
DuplicateValidator-empty-dir fix (#101/#102).

## Verification

```
ghcr.io/tracebloc/ingestor@sha256:463e236748708a5e3564569eec9173ea8cb3bcf515992d4939c5b610f3807a4a
```

- Multi-arch OCI index with `linux/amd64` manifest + SLSA attestation
- Cosign verify command in the release notes:
  https://github.com/tracebloc/data-ingestors/releases/tag/v0.3.0

## Test plan

- [x] `docker buildx imagetools inspect` confirms image is pullable,
      signed, and has the SBOM attestation
- [ ] After merge: run the override-free EKS smoke test:
      ```bash
      helm install my-dataset tracebloc/ingestor \
        --namespace tracebloc-templates \
        --set-file ingestConfig=./sample-ingest.yaml
      ```
      (no `--set image.digest`, no `--set jobsManager.endpoint`,
      no `--set hookTimeoutSeconds`, no `--set serviceAccount.create` —
      this is the customer-facing UX)
- [ ] Confirm 6 files in `/data/shared/<table>/` + 576 rows in MySQL

## Related

- tracebloc/data-ingestors v0.3.0 release: https://github.com/tracebloc/data-ingestors/releases/tag/v0.3.0
- This unblocks publishing the client chart (no longer needs the
  --set image.digest workaround).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump that changes the pinned `ingestor` container image digest; impact is limited to deployments that rely on the chart’s default ingestor image pinning.
> 
> **Overview**
> Bumps the Helm chart `version`/`appVersion` from `1.3.4` to `1.3.5` so auto-upgrade detects a new release.
> 
> Updates the default pinned `images.ingestor.digest` to the `v0.3.0` ingestor image and refreshes the surrounding release comment to reflect the new baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef6ddbb02d57c2d6f093c2dba29e99f260737932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->