### PR TITLE
docs(ingestor): explain image vs chart update lifecycle

### DIFF
--- a/ingestor/README.md
+++ b/ingestor/README.md
@@ -50,6 +50,20 @@ which broke as soon as a second ingestor release tried to install
 
 The customer never builds an image. The customer never writes a Dockerfile. The customer writes ~8 lines of YAML.
 
+## How updates work
+
+The ingestor has two independent update lifecycles, and customers usually only need to think about one.
+
+**Image: always current, automatically.** New `ghcr.io/tracebloc/ingestor` releases roll out to your cluster via the parent `tracebloc/client` chart's auto-upgrade cronjob (`autoUpgrade.enabled: true`, default). The cronjob runs `helm repo update` + `helm upgrade tracebloc/client` daily, which writes the new digest into the `INGESTOR_IMAGE_DIGEST` env on the running `tracebloc-jobs-manager` deployment. Your next `helm install tracebloc/ingestor ...` uses the new image automatically — no digest to pin, no version to track, no redeploy of anything you've already installed.
+
+**Chart: refresh your local cache before each install.** Helm's repo cache on _your workstation_ is independent of the cluster. The cluster's cronjob can refresh its own cache, but it cannot reach your laptop. Run `helm repo update` before each install to pick up new chart features (new values, new templates, new defaults). A stale cache still works — it just locks you out of chart-level options added since you last refreshed. **The image you run does not depend on the chart version**: jobs-manager picks the current `INGESTOR_IMAGE_DIGEST` regardless of which subchart version submitted the request.
+
+This stratification is intentional. The image picks up bugfixes and security patches without anyone restating their dataset configs; the chart only changes when there's a real protocol or UX shift.
+
+### What about previously-installed ingestor releases?
+
+Nothing to upgrade. The chart is fire-and-forget: each `helm install` POSTs once to jobs-manager, the ingestor Job runs to completion, and the chart artifacts (ConfigMap + completed hook Job) become inert. There's no controller to update, no deployment to roll, no scheduled work to bump. `helm upgrade <release>` would replay the same submission as a 200 no-op (the idempotency key was stamped at install time and is preserved under `--reuse-values`).
+
 ## Required values
 
 | Value | Description |


### PR DESCRIPTION
## Summary

Adds a \`## How updates work\` section to the ingestor chart README.
Was meant to land as part of PR #136 but got pushed 32 seconds after
the squash-merge — missed the window. This is the same commit
(\`10c7381\`), cherry-picked onto a fresh branch off develop.

## Why this matters

Customers ask: \"the cluster has an auto-upgrade cronjob — does that
mean my ingestor chart updates too?\" The answer is nuanced:

- The ingestor **image** auto-updates via the parent client chart's
  cronjob writing the digest into \`INGESTOR_IMAGE_DIGEST\` on
  jobs-manager. Image stays current automatically.
- The ingestor **chart** on the customer's workstation is independent
  — Helm's repo cache doesn't refresh itself. Customers run
  \`helm repo update\` periodically (standard helm UX).

The new section explains this two-layer model and the strong
property: the image you run does not depend on the chart version.
Plus an FAQ on previously-installed releases (nothing to upgrade —
fire-and-forget).

## Test plan

- [x] README renders correctly (verified via raw content review)
- [x] No code changes; nothing else to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change with no impact on runtime behavior or configuration defaults.
> 
> **Overview**
> Adds a new **“How updates work”** section to the `tracebloc/ingestor` chart README clarifying the split between automatic ingestor *image* updates (via the parent `tracebloc/client` auto-upgrade cronjob updating `INGESTOR_IMAGE_DIGEST`) and manual *chart* updates on the user’s workstation (via `helm repo update`).
> 
> Also documents that previously installed ingestor releases are *fire-and-forget* and don’t require upgrades; `helm upgrade` will effectively be a no-op due to the idempotency key behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bdde8e704191a6211e3af18530de891293aa9f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->