### PR TITLE
Publish ingestor subchart alongside parent chart

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -5,11 +5,13 @@ on:
     branches: [main, openshift]
     paths:
       - 'client/**'
+      - 'ingestor/**'
       - '.github/workflows/helm-ci.yaml'
   pull_request:
     branches: [main, openshift]
     paths:
       - 'client/**'
+      - 'ingestor/**'
       - '.github/workflows/helm-ci.yaml'
 
 jobs:
@@ -24,12 +26,23 @@ jobs:
         with:
           version: v3.15.4
 
-      - name: Helm lint (strict) — all platforms
+      - name: Helm lint (strict) — parent client chart, all platforms
         run: |
           for f in client/ci/*-values.yaml; do
-            echo "=== Linting with $f ==="
+            echo "=== Linting client with $f ==="
             helm lint --strict ./client -f "$f"
           done
+
+      - name: Helm lint (strict) — ingestor subchart
+        # The ingestor subchart has no per-platform CI values files because
+        # its templates don't branch on platform — they only render a
+        # ConfigMap + Job + SA. The chart's one required value
+        # (`ingestConfig`) is supplied by customers at install time via
+        # `--set-file`; missing it during lint emits an INFO, not a FAIL,
+        # so plain `helm lint --strict ./ingestor` exercises the templates
+        # cleanly. See #135 for why we lint it here at all (publish workflow
+        # now packages both charts).
+        run: helm lint --strict ./ingestor
 
   template:
     name: Template render

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -37,28 +37,44 @@ jobs:
         with:
           version: v3.15.4
 
-      - name: Lint chart
-        # Use a CI values file so `--strict` sees non-empty clientId /
-        # clientPassword (the defaults in values.yaml are deliberately empty
-        # to force operators to supply real credentials, and the schema
-        # enforces minLength:1). Exhaustive multi-platform linting happens in
-        # helm-ci.yaml on every PR — here we just need the chart to lint
-        # cleanly for packaging.
-        run: helm lint --strict ./client -f client/ci/eks-values.yaml
+      - name: Lint charts
+        # The parent `client` chart needs a CI values file so `--strict` sees
+        # non-empty clientId / clientPassword (the defaults in values.yaml are
+        # deliberately empty to force operators to supply real credentials, and
+        # the schema enforces minLength:1). The `ingestor` subchart needs no
+        # values file — its only required value (ingestConfig) emits an INFO
+        # level, not FAIL, when missing, and customers always supply it via
+        # --set-file at install time.
+        # Exhaustive multi-platform linting happens in helm-ci.yaml on every
+        # PR — here we just need both charts to lint cleanly for packaging.
+        run: |
+          helm lint --strict ./client -f client/ci/eks-values.yaml
+          helm lint --strict ./ingestor
 
-      - name: Package tracebloc chart
+      - name: Package tracebloc charts
         id: package
+        # Package BOTH the parent client chart AND the ingestor subchart.
+        # Customers run two flavors of install:
+        #   1. `helm install tracebloc/client ...` — bootstraps the cluster.
+        #   2. `helm install tracebloc/ingestor ...` — per-dataset ingestion.
+        # Both must resolve from the same helm repo, so both .tgz files need
+        # to live alongside each other in gh-pages and be referenced in a
+        # single shared index.yaml. Earlier versions packaged only `./client`
+        # and the second install path failed with "chart not found" — see #135.
         run: |
           helm package ./client
-          TGZ=$(ls -t client-*.tgz | head -1)
-          echo "chart_tgz=$TGZ" >> $GITHUB_OUTPUT
-          echo "Packaged $TGZ"
+          helm package ./ingestor
+          echo "Packaged:"
+          ls -la *.tgz
 
-      - name: Upload chart artifact
+      - name: Upload chart artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: helm-chart
-          path: ${{ steps.package.outputs.chart_tgz }}
+          name: helm-charts
+          # Glob picks up both client-*.tgz and ingestor-*.tgz.
+          path: |
+            client-*.tgz
+            ingestor-*.tgz
 
       - name: Configure Git
         run: |
@@ -70,7 +86,8 @@ jobs:
         run: |
           # Remove any local chart packages before switching branches to avoid
           # "untracked working tree files would be overwritten" checkout errors.
-          rm -f client-*.tgz || true
+          # Cover both chart name prefixes — see Package step above.
+          rm -f client-*.tgz ingestor-*.tgz || true
           if git fetch origin gh-pages 2>/dev/null; then
             git checkout gh-pages
             echo "index_exists=true" >> $GITHUB_OUTPUT
@@ -80,37 +97,45 @@ jobs:
             echo "index_exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Download chart artifact
+      - name: Download chart artifacts
         uses: actions/download-artifact@v4
         with:
-          name: helm-chart
+          name: helm-charts
 
       - name: Update index and push to gh-pages
         env:
           REPO_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
         run: |
+          # `helm repo index .` indexes every .tgz in the working dir, so both
+          # client-*.tgz and ingestor-*.tgz get listed in the shared
+          # index.yaml. Customers then resolve `tracebloc/client` and
+          # `tracebloc/ingestor` from the same repo URL.
           if [ "${{ steps.fetch.outputs.index_exists }}" = "true" ] && [ -f index.yaml ]; then
             helm repo index . --url "$REPO_URL" --merge index.yaml
           else
             helm repo index . --url "$REPO_URL"
           fi
-          git add index.yaml client-*.tgz
+          git add index.yaml client-*.tgz ingestor-*.tgz
           git status
           if git diff --staged --quiet; then
             echo "No index/tgz changes to commit"
           else
-            git commit -m "Release helm chart(s): $(ls client-*.tgz 2>/dev/null | tr '\n' ' ')"
+            git commit -m "Release helm chart(s): $(ls client-*.tgz ingestor-*.tgz 2>/dev/null | tr '\n' ' ')"
             git push origin gh-pages
           fi
 
-      - name: Upload chart to GitHub Release
+      - name: Upload charts to GitHub Release
         # Pin tag_name from the release event payload rather than relying on
         # github.ref / github.ref_name, which intermittently arrive empty on
         # release-triggered runs (actions/runner#2788, still open).
+        # Attach BOTH chart tgzs so downloaders pinning a specific release
+        # tag can pull either chart's exact bytes from this release page.
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.release.tag_name }}
-          files: client-*.tgz
+          files: |
+            client-*.tgz
+            ingestor-*.tgz
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ingestor/Chart.yaml
+++ b/ingestor/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   artifacts, not the resulting Job or its data.
 type: application
 version: 0.2.0
-appVersion: "0.3.0-rc1"
+appVersion: "0.3.0"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
## Summary

Unblocks the customer-facing install path. Without this, the documented command

```bash
helm repo add tracebloc https://tracebloc.github.io/client
helm install my-dataset tracebloc/ingestor \
  --namespace tracebloc-templates \
  --set-file ingestConfig=./my.yaml
```

returns `Error: chart "ingestor" not found` after a release because the existing
`release-helm-chart.yaml` only packaged `./client`. Three changes:

1. **`release-helm-chart.yaml`** — package + index BOTH `./client` and
   `./ingestor`. Single shared `index.yaml` in gh-pages so customers resolve
   both charts from the same `helm repo add tracebloc ...`. Attach both tgzs
   to the GitHub release.

2. **`helm-ci.yaml`** — add a lint step for `./ingestor` on every PR alongside
   the existing per-platform client lints. Plain `helm lint --strict` is
   sufficient (ingestor has one required value, `ingestConfig`, which emits
   INFO not FAIL when missing; the templates don't branch on platform, so the
   per-platform-values matrix that the parent chart needs doesn't apply).

3. **`ingestor/Chart.yaml`** — bump `appVersion` `0.3.0-rc1` → `0.3.0` to
   match the tracebloc/data-ingestors v0.3.0 release that just shipped
   (https://github.com/tracebloc/data-ingestors/releases/tag/v0.3.0). Chart
   `version` (0.2.0) is unchanged; appVersion is purely descriptive.

## Test plan

- [x] Both charts package cleanly locally:
  ```
  Successfully packaged chart and saved it to: client-1.3.5.tgz
  Successfully packaged chart and saved it to: ingestor-0.2.0.tgz
  ```
- [x] All four platform-specific lints pass (aks/bm/eks/oc) for client.
- [x] Plain `helm lint --strict ./ingestor` passes.
- [x] YAML syntax valid for both workflow files.
- [ ] After merge + release tag: `tracebloc.github.io/client/index.yaml` lists
      both `client` and `ingestor` entries.
- [ ] After merge + release tag: customer install command resolves and
      succeeds end-to-end (validated today against EKS with local-path
      install — 6 files in PVC + 576 rows in MySQL).

## Closes

#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Helm release/publishing workflow to package, index, and upload multiple chart artifacts, which can break chart distribution if misconfigured. No runtime application logic is modified beyond an `appVersion` metadata bump.
> 
> **Overview**
> **Helm chart distribution now includes `ingestor` alongside `client`.** The Helm CI workflow starts triggering on `ingestor/**` changes and adds a strict lint step for the `ingestor` chart.
> 
> The release workflow is updated to lint, package, artifact-upload, index (gh-pages), and attach to GitHub Releases **both** `client-*.tgz` and `ingestor-*.tgz`, so `tracebloc/ingestor` resolves from the same repo as `tracebloc/client`. Separately, `ingestor/Chart.yaml` bumps `appVersion` from `0.3.0-rc1` to `0.3.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c16b2a43eb546003dd23c95bedf6946785fd10cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->