### PR TITLE
feat(#154): auto-refresh jobs-manager image on Docker Hub publish

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.3.5
-appVersion: "1.3.5"
+version: 1.4.0
+appVersion: "1.4.0"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -106,6 +106,35 @@ mysql-pvc
 {{- end }}
 
 {{/*
+  Release-scoped name shared by the image-refresh CronJob, ServiceAccount,
+  Role, RoleBinding, and ConfigMap. Same lockstep reasoning as
+  tracebloc.autoUpgradeName above. Distinct from auto-upgrade because the
+  two CronJobs have different cadences, different RBAC scopes (image-refresh
+  is namespace-scoped, auto-upgrade is cluster-admin), and customers may
+  reasonably disable one but not the other.
+*/}}
+{{- define "tracebloc.imageRefreshName" -}}
+{{ .Release.Name }}-image-refresh
+{{- end }}
+
+{{/*
+  Whether the image-refresh CronJob has anything to do. When BOTH
+  jobs-manager and pods-monitor are digest-pinned, the customer has
+  explicitly opted into reproducible pinning and we must not fight that
+  by restarting on tag changes. In that case we render nothing — no
+  CronJob, no RBAC, no ConfigMap. If only one is pinned, the other can
+  still drift, so the CronJob is rendered and the script skips the
+  pinned image at runtime via env flags.
+*/}}
+{{- define "tracebloc.imageRefreshEnabled" -}}
+{{- if not .Values.imageRefresh.enabled -}}
+{{- else if and .Values.images.jobsManager.digest .Values.images.podsMonitor.digest -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
   StorageClass name: when storageClass.create is true, use a release-unique name
   so each release gets its own StorageClass (avoids Helm ownership conflicts).
   When create is false, use the user-provided storageClass.name for an existing class.

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -125,10 +125,24 @@ mysql-pvc
   CronJob, no RBAC, no ConfigMap. If only one is pinned, the other can
   still drift, so the CronJob is rendered and the script skips the
   pinned image at runtime via env flags.
+
+  Nil-guarded with `default dict` on every dereference: this is a new
+  top-level key in 1.4.0, and a customer who runs
+  `helm upgrade --reuse-values` (instead of the recommended
+  --reset-then-reuse-values that autoUpgrade itself uses) would replay
+  stored 1.3.x values that have no `imageRefresh` block. Without the
+  guard, `.Values.imageRefresh.enabled` would still nil-coalesce safely,
+  but `.Values.images.jobsManager.digest` could crash if `.Values.images`
+  were ever absent. Belt-and-suspenders — see the "nil-guard every new
+  top-level value key" rule in CLAUDE.md.
 */}}
 {{- define "tracebloc.imageRefreshEnabled" -}}
-{{- if not .Values.imageRefresh.enabled -}}
-{{- else if and .Values.images.jobsManager.digest .Values.images.podsMonitor.digest -}}
+{{- $ir := default dict .Values.imageRefresh -}}
+{{- $imgs := default dict .Values.images -}}
+{{- $jm := default dict $imgs.jobsManager -}}
+{{- $pm := default dict $imgs.podsMonitor -}}
+{{- if not $ir.enabled -}}
+{{- else if and $jm.digest $pm.digest -}}
 {{- else -}}
 true
 {{- end -}}

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -39,6 +39,12 @@ data:
     # the Docker-Content-Digest header for both manifest-v2 single-arch and
     # the OCI / multi-arch index variants, but only when the client signals
     # support; omit one and registries that return that variant will 404.
+    #
+    # The media types are sent as a SINGLE comma-separated Accept header
+    # per the Docker registry v2 spec and the HTTP semantics RFC 7230 §3.2.2
+    # (which allows the syntactically-equivalent multi-line form, but the
+    # registry's documented form is the single-header one; some proxies
+    # have been observed dropping or reordering repeated Accept headers).
     get_latest_digest() {
       _repo="$1"
       _token="$(get_token "$_repo")"
@@ -53,10 +59,7 @@ data:
       # lowercase-by-spec (sha256:<64 hex>), so tr never mangles the value.
       curl -fsSI --max-time 10 \
         -H "Authorization: Bearer $_token" \
-        -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
-        -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
-        -H "Accept: application/vnd.oci.image.manifest.v1+json" \
-        -H "Accept: application/vnd.oci.image.index.v1+json" \
+        -H "Accept: application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json" \
         "https://registry-1.docker.io/v2/${_repo}/manifests/${IMAGE_TAG}" \
         | tr '[:upper:]' '[:lower:]' \
         | awk '/^docker-content-digest:/ {print $2}' \

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -1,0 +1,226 @@
+{{- if include "tracebloc.imageRefreshEnabled" . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-refresh
+data:
+  image-refresh.sh: |
+    #!/bin/sh
+    # Compares the latest manifest digest on Docker Hub against the running
+    # container's digest for jobs-manager and pods-monitor. If either has
+    # changed, rolls the deployment. See `imageRefresh` in values.yaml for
+    # the design + trust-boundary discussion.
+    #
+    # Parsing is sed/awk-only on purpose: alpine/k8s ships jq, but keeping
+    # the script jq-free means it survives image swaps to leaner bases.
+    set -eu
+
+    log() { printf '[image-refresh] %s\n' "$*"; }
+
+    log "release=$RELEASE_NAME namespace=$RELEASE_NAMESPACE tag=$IMAGE_TAG deployment=$DEPLOYMENT_NAME"
+
+    # Get an anonymous pull-scope token for one repository on Docker Hub.
+    get_token() {
+      _repo="$1"
+      # tr cleanup handles the trailing newline some curl builds emit.
+      curl -fsS --max-time 10 \
+        "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${_repo}:pull" \
+        | sed -n 's/.*"token":"\([^"]*\)".*/\1/p' \
+        | tr -d '\r\n'
+    }
+
+    # Resolve the manifest digest for repo:tag from Docker Hub. We HEAD the
+    # manifest endpoint with all four Accept media types — registries serve
+    # the Docker-Content-Digest header for both manifest-v2 single-arch and
+    # the OCI / multi-arch index variants, but only when the client signals
+    # support; omit one and registries that return that variant will 404.
+    get_latest_digest() {
+      _repo="$1"
+      _token="$(get_token "$_repo")"
+      if [ -z "$_token" ]; then
+        log "  WARN: could not fetch auth token for $_repo"
+        return 1
+      fi
+      curl -fsSI --max-time 10 \
+        -H "Authorization: Bearer $_token" \
+        -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+        -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+        -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+        -H "Accept: application/vnd.oci.image.index.v1+json" \
+        "https://registry-1.docker.io/v2/${_repo}/manifests/${IMAGE_TAG}" \
+        | awk 'BEGIN{IGNORECASE=1} /^docker-content-digest:/ {print $2}' \
+        | tr -d '\r\n'
+    }
+
+    # Read the running pod's imageID for a specific container by name.
+    # imageID format is `<registry>/<repo>@sha256:...`; we trim the prefix
+    # so it can be compared directly against the registry's digest.
+    get_running_digest() {
+      _container="$1"
+      kubectl get pod -n "$RELEASE_NAMESPACE" -l app=manager \
+        -o jsonpath="{.items[0].status.containerStatuses[?(@.name=='${_container}')].imageID}" \
+        | sed 's|.*@||' \
+        | tr -d '\r\n'
+    }
+
+    restart_needed=0
+
+    # Each entry: "<docker-hub-repo>|<container-name-in-pod>|<digest-pin-flag>".
+    # digest-pin-flag is "1" when values pin the image by digest — the
+    # deployment uses imagePullPolicy: IfNotPresent for that container and
+    # restarting on tag drift would fight the customer's opt-in pinning.
+    set -- \
+      "tracebloc/jobs-manager|api|${JOBS_MANAGER_PINNED}" \
+      "tracebloc/pods-monitor|pods-monitor-container|${PODS_MONITOR_PINNED}"
+
+    for entry in "$@"; do
+      repo="${entry%%|*}"
+      rest="${entry#*|}"
+      container="${rest%%|*}"
+      pinned="${rest#*|}"
+
+      log "checking ${repo}:${IMAGE_TAG} (container=${container})"
+
+      if [ "$pinned" = "1" ]; then
+        log "  pinned by digest in values; skipping (auto-refresh disabled for this image)"
+        continue
+      fi
+
+      latest="$(get_latest_digest "$repo" || true)"
+      if [ -z "$latest" ]; then
+        log "  WARN: could not resolve latest digest (rate-limited or transient); skipping this tick"
+        continue
+      fi
+
+      running="$(get_running_digest "$container" || true)"
+      if [ -z "$running" ]; then
+        log "  WARN: could not read running digest for container=$container; skipping"
+        continue
+      fi
+
+      log "  latest=$latest"
+      log "  running=$running"
+
+      if [ "$latest" != "$running" ]; then
+        log "  digest changed -> restart needed"
+        restart_needed=1
+      else
+        log "  digests match"
+      fi
+    done
+
+    if [ "$restart_needed" -eq 0 ]; then
+      log "all images up to date; nothing to do"
+      exit 0
+    fi
+
+    log "rolling restart of deployment/${DEPLOYMENT_NAME}"
+    kubectl rollout restart -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}"
+    kubectl rollout status  -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" \
+      --timeout="$ROLLOUT_TIMEOUT"
+    log "rollout complete"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-refresh
+spec:
+  schedule: {{ .Values.imageRefresh.schedule | quote }}
+  suspend: {{ .Values.imageRefresh.suspend }}
+  # Forbid: never run two checks at once. A long rollout that crosses the
+  # next scheduled tick must not stack a second `rollout restart` on top
+  # of itself — that would orphan the in-flight rollout's new ReplicaSet.
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.imageRefresh.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.imageRefresh.failedJobsHistoryLimit }}
+  startingDeadlineSeconds: {{ .Values.imageRefresh.startingDeadlineSeconds }}
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            {{- include "tracebloc.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: image-refresh
+        spec:
+          serviceAccountName: {{ include "tracebloc.imageRefreshName" . }}
+          restartPolicy: OnFailure
+          {{- if include "tracebloc.useImagePullSecrets" . }}
+          imagePullSecrets:
+            - name: {{ include "tracebloc.registrySecretName" . }}
+          {{- end }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: refresh
+              image: "{{ .Values.imageRefresh.image.repository }}:{{ .Values.imageRefresh.image.tag }}"
+              imagePullPolicy: {{ .Values.imageRefresh.image.pullPolicy }}
+              # alpine/k8s entrypoint is kubectl; override to run our script.
+              command: ["/bin/sh", "/scripts/image-refresh.sh"]
+              env:
+                # alpine/k8s's kubectl writes a discovery cache under
+                # $HOME/.kube. The pod runs uid 1000 with
+                # readOnlyRootFilesystem, so point HOME at the writable
+                # emptyDir mounted at /home/kubectl.
+                - name: HOME
+                  value: "/home/kubectl"
+                - name: RELEASE_NAME
+                  value: {{ .Release.Name | quote }}
+                - name: RELEASE_NAMESPACE
+                  value: {{ .Release.Namespace | quote }}
+                - name: DEPLOYMENT_NAME
+                  value: {{ printf "%s-jobs-manager" .Release.Name | quote }}
+                - name: IMAGE_TAG
+                  value: {{ .Values.env.CLIENT_ENV | default "prod" | quote }}
+                - name: ROLLOUT_TIMEOUT
+                  value: {{ .Values.imageRefresh.rolloutTimeout | quote }}
+                # Per-image opt-out flags. When the operator pins by digest
+                # in values.images.*.digest, skip that image — auto-refresh
+                # is incompatible with the reproducibility contract digest
+                # pinning provides.
+                - name: JOBS_MANAGER_PINNED
+                  value: {{ ternary "1" "0" (not (empty .Values.images.jobsManager.digest)) | quote }}
+                - name: PODS_MONITOR_PINNED
+                  value: {{ ternary "1" "0" (not (empty .Values.images.podsMonitor.digest)) | quote }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                {{- toYaml .Values.imageRefresh.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+                # alpine/k8s's kubectl writes a cache under $HOME (default
+                # /root). The pod runs as uid 1000 with readOnlyRootFilesystem,
+                # so HOME=/home/kubectl needs to be writable; emptyDir mount.
+                - name: home
+                  mountPath: /home/kubectl
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "tracebloc.imageRefreshName" . }}
+                defaultMode: 0555
+            - name: tmp
+              emptyDir: {}
+            - name: home
+              emptyDir: {}
+{{- end }}

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -92,21 +92,37 @@ data:
     # Single-arch manifests have sha256: refs inside `config` and
     # `layers`, NOT manifest digests — so we gate this on the presence
     # of a `"manifests"` key, which only the index/list bodies carry.
+    #
+    # Exit status MUST distinguish transient failure from
+    # "successfully-fetched-but-single-platform" so the caller can decide
+    # whether to skip the tick (transient) or proceed with the top-level
+    # HEAD digest as authoritative (single-platform). Treating empty
+    # output as "no match" would cause every transient network blip to
+    # spuriously restart the deployment — caught in PR #155 review
+    # (bugbot, medium severity).
+    #   return 0 + (possibly empty) stdout = fetched OK; caller may
+    #                                        treat empty as "single-arch
+    #                                        body, HEAD digest is final".
+    #   return 1                            = transient; caller should
+    #                                        skip this tick.
     get_index_digests() {
       _repo="$1"
       _token="$(get_token "$_repo")"
       if [ -z "$_token" ]; then
         return 1
       fi
-      _body="$(curl -fsS --max-time 10 \
+      if ! _body="$(curl -fsS --max-time 10 \
         -H "Authorization: Bearer $_token" \
         -H "Accept: application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json" \
-        "https://registry-1.docker.io/v2/${_repo}/manifests/${IMAGE_TAG}")"
+        "https://registry-1.docker.io/v2/${_repo}/manifests/${IMAGE_TAG}")"; then
+        return 1
+      fi
       # Only enumerate digests for index/list bodies. For single-platform
       # manifests, the top-level HEAD digest is already authoritative.
       if printf '%s' "$_body" | grep -q '"manifests"'; then
         printf '%s' "$_body" | grep -oE 'sha256:[a-f0-9]{64}'
       fi
+      return 0
     }
 
     restart_needed=0
@@ -156,14 +172,32 @@ data:
       # asymmetry where `latest` is the index digest and `running` is a
       # per-platform manifest digest. Disambiguate by fetching the index
       # body and checking whether running ∈ per-platform digests.
+      #
+      # Critically, capture the exit status of get_index_digests
+      # separately from its stdout: a transient GET failure (timeout,
+      # rate-limit, token failure) must skip the tick, NOT fall through
+      # to restart_needed=1. Treating "empty output" as "no match" would
+      # turn every network blip into a spurious deployment restart.
       log "  top-level mismatch; checking multi-arch index for match"
+      if ! _index_digests="$(get_index_digests "$repo")"; then
+        log "  WARN: could not fetch index body (rate-limited or transient); skipping this tick to avoid spurious restart"
+        continue
+      fi
+
       _matched=0
-      for _d in $(get_index_digests "$repo" || true); do
-        if [ "$_d" = "$running" ]; then
-          _matched=1
-          break
-        fi
-      done
+      if [ -n "$_index_digests" ]; then
+        # Multi-arch index body — check membership.
+        for _d in $_index_digests; do
+          if [ "$_d" = "$running" ]; then
+            _matched=1
+            break
+          fi
+        done
+      fi
+      # If _index_digests is empty here, the response was a single-platform
+      # manifest body (no "manifests" key). The top-level HEAD digest was
+      # already authoritative for that case, and we know it didn't match —
+      # so falling through to restart_needed=1 is correct.
 
       if [ "$_matched" -eq 1 ]; then
         log "  running matches a per-platform manifest digest in the index; up to date"

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -77,6 +77,38 @@ data:
         | tr -d '\r\n'
     }
 
+    # For multi-arch tags: GET the manifest body and extract every
+    # per-platform manifest digest. This handles the runtime/registry
+    # asymmetry from kubernetes/kubernetes#108689 + #115199 — Docker Hub's
+    # HEAD on a multi-arch tag returns the INDEX digest, but containerd
+    # records the PLATFORM-specific manifest digest in containerStatuses
+    # imageID. The two will never match directly; instead, we check
+    # whether running ∈ {all per-platform digests in the index}.
+    #
+    # An OCI/Docker index's only sha256: references live inside
+    # `manifests[].digest`, so a plain `grep -oE 'sha256:[a-f0-9]{64}'`
+    # on the body suffices — no jq needed (which keeps the script's
+    # parsing dependencies the same as the auto-upgrade pattern).
+    # Single-arch manifests have sha256: refs inside `config` and
+    # `layers`, NOT manifest digests — so we gate this on the presence
+    # of a `"manifests"` key, which only the index/list bodies carry.
+    get_index_digests() {
+      _repo="$1"
+      _token="$(get_token "$_repo")"
+      if [ -z "$_token" ]; then
+        return 1
+      fi
+      _body="$(curl -fsS --max-time 10 \
+        -H "Authorization: Bearer $_token" \
+        -H "Accept: application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json" \
+        "https://registry-1.docker.io/v2/${_repo}/manifests/${IMAGE_TAG}")"
+      # Only enumerate digests for index/list bodies. For single-platform
+      # manifests, the top-level HEAD digest is already authoritative.
+      if printf '%s' "$_body" | grep -q '"manifests"'; then
+        printf '%s' "$_body" | grep -oE 'sha256:[a-f0-9]{64}'
+      fi
+    }
+
     restart_needed=0
 
     # Each entry: "<docker-hub-repo>|<container-name-in-pod>|<digest-pin-flag>".
@@ -115,11 +147,29 @@ data:
       log "  latest=$latest"
       log "  running=$running"
 
-      if [ "$latest" != "$running" ]; then
+      if [ "$latest" = "$running" ]; then
+        log "  digests match"
+        continue
+      fi
+
+      # Top-level mismatch. Could be a genuine update OR a multi-arch
+      # asymmetry where `latest` is the index digest and `running` is a
+      # per-platform manifest digest. Disambiguate by fetching the index
+      # body and checking whether running ∈ per-platform digests.
+      log "  top-level mismatch; checking multi-arch index for match"
+      _matched=0
+      for _d in $(get_index_digests "$repo" || true); do
+        if [ "$_d" = "$running" ]; then
+          _matched=1
+          break
+        fi
+      done
+
+      if [ "$_matched" -eq 1 ]; then
+        log "  running matches a per-platform manifest digest in the index; up to date"
+      else
         log "  digest changed -> restart needed"
         restart_needed=1
-      else
-        log "  digests match"
       fi
     done
 

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -11,16 +11,41 @@ metadata:
 data:
   image-refresh.sh: |
     #!/bin/sh
-    # Compares the latest manifest digest on Docker Hub against the running
-    # container's digest for jobs-manager and pods-monitor. If either has
-    # changed, rolls the deployment. See `imageRefresh` in values.yaml for
-    # the design + trust-boundary discussion.
+    # Polls Docker Hub for new manifest digests of tracebloc/jobs-manager
+    # and tracebloc/pods-monitor under the floating CLIENT_ENV tag, and
+    # rolls the jobs-manager Deployment whenever a published digest
+    # differs from the one we last successfully rolled to.
     #
-    # Parsing is sed/awk-only on purpose: alpine/k8s ships jq, but keeping
-    # the script jq-free means it survives image swaps to leaner bases.
+    # Source of truth: an annotation on the deployment itself
+    # (`tracebloc.io/last-refreshed-<image>-digest`) records the digest
+    # the last successful refresh restarted to. We compare what the
+    # registry publishes today to that recorded value, NOT to the running
+    # pod's containerStatuses[].imageID. This sidesteps:
+    #   * imageID format variation across container runtimes
+    #     (kubernetes/kubernetes#108689 + #115199 — containerd records
+    #     platform-specific manifest digests, dockershim records other
+    #     things, value is documented as inconsistent).
+    #   * multi-arch manifest-list vs platform-manifest divergence — the
+    #     registry returns the index digest under the tag, the runtime
+    #     records a per-platform digest, the two never match.
+    # Both classes of bug disappear when the comparison is "what the
+    # registry says today" vs "what we wrote into the annotation last
+    # time we acted on a change."
+    #
+    # First-tick contract: when an annotation is absent, we record the
+    # current digest WITHOUT restarting. The customer just installed (or
+    # someone manually wiped the annotation) — no evidence of drift, so
+    # no churn. Subsequent ticks compare to the recorded value normally.
+    #
+    # Parsing is sed/awk-only on purpose: alpine/k8s ships jq, but
+    # keeping the script jq-free means it survives image swaps to leaner
+    # bases — same constraint as the auto-upgrade script in this chart.
+    #
+    # All log() output goes to stderr so it can never pollute a
+    # command-substitution capture site like `latest="$(...)"`.
     set -eu
 
-    log() { printf '[image-refresh] %s\n' "$*"; }
+    log() { printf '[image-refresh] %s\n' "$*" >&2; }
 
     log "release=$RELEASE_NAME namespace=$RELEASE_NAMESPACE tag=$IMAGE_TAG deployment=$DEPLOYMENT_NAME"
 
@@ -34,17 +59,20 @@ data:
         | tr -d '\r\n'
     }
 
-    # Resolve the manifest digest for repo:tag from Docker Hub. We HEAD the
-    # manifest endpoint with all four Accept media types — registries serve
-    # the Docker-Content-Digest header for both manifest-v2 single-arch and
-    # the OCI / multi-arch index variants, but only when the client signals
-    # support; omit one and registries that return that variant will 404.
+    # Resolve the manifest digest for repo:tag from Docker Hub. We HEAD
+    # the manifest endpoint with all four manifest media types in a
+    # single comma-separated Accept header (registry v2 spec form; some
+    # TLS-terminating proxies have been observed dropping repeated
+    # Accept headers). The value returned in Docker-Content-Digest is
+    # whatever the registry serves for that tag — for multi-arch tags
+    # the index digest, for single-arch the manifest digest. Both work
+    # here because we compare to OUR annotation, not to a runtime
+    # imageID; consistency tick-over-tick is all we need.
     #
-    # The media types are sent as a SINGLE comma-separated Accept header
-    # per the Docker registry v2 spec and the HTTP semantics RFC 7230 §3.2.2
-    # (which allows the syntactically-equivalent multi-line form, but the
-    # registry's documented form is the single-header one; some proxies
-    # have been observed dropping or reordering repeated Accept headers).
+    # Case-fold with tr BEFORE awk: alpine/k8s ships BusyBox awk which
+    # silently ignores gawk's IGNORECASE=1, and the header case differs
+    # between HTTP/1.1 and HTTP/2. Digest values are lowercase-by-spec
+    # (sha256:<64 hex>) so the value is unaffected.
     get_latest_digest() {
       _repo="$1"
       _token="$(get_token "$_repo")"
@@ -52,11 +80,6 @@ data:
         log "  WARN: could not fetch auth token for $_repo"
         return 1
       fi
-      # Header case varies by transport: HTTP/2 mandates lowercase but
-      # HTTP/1.1 over a TLS-terminating proxy can return mixed case.
-      # alpine/k8s ships BusyBox awk, which silently ignores gawk's
-      # IGNORECASE=1, so we case-fold with tr BEFORE awk. Digests are
-      # lowercase-by-spec (sha256:<64 hex>), so tr never mangles the value.
       curl -fsSI --max-time 10 \
         -H "Authorization: Bearer $_token" \
         -H "Accept: application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json" \
@@ -66,82 +89,35 @@ data:
         | tr -d '\r\n'
     }
 
-    # Read the running pod's imageID for a specific container by name.
-    # imageID format is `<registry>/<repo>@sha256:...`; we trim the prefix
-    # so it can be compared directly against the registry's digest.
-    get_running_digest() {
-      _container="$1"
-      kubectl get pod -n "$RELEASE_NAMESPACE" -l app=manager \
-        -o jsonpath="{.items[0].status.containerStatuses[?(@.name=='${_container}')].imageID}" \
-        | sed 's|.*@||' \
+    # Read an annotation value off the deployment. Empty output means
+    # the annotation is absent (first observation) — distinct from an
+    # explicit empty string, which the chart never writes.
+    get_annotation() {
+      _key="$1"
+      # jsonpath treats '.' / '/' as separators; brace-escape the key.
+      kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" \
+        -o "jsonpath={.metadata.annotations['$_key']}" \
         | tr -d '\r\n'
     }
 
-    # For multi-arch tags: GET the manifest body and extract every
-    # per-platform manifest digest. This handles the runtime/registry
-    # asymmetry from kubernetes/kubernetes#108689 + #115199 — Docker Hub's
-    # HEAD on a multi-arch tag returns the INDEX digest, but containerd
-    # records the PLATFORM-specific manifest digest in containerStatuses
-    # imageID. The two will never match directly; instead, we check
-    # whether running ∈ {all per-platform digests in the index}.
-    #
-    # An OCI/Docker index's only sha256: references live inside
-    # `manifests[].digest`, so a plain `grep -oE 'sha256:[a-f0-9]{64}'`
-    # on the body suffices — no jq needed (which keeps the script's
-    # parsing dependencies the same as the auto-upgrade pattern).
-    # Single-arch manifests have sha256: refs inside `config` and
-    # `layers`, NOT manifest digests — so we gate this on the presence
-    # of a `"manifests"` key, which only the index/list bodies carry.
-    #
-    # Exit status MUST distinguish transient failure from
-    # "successfully-fetched-but-single-platform" so the caller can decide
-    # whether to skip the tick (transient) or proceed with the top-level
-    # HEAD digest as authoritative (single-platform). Treating empty
-    # output as "no match" would cause every transient network blip to
-    # spuriously restart the deployment — caught in PR #155 review
-    # (bugbot, medium severity).
-    #   return 0 + (possibly empty) stdout = fetched OK; caller may
-    #                                        treat empty as "single-arch
-    #                                        body, HEAD digest is final".
-    #   return 1                            = transient; caller should
-    #                                        skip this tick.
-    get_index_digests() {
-      _repo="$1"
-      _token="$(get_token "$_repo")"
-      if [ -z "$_token" ]; then
-        return 1
-      fi
-      if ! _body="$(curl -fsS --max-time 10 \
-        -H "Authorization: Bearer $_token" \
-        -H "Accept: application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json" \
-        "https://registry-1.docker.io/v2/${_repo}/manifests/${IMAGE_TAG}")"; then
-        return 1
-      fi
-      # Only enumerate digests for index/list bodies. For single-platform
-      # manifests, the top-level HEAD digest is already authoritative.
-      if printf '%s' "$_body" | grep -q '"manifests"'; then
-        printf '%s' "$_body" | grep -oE 'sha256:[a-f0-9]{64}'
-      fi
-      return 0
-    }
-
     restart_needed=0
+    annotate_args=""
 
-    # Each entry: "<docker-hub-repo>|<container-name-in-pod>|<digest-pin-flag>".
-    # digest-pin-flag is "1" when values pin the image by digest — the
-    # deployment uses imagePullPolicy: IfNotPresent for that container and
-    # restarting on tag drift would fight the customer's opt-in pinning.
+    # Each entry: "<docker-hub-repo>|<annotation-key>|<digest-pin-flag>".
+    # digest-pin-flag is "1" when values.images.*.digest is set — the
+    # deployment uses imagePullPolicy: IfNotPresent for that container
+    # and auto-refresh must not fight the customer's opt-in pinning.
     set -- \
-      "tracebloc/jobs-manager|api|${JOBS_MANAGER_PINNED}" \
-      "tracebloc/pods-monitor|pods-monitor-container|${PODS_MONITOR_PINNED}"
+      "tracebloc/jobs-manager|tracebloc.io/last-refreshed-jobs-manager-digest|${JOBS_MANAGER_PINNED}" \
+      "tracebloc/pods-monitor|tracebloc.io/last-refreshed-pods-monitor-digest|${PODS_MONITOR_PINNED}"
 
     for entry in "$@"; do
       repo="${entry%%|*}"
       rest="${entry#*|}"
-      container="${rest%%|*}"
+      key="${rest%%|*}"
       pinned="${rest#*|}"
 
-      log "checking ${repo}:${IMAGE_TAG} (container=${container})"
+      log "checking ${repo}:${IMAGE_TAG} (annotation=${key})"
 
       if [ "$pinned" = "1" ]; then
         log "  pinned by digest in values; skipping (auto-refresh disabled for this image)"
@@ -154,69 +130,51 @@ data:
         continue
       fi
 
-      running="$(get_running_digest "$container" || true)"
-      if [ -z "$running" ]; then
-        log "  WARN: could not read running digest for container=$container; skipping"
-        continue
-      fi
+      recorded="$(get_annotation "$key" || true)"
 
       log "  latest=$latest"
-      log "  running=$running"
+      log "  recorded=${recorded:-<unset>}"
 
-      if [ "$latest" = "$running" ]; then
-        log "  digests match"
-        continue
-      fi
-
-      # Top-level mismatch. Could be a genuine update OR a multi-arch
-      # asymmetry where `latest` is the index digest and `running` is a
-      # per-platform manifest digest. Disambiguate by fetching the index
-      # body and checking whether running ∈ per-platform digests.
-      #
-      # Critically, capture the exit status of get_index_digests
-      # separately from its stdout: a transient GET failure (timeout,
-      # rate-limit, token failure) must skip the tick, NOT fall through
-      # to restart_needed=1. Treating "empty output" as "no match" would
-      # turn every network blip into a spurious deployment restart.
-      log "  top-level mismatch; checking multi-arch index for match"
-      if ! _index_digests="$(get_index_digests "$repo")"; then
-        log "  WARN: could not fetch index body (rate-limited or transient); skipping this tick to avoid spurious restart"
-        continue
-      fi
-
-      _matched=0
-      if [ -n "$_index_digests" ]; then
-        # Multi-arch index body — check membership.
-        for _d in $_index_digests; do
-          if [ "$_d" = "$running" ]; then
-            _matched=1
-            break
-          fi
-        done
-      fi
-      # If _index_digests is empty here, the response was a single-platform
-      # manifest body (no "manifests" key). The top-level HEAD digest was
-      # already authoritative for that case, and we know it didn't match —
-      # so falling through to restart_needed=1 is correct.
-
-      if [ "$_matched" -eq 1 ]; then
-        log "  running matches a per-platform manifest digest in the index; up to date"
+      if [ -z "$recorded" ]; then
+        # First-observation path: record without restarting. We have no
+        # evidence the running pod is on an older digest, and a spurious
+        # restart on install would surprise operators.
+        log "  first observation; recording without restart"
+        annotate_args="$annotate_args ${key}=${latest}"
+      elif [ "$recorded" = "$latest" ]; then
+        log "  digest unchanged since last refresh; no-op"
       else
-        log "  digest changed -> restart needed"
+        log "  digest changed (${recorded} -> ${latest}); restart needed"
+        annotate_args="$annotate_args ${key}=${latest}"
         restart_needed=1
       fi
     done
 
-    if [ "$restart_needed" -eq 0 ]; then
-      log "all images up to date; nothing to do"
-      exit 0
+    # Order matters: rollout FIRST, annotate AFTER `rollout status`
+    # succeeds. If the rollout fails or times out, we leave the
+    # annotation stale so the next tick retries the same digest. If we
+    # annotated first and then the rollout failed, the next tick would
+    # see recorded == latest and skip — leaving the deployment frozen
+    # on the old image with no signal that anything went wrong.
+    if [ "$restart_needed" -eq 1 ]; then
+      log "rolling restart of deployment/${DEPLOYMENT_NAME}"
+      kubectl rollout restart -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}"
+      kubectl rollout status  -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" \
+        --timeout="$ROLLOUT_TIMEOUT"
+      log "rollout complete"
     fi
 
-    log "rolling restart of deployment/${DEPLOYMENT_NAME}"
-    kubectl rollout restart -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}"
-    kubectl rollout status  -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" \
-      --timeout="$ROLLOUT_TIMEOUT"
-    log "rollout complete"
+    # Apply all pending annotation updates in a single kubectl call.
+    # Both restart-then-annotate (after a successful rollout) and
+    # first-observation (without restart) go through here.
+    if [ -n "$annotate_args" ]; then
+      log "updating deployment annotations:$annotate_args"
+      # shellcheck disable=SC2086  # word-split annotate_args intentional
+      kubectl annotate deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" \
+        $annotate_args --overwrite
+    else
+      log "nothing to record or restart"
+    fi
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -46,6 +46,11 @@ data:
         log "  WARN: could not fetch auth token for $_repo"
         return 1
       fi
+      # Header case varies by transport: HTTP/2 mandates lowercase but
+      # HTTP/1.1 over a TLS-terminating proxy can return mixed case.
+      # alpine/k8s ships BusyBox awk, which silently ignores gawk's
+      # IGNORECASE=1, so we case-fold with tr BEFORE awk. Digests are
+      # lowercase-by-spec (sha256:<64 hex>), so tr never mangles the value.
       curl -fsSI --max-time 10 \
         -H "Authorization: Bearer $_token" \
         -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
@@ -53,7 +58,8 @@ data:
         -H "Accept: application/vnd.oci.image.manifest.v1+json" \
         -H "Accept: application/vnd.oci.image.index.v1+json" \
         "https://registry-1.docker.io/v2/${_repo}/manifests/${IMAGE_TAG}" \
-        | awk 'BEGIN{IGNORECASE=1} /^docker-content-digest:/ {print $2}' \
+        | tr '[:upper:]' '[:lower:]' \
+        | awk '/^docker-content-digest:/ {print $2}' \
         | tr -d '\r\n'
     }
 

--- a/client/templates/image-refresh-rbac.yaml
+++ b/client/templates/image-refresh-rbac.yaml
@@ -32,10 +32,13 @@ rules:
     verbs: ["get", "list"]
   # `kubectl rollout restart` patches the deployment's pod template
   # annotations (kubectl.kubernetes.io/restartedAt). `rollout status`
-  # reads the deployment.
+  # uses a ListWatch on the deployment to wait for rollout completion;
+  # without `watch` it enters a reflector error loop (kubectl#580) and
+  # hangs until --timeout fires, marking every successful restart as a
+  # failed Job. Caught in PR #155 review.
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["get", "patch"]
+    verbs: ["get", "patch", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/client/templates/image-refresh-rbac.yaml
+++ b/client/templates/image-refresh-rbac.yaml
@@ -1,0 +1,56 @@
+{{- if include "tracebloc.imageRefreshEnabled" . }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-refresh
+---
+{{/*
+  Namespace-scoped Role — narrower than autoUpgrade's cluster-admin binding
+  on purpose. This CronJob only needs to read pod imageIDs (to compare the
+  running digest) and patch the jobs-manager Deployment (to trigger a
+  rollout restart). All resources live in {{ .Release.Namespace }}, so no
+  cluster scope is required. A compromise of this Pod is bounded to
+  kicking the jobs-manager Deployment in this one namespace.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-refresh
+rules:
+  # Read the running pod's container imageIDs to extract the active digest.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  # `kubectl rollout restart` patches the deployment's pod template
+  # annotations (kubectl.kubernetes.io/restartedAt). `rollout status`
+  # reads the deployment.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-refresh
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "tracebloc.imageRefreshName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/client/templates/image-refresh-rbac.yaml
+++ b/client/templates/image-refresh-rbac.yaml
@@ -10,12 +10,12 @@ metadata:
     app.kubernetes.io/component: image-refresh
 ---
 {{/*
-  Namespace-scoped Role — narrower than autoUpgrade's cluster-admin binding
-  on purpose. This CronJob only needs to read pod imageIDs (to compare the
-  running digest) and patch the jobs-manager Deployment (to trigger a
-  rollout restart). All resources live in {{ .Release.Namespace }}, so no
-  cluster scope is required. A compromise of this Pod is bounded to
-  kicking the jobs-manager Deployment in this one namespace.
+  Namespace-scoped Role — narrower than autoUpgrade's cluster-admin
+  binding on purpose. This CronJob only touches the jobs-manager
+  Deployment in {{ .Release.Namespace }}: read it to compare the recorded
+  refresh digest, and patch it for `rollout restart` + annotation
+  update. No pods, no other resources, no cluster scope. A compromise
+  of this Pod is bounded to kicking and annotating one Deployment.
 */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -26,17 +26,13 @@ metadata:
     {{- include "tracebloc.labels" . | nindent 4 }}
     app.kubernetes.io/component: image-refresh
 rules:
-  # Read the running pod's container imageIDs to extract the active digest.
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get", "list"]
-  # `kubectl rollout restart` patches the deployment's pod template
-  # annotations (kubectl.kubernetes.io/restartedAt). `rollout status`
-  # uses a ListWatch on the deployment to wait for rollout completion;
-  # a ListWatch reflector needs BOTH `list` (initial sync) and `watch`
-  # (incremental updates). Missing either one drops the call into a
-  # 403 retry loop until --timeout fires (kubectl#580), marking every
-  # successful restart as a failed Job. Both caught in PR #155 review.
+  # `kubectl rollout restart` + `kubectl annotate` are both patches on
+  # the deployment. `rollout status` uses a ListWatch on the deployment
+  # to wait for completion; a ListWatch reflector needs BOTH `list`
+  # (initial sync) and `watch` (incremental updates). Missing either
+  # one drops the call into a 403 retry loop until --timeout fires
+  # (kubectl#580), marking every successful restart as a failed Job.
+  # Both caught in PR #155 review.
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "patch", "watch"]

--- a/client/templates/image-refresh-rbac.yaml
+++ b/client/templates/image-refresh-rbac.yaml
@@ -33,12 +33,13 @@ rules:
   # `kubectl rollout restart` patches the deployment's pod template
   # annotations (kubectl.kubernetes.io/restartedAt). `rollout status`
   # uses a ListWatch on the deployment to wait for rollout completion;
-  # without `watch` it enters a reflector error loop (kubectl#580) and
-  # hangs until --timeout fires, marking every successful restart as a
-  # failed Job. Caught in PR #155 review.
+  # a ListWatch reflector needs BOTH `list` (initial sync) and `watch`
+  # (incremental updates). Missing either one drops the call into a
+  # 403 retry loop until --timeout fires (kubectl#580), marking every
+  # successful restart as a failed Job. Both caught in PR #155 review.
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["get", "patch", "watch"]
+    verbs: ["get", "list", "patch", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -273,3 +273,26 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "must not be valid against schema"
+
+  - it: cronjob template renders nothing (no crash) when imageRefresh key is entirely absent
+    # Regression guard for the --reuse-values upgrade path. Customers who
+    # upgrade with `helm upgrade --reuse-values --version 1.4.0` (instead
+    # of the autoUpgrade-recommended --reset-then-reuse-values) replay
+    # stored 1.3.x values that have NO `imageRefresh` block at all. The
+    # template must degrade silently (no resources rendered) rather than
+    # crash with nil-pointer — see the "nil-guard every new top-level
+    # value key" rule in CLAUDE.md.
+    template: templates/image-refresh-cronjob.yaml
+    set:
+      imageRefresh: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rbac template renders nothing (no crash) when imageRefresh key is entirely absent
+    template: templates/image-refresh-rbac.yaml
+    set:
+      imageRefresh: null
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -105,82 +105,74 @@ tests:
           path: data["image-refresh.sh"]
           pattern: "registry-1.docker.io"
       # Regression guard: the digest-pinned skip MUST stay in the script.
-      # Without it a customer who pins one image would still get restarts
-      # when the OTHER image changes, which is fine — but a future
-      # refactor must not drop the pin check for the pinned image itself.
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: "pinned by digest in values"
-      # Regression guard: the script must HEAD the manifest with all four
-      # Accept media types (v2 + list-v2 + OCI manifest + OCI index).
-      # Dropping any one of these silently breaks digest resolution for
-      # registries that serve only that media type. They MUST be in a
-      # single comma-separated Accept header — per the Docker registry
-      # v2 spec, and because some proxies have been observed dropping
-      # or reordering repeated Accept headers (caught in PR #155 review,
-      # bugbot medium severity).
-      - matchRegex:
-          path: data["image-refresh.sh"]
-          pattern: "vnd.docker.distribution.manifest.list.v2"
-      - matchRegex:
-          path: data["image-refresh.sh"]
-          pattern: "vnd.oci.image.index.v1"
-      # The four media types must appear in ONE `-H "Accept: ...,...,..."`
-      # header. This regex matches all four joined by commas on one line.
+      # Regression guard: the script must HEAD the manifest with all
+      # four Accept media types in a SINGLE comma-separated Accept
+      # header per the Docker registry v2 spec (some proxies have been
+      # observed dropping repeated Accept headers — caught in PR #155
+      # review, bugbot medium severity).
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: 'Accept: application/vnd\.docker\.distribution\.manifest\.v2\+json,application/vnd\.docker\.distribution\.manifest\.list\.v2\+json,application/vnd\.oci\.image\.manifest\.v1\+json,application/vnd\.oci\.image\.index\.v1\+json'
-      # Regression guard: multi-arch tags publish a manifest list/index
-      # at the tag. Docker Hub's HEAD returns the INDEX digest, but
-      # containerd records the PLATFORM manifest digest in the pod's
-      # imageID (kubernetes/kubernetes#108689 + #115199). The two will
-      # never match directly. The script must fall back to GET-ing the
-      # index body and checking whether running ∈ per-platform digests,
-      # otherwise multi-arch images would trigger a restart on every
-      # 15-minute tick. Caught in PR #155 review (bugbot, medium).
-      - matchRegex:
-          path: data["image-refresh.sh"]
-          pattern: "get_index_digests"
-      # The fallback only kicks in for index/list bodies. Gate on
-      # `"manifests"` key presence — single-platform manifest bodies
-      # don't have that key and would otherwise yield layer/config
-      # digests (which are NOT manifest digests) and trigger a never-
-      # matching false-positive restart.
-      - matchRegex:
-          path: data["image-refresh.sh"]
-          pattern: 'grep -q .{0,3}"manifests"'
-      # Regression guard: get_index_digests must distinguish transient
-      # failure (return 1) from successfully-fetched-but-single-platform
-      # (return 0 + empty stdout). The caller's `if !` check turns a
-      # transient into a `continue` (skip tick), not a restart. Asserting
-      # the WARN/skip log line keeps the asymmetric-failure regression
-      # caught by bugbot from creeping back in. (Caught in PR #155 review,
-      # medium severity.)
-      - matchRegex:
-          path: data["image-refresh.sh"]
-          pattern: 'if ! _index_digests='
-      - matchRegex:
-          path: data["image-refresh.sh"]
-          pattern: "could not fetch index body"
-      # Regression guard: case-fold the response headers with tr BEFORE
-      # awk. alpine/k8s ships BusyBox awk, which silently ignores gawk's
+      # Regression guard: case-fold response headers with tr BEFORE awk.
+      # alpine/k8s ships BusyBox awk which silently ignores gawk's
       # IGNORECASE=1; a mixed-case `Docker-Content-Digest` from an
-      # HTTP/1.1 proxy would then never match the lowercase pattern and
-      # the script would silently never restart on new image publishes.
-      # Caught in PR #155 review (bugbot, medium severity).
+      # HTTP/1.1 proxy would otherwise never match. Caught in PR #155
+      # review (bugbot medium severity).
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: "tr '\\[:upper:\\]' '\\[:lower:\\]'"
-      # And: no `BEGIN{IGNORECASE=1}` block in awk. Together with the tr
-      # above, this is what makes case-folding actually correct on
-      # BusyBox. If a future refactor adds the gawk-only IGNORECASE
-      # action back to awk code, that's a code smell suggesting the tr
-      # has been dropped; fail the test loudly so the regression is
-      # caught. Regex targets `BEGIN{IGNORECASE` specifically so the
-      # word `IGNORECASE` is still free to appear in prose comments.
       - notMatchRegex:
           path: data["image-refresh.sh"]
           pattern: "BEGIN[{ ]IGNORECASE"
+      # Regression guard: log() MUST write to stderr (>&2) so log lines
+      # cannot pollute command-substitution capture sites like
+      # `latest="$(get_latest_digest "$repo")"`. Caught in PR #155
+      # review (bugbot medium severity).
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'log\(\) \{ printf .*>&2'
+      # Regression guards for the annotation-based comparison model.
+      # Source of truth is `tracebloc.io/last-refreshed-*-digest`
+      # annotations on the deployment, NOT the pod's
+      # containerStatuses[].imageID. This shape is deliberate — it
+      # sidesteps imageID format variance across runtimes and the
+      # multi-arch index-vs-platform-digest divergence. A future
+      # refactor that re-introduces imageID comparison would re-
+      # introduce that whole class of bugs.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "tracebloc\\.io/last-refreshed-jobs-manager-digest"
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "tracebloc\\.io/last-refreshed-pods-monitor-digest"
+      # The script must NOT reach into pod containerStatuses to read
+      # imageIDs — that's the runtime-variant data shape we explicitly
+      # designed around. Pattern targets the only call shape that could
+      # do it (`kubectl get pod`) rather than the words, so the design-
+      # rationale comments are free to keep mentioning containerStatuses
+      # / imageID as history.
+      - notMatchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "kubectl get pod"
+      # First-observation contract: when an annotation is absent
+      # (recorded is empty), the script must record the current digest
+      # WITHOUT triggering a restart. A spurious first-tick restart
+      # would churn the deployment on every fresh install.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "first observation; recording without restart"
+      # Order-of-operations contract: `rollout restart` + `rollout
+      # status` MUST run before `kubectl annotate`. If we annotated
+      # first and the rollout then failed, the next tick would see
+      # recorded == latest and skip — leaving the deployment frozen
+      # on the old image with no signal. The test asserts that the
+      # rollout block appears in the script BEFORE the annotate block.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: '(?s)kubectl rollout restart.*kubectl annotate deployment'
 
   - it: CronJob has the right schedule, concurrency, and SA wiring
     template: templates/image-refresh-cronjob.yaml
@@ -252,7 +244,14 @@ tests:
           path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.capabilities.drop[0]
           value: ALL
 
-  - it: Role is namespace-scoped with minimum verbs (no cluster-admin)
+  - it: Role is namespace-scoped, deployments-only (no pods, no cluster-admin)
+    # The annotation pattern eliminated the need to read pods entirely —
+    # the script reads the recorded digest from a deployment annotation,
+    # not from containerStatuses[].imageID. Tightening RBAC to just
+    # apps/deployments shrinks the blast radius of a compromised refresh
+    # Pod to one resource type in one namespace. Lock the rule list
+    # with `equal` so a regression that adds back a pods rule (or worse,
+    # a cluster role) fails loudly.
     template: templates/image-refresh-rbac.yaml
     asserts:
       - hasDocuments:
@@ -267,9 +266,13 @@ tests:
       - isKind:
           of: Role
         documentIndex: 1
-      # Regression guard: Role MUST be namespace-scoped (kind: Role, not
-      # ClusterRole). The narrower trust boundary is the entire reason for
-      # using a separate RBAC bundle from autoUpgrade.
+      - equal:
+          path: rules
+          value:
+            - apiGroups: ["apps"]
+              resources: ["deployments"]
+              verbs: ["get", "list", "patch", "watch"]
+        documentIndex: 1
       - equal:
           path: roleRef.kind
           value: Role
@@ -278,31 +281,6 @@ tests:
           path: subjects[0].name
           value: stg-image-refresh
         documentIndex: 2
-
-  - it: Role grants only pods/get,list and deployments/get,list,patch,watch
-    # A ListWatch reflector (which `kubectl rollout status` uses on the
-    # deployment) needs BOTH `list` (initial sync) and `watch`
-    # (incremental updates). Drop either and the call hangs in a 403
-    # retry loop until --timeout fires (kubectl#580), marking every
-    # successful restart as a failed Job. Both verbs caught in PR #155
-    # review. Lock the full verb set with equal, not contains, so a
-    # future refactor that drops either one fails loudly instead of
-    # silently regressing.
-    template: templates/image-refresh-rbac.yaml
-    documentIndex: 1
-    asserts:
-      - equal:
-          path: rules[0]
-          value:
-            apiGroups: [""]
-            resources: ["pods"]
-            verbs: ["get", "list"]
-      - equal:
-          path: rules[1]
-          value:
-            apiGroups: ["apps"]
-            resources: ["deployments"]
-            verbs: ["get", "list", "patch", "watch"]
 
   - it: should accept operator overrides for schedule, image, and timeout
     template: templates/image-refresh-cronjob.yaml
@@ -343,13 +321,13 @@ tests:
           errorPattern: "must not be valid against schema"
 
   - it: cronjob template renders nothing (no crash) when imageRefresh key is entirely absent
-    # Regression guard for the --reuse-values upgrade path. Customers who
-    # upgrade with `helm upgrade --reuse-values --version 1.4.0` (instead
-    # of the autoUpgrade-recommended --reset-then-reuse-values) replay
-    # stored 1.3.x values that have NO `imageRefresh` block at all. The
-    # template must degrade silently (no resources rendered) rather than
-    # crash with nil-pointer — see the "nil-guard every new top-level
-    # value key" rule in CLAUDE.md.
+    # Regression guard for the --reuse-values upgrade path. Customers
+    # who upgrade with `helm upgrade --reuse-values --version 1.4.0`
+    # (instead of the autoUpgrade-recommended --reset-then-reuse-values)
+    # replay stored 1.3.x values that have NO `imageRefresh` block at
+    # all. The template must degrade silently (no resources rendered)
+    # rather than crash with nil-pointer — see the "nil-guard every new
+    # top-level value key" rule in CLAUDE.md.
     template: templates/image-refresh-cronjob.yaml
     set:
       imageRefresh: null

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -114,13 +114,22 @@ tests:
       # Regression guard: the script must HEAD the manifest with all four
       # Accept media types (v2 + list-v2 + OCI manifest + OCI index).
       # Dropping any one of these silently breaks digest resolution for
-      # registries that serve only that media type.
+      # registries that serve only that media type. They MUST be in a
+      # single comma-separated Accept header — per the Docker registry
+      # v2 spec, and because some proxies have been observed dropping
+      # or reordering repeated Accept headers (caught in PR #155 review,
+      # bugbot medium severity).
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: "vnd.docker.distribution.manifest.list.v2"
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: "vnd.oci.image.index.v1"
+      # The four media types must appear in ONE `-H "Accept: ...,...,..."`
+      # header. This regex matches all four joined by commas on one line.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'Accept: application/vnd\.docker\.distribution\.manifest\.v2\+json,application/vnd\.docker\.distribution\.manifest\.list\.v2\+json,application/vnd\.oci\.image\.manifest\.v1\+json,application/vnd\.oci\.image\.index\.v1\+json'
       # Regression guard: case-fold the response headers with tr BEFORE
       # awk. alpine/k8s ships BusyBox awk, which silently ignores gawk's
       # IGNORECASE=1; a mixed-case `Docker-Content-Digest` from an
@@ -238,14 +247,15 @@ tests:
           value: stg-image-refresh
         documentIndex: 2
 
-  - it: Role grants only pods/get,list and deployments/get,patch,watch
-    # `watch` on deployments is REQUIRED — `kubectl rollout status` does a
-    # ListWatch on the deployment resource to wait for rollout completion.
-    # Without it the call hangs in a reflector error loop until --timeout
-    # fires (kubectl#580), marking every successful restart as a failed
-    # Job. Caught in PR #155 review. Lock the full verb set with equal,
-    # not contains, so a future refactor that drops `watch` fails loudly
-    # instead of silently regressing.
+  - it: Role grants only pods/get,list and deployments/get,list,patch,watch
+    # A ListWatch reflector (which `kubectl rollout status` uses on the
+    # deployment) needs BOTH `list` (initial sync) and `watch`
+    # (incremental updates). Drop either and the call hangs in a 403
+    # retry loop until --timeout fires (kubectl#580), marking every
+    # successful restart as a failed Job. Both verbs caught in PR #155
+    # review. Lock the full verb set with equal, not contains, so a
+    # future refactor that drops either one fails loudly instead of
+    # silently regressing.
     template: templates/image-refresh-rbac.yaml
     documentIndex: 1
     asserts:
@@ -260,7 +270,7 @@ tests:
           value:
             apiGroups: ["apps"]
             resources: ["deployments"]
-            verbs: ["get", "patch", "watch"]
+            verbs: ["get", "list", "patch", "watch"]
 
   - it: should accept operator overrides for schedule, image, and timeout
     template: templates/image-refresh-cronjob.yaml

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -130,6 +130,25 @@ tests:
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: 'Accept: application/vnd\.docker\.distribution\.manifest\.v2\+json,application/vnd\.docker\.distribution\.manifest\.list\.v2\+json,application/vnd\.oci\.image\.manifest\.v1\+json,application/vnd\.oci\.image\.index\.v1\+json'
+      # Regression guard: multi-arch tags publish a manifest list/index
+      # at the tag. Docker Hub's HEAD returns the INDEX digest, but
+      # containerd records the PLATFORM manifest digest in the pod's
+      # imageID (kubernetes/kubernetes#108689 + #115199). The two will
+      # never match directly. The script must fall back to GET-ing the
+      # index body and checking whether running ∈ per-platform digests,
+      # otherwise multi-arch images would trigger a restart on every
+      # 15-minute tick. Caught in PR #155 review (bugbot, medium).
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "get_index_digests"
+      # The fallback only kicks in for index/list bodies. Gate on
+      # `"manifests"` key presence — single-platform manifest bodies
+      # don't have that key and would otherwise yield layer/config
+      # digests (which are NOT manifest digests) and trigger a never-
+      # matching false-positive restart.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'grep -q .{0,3}"manifests"'
       # Regression guard: case-fold the response headers with tr BEFORE
       # awk. alpine/k8s ships BusyBox awk, which silently ignores gawk's
       # IGNORECASE=1; a mixed-case `Docker-Content-Digest` from an

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -121,6 +121,25 @@ tests:
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: "vnd.oci.image.index.v1"
+      # Regression guard: case-fold the response headers with tr BEFORE
+      # awk. alpine/k8s ships BusyBox awk, which silently ignores gawk's
+      # IGNORECASE=1; a mixed-case `Docker-Content-Digest` from an
+      # HTTP/1.1 proxy would then never match the lowercase pattern and
+      # the script would silently never restart on new image publishes.
+      # Caught in PR #155 review (bugbot, medium severity).
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "tr '\\[:upper:\\]' '\\[:lower:\\]'"
+      # And: no `BEGIN{IGNORECASE=1}` block in awk. Together with the tr
+      # above, this is what makes case-folding actually correct on
+      # BusyBox. If a future refactor adds the gawk-only IGNORECASE
+      # action back to awk code, that's a code smell suggesting the tr
+      # has been dropped; fail the test loudly so the regression is
+      # caught. Regex targets `BEGIN{IGNORECASE` specifically so the
+      # word `IGNORECASE` is still free to appear in prose comments.
+      - notMatchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "BEGIN[{ ]IGNORECASE"
 
   - it: CronJob has the right schedule, concurrency, and SA wiring
     template: templates/image-refresh-cronjob.yaml

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -1,0 +1,275 @@
+suite: image-refresh CronJob and RBAC
+templates:
+  - templates/image-refresh-cronjob.yaml
+  - templates/image-refresh-rbac.yaml
+release:
+  name: stg
+  namespace: tracebloc
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: cronjob template renders ConfigMap + CronJob by default
+    template: templates/image-refresh-cronjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: rbac template renders ServiceAccount + Role + RoleBinding by default
+    template: templates/image-refresh-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: cronjob template renders nothing when imageRefresh.enabled=false
+    template: templates/image-refresh-cronjob.yaml
+    set:
+      imageRefresh:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rbac template renders nothing when imageRefresh.enabled=false
+    template: templates/image-refresh-rbac.yaml
+    set:
+      imageRefresh:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: cronjob template renders nothing when BOTH images are digest-pinned
+    # Digest pinning is an explicit opt-out from drift. If both images
+    # are pinned, auto-refresh has nothing to do and the resources
+    # should not be created at all.
+    template: templates/image-refresh-cronjob.yaml
+    set:
+      images:
+        jobsManager:
+          digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        podsMonitor:
+          digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rbac template renders nothing when BOTH images are digest-pinned
+    template: templates/image-refresh-rbac.yaml
+    set:
+      images:
+        jobsManager:
+          digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        podsMonitor:
+          digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: cronjob still renders when only ONE image is digest-pinned
+    # The other image can still drift, so the CronJob must run and the
+    # script will skip the pinned image via env flags.
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    set:
+      images:
+        jobsManager:
+          digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    asserts:
+      - isKind:
+          of: CronJob
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: JOBS_MANAGER_PINNED
+            value: "1"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PODS_MONITOR_PINNED
+            value: "0"
+
+  - it: ConfigMap holds the digest-poll script
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: stg-image-refresh
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "kubectl rollout restart"
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "registry-1.docker.io"
+      # Regression guard: the digest-pinned skip MUST stay in the script.
+      # Without it a customer who pins one image would still get restarts
+      # when the OTHER image changes, which is fine — but a future
+      # refactor must not drop the pin check for the pinned image itself.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "pinned by digest in values"
+      # Regression guard: the script must HEAD the manifest with all four
+      # Accept media types (v2 + list-v2 + OCI manifest + OCI index).
+      # Dropping any one of these silently breaks digest resolution for
+      # registries that serve only that media type.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "vnd.docker.distribution.manifest.list.v2"
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "vnd.oci.image.index.v1"
+
+  - it: CronJob has the right schedule, concurrency, and SA wiring
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: stg-image-refresh
+      - equal:
+          path: spec.schedule
+          value: "7,22,37,52 * * * *"
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: stg-image-refresh
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.restartPolicy
+          value: OnFailure
+
+  - it: CronJob env carries release identity and tag to the script
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    set:
+      env:
+        CLIENT_ENV: "prod"
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: RELEASE_NAME
+            value: stg
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: RELEASE_NAMESPACE
+            value: tracebloc
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: DEPLOYMENT_NAME
+            value: stg-jobs-manager
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: IMAGE_TAG
+            value: prod
+
+  - it: CronJob pod satisfies PSA restricted (runAsNonRoot, dropped caps, RO root, seccomp)
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+
+  - it: Role is namespace-scoped with minimum verbs (no cluster-admin)
+    template: templates/image-refresh-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 3
+      - isKind:
+          of: ServiceAccount
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: stg-image-refresh
+        documentIndex: 0
+      - isKind:
+          of: Role
+        documentIndex: 1
+      # Regression guard: Role MUST be namespace-scoped (kind: Role, not
+      # ClusterRole). The narrower trust boundary is the entire reason for
+      # using a separate RBAC bundle from autoUpgrade.
+      - equal:
+          path: roleRef.kind
+          value: Role
+        documentIndex: 2
+      - equal:
+          path: subjects[0].name
+          value: stg-image-refresh
+        documentIndex: 2
+
+  - it: Role grants only pods/get,list and deployments/get,patch
+    template: templates/image-refresh-rbac.yaml
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["pods"]
+            verbs: ["get", "list"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["apps"]
+            resources: ["deployments"]
+            verbs: ["get", "patch"]
+
+  - it: should accept operator overrides for schedule, image, and timeout
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    set:
+      imageRefresh:
+        enabled: true
+        schedule: "*/5 * * * *"
+        rolloutTimeout: "20m"
+        image:
+          repository: my-mirror/k8s
+          tag: "1.30.5"
+          pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "*/5 * * * *"
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: my-mirror/k8s:1.30.5
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: ROLLOUT_TIMEOUT
+            value: "20m"
+
+  - it: schema rejects image.tag=latest (image-refresh behaviour must not drift)
+    template: templates/image-refresh-cronjob.yaml
+    set:
+      imageRefresh:
+        image:
+          tag: "latest"
+    asserts:
+      - failedTemplate:
+          errorPattern: "must not be valid against schema"

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -219,22 +219,29 @@ tests:
           value: stg-image-refresh
         documentIndex: 2
 
-  - it: Role grants only pods/get,list and deployments/get,patch
+  - it: Role grants only pods/get,list and deployments/get,patch,watch
+    # `watch` on deployments is REQUIRED — `kubectl rollout status` does a
+    # ListWatch on the deployment resource to wait for rollout completion.
+    # Without it the call hangs in a reflector error loop until --timeout
+    # fires (kubectl#580), marking every successful restart as a failed
+    # Job. Caught in PR #155 review. Lock the full verb set with equal,
+    # not contains, so a future refactor that drops `watch` fails loudly
+    # instead of silently regressing.
     template: templates/image-refresh-rbac.yaml
     documentIndex: 1
     asserts:
-      - contains:
-          path: rules
-          content:
+      - equal:
+          path: rules[0]
+          value:
             apiGroups: [""]
             resources: ["pods"]
             verbs: ["get", "list"]
-      - contains:
-          path: rules
-          content:
+      - equal:
+          path: rules[1]
+          value:
             apiGroups: ["apps"]
             resources: ["deployments"]
-            verbs: ["get", "patch"]
+            verbs: ["get", "patch", "watch"]
 
   - it: should accept operator overrides for schedule, image, and timeout
     template: templates/image-refresh-cronjob.yaml

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -149,6 +149,19 @@ tests:
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: 'grep -q .{0,3}"manifests"'
+      # Regression guard: get_index_digests must distinguish transient
+      # failure (return 1) from successfully-fetched-but-single-platform
+      # (return 0 + empty stdout). The caller's `if !` check turns a
+      # transient into a `continue` (skip tick), not a restart. Asserting
+      # the WARN/skip log line keeps the asymmetric-failure regression
+      # caught by bugbot from creeping back in. (Caught in PR #155 review,
+      # medium severity.)
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'if ! _index_digests='
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "could not fetch index body"
       # Regression guard: case-fold the response headers with tr BEFORE
       # awk. alpine/k8s ships BusyBox awk, which silently ignores gawk's
       # IGNORECASE=1; a mixed-case `Docker-Content-Digest` from an

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -555,6 +555,80 @@
         }
       }
     },
+    "imageRefresh": {
+      "type": "object",
+      "description": "Image-refresh CronJob (issue tracebloc/client#154). Polls Docker Hub for jobs-manager and pods-monitor digests under the floating CLIENT_ENV tag and rolls the deployment when a new image is published. Disable to keep the running image in place until manual restart.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "When false, no CronJob, ServiceAccount, Role, or RoleBinding is rendered. The deployment will not auto-refresh on new image pushes."
+        },
+        "schedule": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Cron expression. Keep the tick rate compatible with Docker Hub's 100/6h anonymous pull-rate limit (each tick HEADs two manifests)."
+        },
+        "rolloutTimeout": {
+          "type": "string",
+          "pattern": "^[0-9]+(s|m|h)$",
+          "description": "Passed to `kubectl rollout status --timeout`. Allow headroom for bare-metal image pull."
+        },
+        "suspend": {
+          "type": "boolean",
+          "default": false,
+          "description": "CronJob.spec.suspend. Set true to pause without removing the resources."
+        },
+        "successfulJobsHistoryLimit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failedJobsHistoryLimit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "startingDeadlineSeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "image": {
+          "type": "object",
+          "required": ["repository", "tag"],
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": {
+              "type": "string",
+              "minLength": 1,
+              "not": { "const": "latest" },
+              "description": "Pin the alpine/k8s version. `latest` is rejected — image-refresh behaviour must not drift."
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            }
+          }
+        }
+      }
+    },
     "dockerRegistry": {
       "type": ["object", "null"],
       "description": "Optional. Omit entirely or set null for public images (no secret or imagePullSecrets). Only create when set and create is true.",

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -372,26 +372,36 @@ autoUpgrade:
 
 # -- Image-refresh CronJob (closes tracebloc/client#154).
 # Auto-restarts the jobs-manager Deployment when a new image digest is
-# published to Docker Hub under the floating CLIENT_ENV tag. Without this,
-# `imagePullPolicy: Always` only pulls on pod creation — running pods stay
-# on the old image until someone manually `kubectl rollout restart`s them,
-# which is exactly the customer-runs-no-commands UX we want to avoid.
+# published to Docker Hub under the floating CLIENT_ENV tag. Without
+# this, `imagePullPolicy: Always` only pulls on pod creation — running
+# pods stay on the old image until someone manually
+# `kubectl rollout restart`s them, which is exactly the
+# customer-runs-no-commands UX we want to avoid.
 #
 # How it works:
-#   - A CronJob in this namespace polls Docker Hub's registry API for the
-#     current manifest digest of tracebloc/jobs-manager:<CLIENT_ENV> and
-#     tracebloc/pods-monitor:<CLIENT_ENV> (both containers share one
-#     deployment), compares each to the running pod's container imageID,
-#     and runs `kubectl rollout restart deployment/<release>-jobs-manager`
-#     only when at least one digest differs. Pulls happen on the new pod
-#     because the deployment already has imagePullPolicy: Always for the
-#     floating-tag path.
-#   - Idle-cheap: on every tick where Docker Hub has not republished, both
-#     digests match and the script exits without touching the deployment.
-#   - Anonymous Docker Hub pulls are rate-limited (100 / 6h / IP). The
-#     default 15-minute schedule yields ~4 manifest HEAD requests per hour
-#     per image — well under the limit even when the cluster shares an
-#     egress IP with other workloads.
+#   - A CronJob in this namespace polls Docker Hub for the current
+#     manifest digest of tracebloc/jobs-manager:<CLIENT_ENV> and
+#     tracebloc/pods-monitor:<CLIENT_ENV> (both containers live in one
+#     deployment).
+#   - The script compares each fetched digest to an annotation on the
+#     deployment (`tracebloc.io/last-refreshed-<image>-digest`) that
+#     records the digest the LAST successful refresh restarted to. Not
+#     to the running pod's imageID — that value's format varies across
+#     container runtimes (kubernetes/kubernetes#108689 + #115199) and
+#     diverges from the registry's index digest on multi-arch tags.
+#     The annotation makes the comparison entirely server-vs-our-record
+#     with no client-side runtime variation in the loop.
+#   - On a real change: `kubectl rollout restart` + `kubectl rollout
+#     status` to wait for completion, then patch the annotation to the
+#     new digest. (Order matters — annotating first would let a failed
+#     rollout silently freeze the deployment.)
+#   - First observation (annotation absent on a fresh install): record
+#     the current digest without restarting. No evidence of drift, no
+#     reason to churn the pod.
+#   - Idle-cheap: when the recorded digest matches today's digest, the
+#     script exits without touching the deployment. Steady state is one
+#     HEAD per image per tick, well under Docker Hub's 100/6h anonymous
+#     pull-rate limit.
 #
 # Pinned-digest interaction: if BOTH images.jobsManager.digest and
 # images.podsMonitor.digest are set, the chart skips rendering this
@@ -400,15 +410,21 @@ autoUpgrade:
 # CronJob still runs but the script skips the pinned image at runtime.
 #
 # Trust boundary: this CronJob's ServiceAccount is bound to a
-# namespace-scoped Role (get pods, get/patch deployments in the release
-# namespace only). Much narrower than autoUpgrade — a compromise of this
-# Pod can only kick the jobs-manager Deployment, not deploy arbitrary
-# resources. The script reaches out only to docker.io's public registry
-# endpoints; if your cluster requires egress through a proxy, set
-# HTTPS_PROXY via env or disable this CronJob.
+# namespace-scoped Role with get/list/patch/watch on the deployment
+# resource ONLY (no pods, no other resources, no cluster scope). Much
+# narrower than autoUpgrade — a compromise of this Pod can only kick
+# and annotate the jobs-manager Deployment in this one namespace. The
+# script reaches out only to docker.io's public registry endpoints; if
+# your cluster requires egress through a proxy, set HTTPS_PROXY via env
+# or disable this CronJob.
 #
 # Disabled-on-this-cluster check after install:
 #   kubectl get cronjob -n <namespace> -l app.kubernetes.io/component=image-refresh
+#
+# Inspect what the controller has recorded so far:
+#   kubectl get deployment <release>-jobs-manager -n <namespace> \
+#     -o jsonpath='{.metadata.annotations}' | tr ',' '\n' \
+#     | grep tracebloc.io/last-refreshed
 imageRefresh:
   # Default ON: the whole point of #154 is that customers don't have to
   # run any commands when we publish a new jobs-manager image.

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -370,6 +370,83 @@ autoUpgrade:
       cpu: "500m"
       memory: "256Mi"
 
+# -- Image-refresh CronJob (closes tracebloc/client#154).
+# Auto-restarts the jobs-manager Deployment when a new image digest is
+# published to Docker Hub under the floating CLIENT_ENV tag. Without this,
+# `imagePullPolicy: Always` only pulls on pod creation — running pods stay
+# on the old image until someone manually `kubectl rollout restart`s them,
+# which is exactly the customer-runs-no-commands UX we want to avoid.
+#
+# How it works:
+#   - A CronJob in this namespace polls Docker Hub's registry API for the
+#     current manifest digest of tracebloc/jobs-manager:<CLIENT_ENV> and
+#     tracebloc/pods-monitor:<CLIENT_ENV> (both containers share one
+#     deployment), compares each to the running pod's container imageID,
+#     and runs `kubectl rollout restart deployment/<release>-jobs-manager`
+#     only when at least one digest differs. Pulls happen on the new pod
+#     because the deployment already has imagePullPolicy: Always for the
+#     floating-tag path.
+#   - Idle-cheap: on every tick where Docker Hub has not republished, both
+#     digests match and the script exits without touching the deployment.
+#   - Anonymous Docker Hub pulls are rate-limited (100 / 6h / IP). The
+#     default 15-minute schedule yields ~4 manifest HEAD requests per hour
+#     per image — well under the limit even when the cluster shares an
+#     egress IP with other workloads.
+#
+# Pinned-digest interaction: if BOTH images.jobsManager.digest and
+# images.podsMonitor.digest are set, the chart skips rendering this
+# CronJob entirely — digest pinning is an explicit opt-out from drift,
+# and auto-restart would defeat the purpose. If only one is pinned the
+# CronJob still runs but the script skips the pinned image at runtime.
+#
+# Trust boundary: this CronJob's ServiceAccount is bound to a
+# namespace-scoped Role (get pods, get/patch deployments in the release
+# namespace only). Much narrower than autoUpgrade — a compromise of this
+# Pod can only kick the jobs-manager Deployment, not deploy arbitrary
+# resources. The script reaches out only to docker.io's public registry
+# endpoints; if your cluster requires egress through a proxy, set
+# HTTPS_PROXY via env or disable this CronJob.
+#
+# Disabled-on-this-cluster check after install:
+#   kubectl get cronjob -n <namespace> -l app.kubernetes.io/component=image-refresh
+imageRefresh:
+  # Default ON: the whole point of #154 is that customers don't have to
+  # run any commands when we publish a new jobs-manager image.
+  enabled: true
+  # Every 15 minutes at minute :07. The off-hour minute spreads load
+  # across Docker Hub's registry-1 origin; 15m balances drift latency
+  # against the 100/6h anonymous pull-rate limit (2 images × 4/hr = 8/hr,
+  # well under the cap even shared with other workloads on the same IP).
+  schedule: "7,22,37,52 * * * *"
+  # `kubectl rollout status --timeout`. Generous; jobs-manager image pulls
+  # on bare-metal first-boot can take minutes, and the CronJob slot
+  # shouldn't hold all night if a rollout genuinely wedges.
+  rolloutTimeout: "10m"
+  # CronJob spec knobs. Override per-cluster if needed.
+  suspend: false
+  # Lower history limits than autoUpgrade — this Job runs ~96x/day, the
+  # successful runs aren't interesting and 1 is enough for an at-a-glance
+  # "last run succeeded" check.
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  # Pod image: needs `sh`, `kubectl`, and `curl`. alpine/k8s ships all
+  # three in a small image and we pin the tag so behaviour cannot drift
+  # if upstream re-tags.
+  image:
+    repository: alpine/k8s
+    tag: "1.30.5"
+    pullPolicy: IfNotPresent
+  # Tiny — the pod is mostly idle waiting on network I/O for the digest
+  # HEADs and the rollout-status watch.
+  resources:
+    requests:
+      cpu: "20m"
+      memory: "64Mi"
+    limits:
+      cpu: "200m"
+      memory: "128Mi"
+
 # ============================================================
 # Ingestion endpoint authorization (client-runtime#21)
 # ============================================================


### PR DESCRIPTION
## Summary

Adds an `imageRefresh` CronJob that polls Docker Hub for new manifest digests of `tracebloc/jobs-manager` and `tracebloc/pods-monitor` under the floating `CLIENT_ENV` tag and runs `kubectl rollout restart` on the jobs-manager Deployment only when at least one digest has changed. Closes the gap left by `imagePullPolicy: Always` — that policy only pulls on pod creation, so running pods stay on the old image until something restarts them. Customers should not have to run any commands when we publish a new image.

Closes #154.

## Design

- Mirrors the existing `autoUpgrade` pattern (ConfigMap + CronJob + RBAC) so operators have one consistent mental model for the chart's background loops.
- **Narrower trust boundary than autoUpgrade**: namespace-scoped Role with `get,list pods` and `get,patch deployments` only — no cluster-admin. A compromise of this Pod is bounded to kicking the jobs-manager Deployment in the release namespace.
- **Idle-cheap**: each tick HEADs two manifests on Docker Hub; when both digests match the running pod, the script exits without touching the deployment. Default schedule (every 15m at :07/:22/:37/:52) stays well under Docker Hub's 100/6h anonymous pull-rate limit.
- **Per-image opt-out**: when `images.jobsManager.digest` or `images.podsMonitor.digest` is set, that image is skipped at runtime via env flags — digest pinning is an explicit reproducibility contract that auto-restart must not fight. If BOTH are pinned, the chart renders no CronJob, Role, RoleBinding, ConfigMap, or ServiceAccount at all.
- Manifest HEAD sends four `Accept` media types (Docker v2 + v2 list + OCI manifest + OCI index) so digest resolution works regardless of which variant the registry serves for that tag.
- Pod is PSA-restricted (runAsNonRoot, readOnlyRootFilesystem, dropped caps, RuntimeDefault seccomp); `HOME` points at a writable emptyDir so kubectl's discovery cache works under read-only root.

## Why not Keel?

Considered — Keel is the canonical "watch the registry, restart on new digest" controller. The benefits (semver policies, approval gates, multi-workload auto-discovery) don't pay off at two deployments on a mutable env tag with anonymous Docker Hub pulls. Revisit if we grow to ~5+ auto-refreshed workloads or need approval gates. See #154 discussion.

## Why not the ingestor?

Out of scope. Ingestor `hookImage` is `curlimages/curl` (third-party, pinned) and the workload is a Helm `post-install,post-upgrade` Job — `rollout restart` doesn't apply, and re-running a side-effecting hook on every image push would be wrong. Ingestor image refreshes ride along with chart upgrades via `autoUpgrade`.

## Test plan

- [x] `helm lint client/ --set clientId=test --set clientPassword=test`
- [x] `helm template` renders `stg-image-refresh` ServiceAccount, Role, RoleBinding, ConfigMap, and CronJob in the release namespace
- [x] `helm unittest client/` — 135/135 (15 new in `image_refresh_test.yaml`)
- [ ] Manual on a dev cluster: install the chart at this branch, confirm the CronJob runs on its first tick and exits with "all images up to date"
- [ ] Manual: push a new `tracebloc/jobs-manager:prod` image, wait for the next tick, confirm the deployment is rolled and pulls the new digest
- [ ] Manual: set `images.jobsManager.digest` to a pinned digest, helm upgrade, confirm the script logs "pinned by digest in values; skipping" and does not restart
- [ ] Manual: set BOTH `images.*.digest` values, helm upgrade, confirm none of the image-refresh resources render

## Chart version

Bumped 1.3.5 → 1.4.0 (feature add). `autoUpgrade` on already-deployed releases will pick this up on its next tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new background CronJob that polls Docker Hub and patches/restarts the `jobs-manager` Deployment, introducing operational risk around unexpected rollouts and reliance on external registry availability, though RBAC is kept namespace-scoped and limited to deployments.
> 
> **Overview**
> Bumps the Helm chart version to `1.4.0` and adds an **`imageRefresh` controller loop** that periodically checks Docker Hub manifest digests for `tracebloc/jobs-manager` and `tracebloc/pods-monitor` under the current `CLIENT_ENV` tag, then performs `kubectl rollout restart` (and records digests via deployment annotations) only when a digest changes.
> 
> This introduces new rendered resources (ConfigMap script, CronJob, ServiceAccount, namespace-scoped Role/RoleBinding) gated by `imageRefresh.enabled`, with additional logic to render nothing when *both* images are digest-pinned, plus new `values.yaml` defaults, `values.schema.json` validation (including rejecting `imageRefresh.image.tag: latest`), and Helm unit tests covering rendering/guardrails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 877e11f37ec26cc28fa5809c37eb615a910d10b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->