### PR TITLE
fix(#154): read annotations via jq (kubectl jsonpath bracket notation broken on dotted keys)

### DIFF
--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -92,12 +92,21 @@ data:
     # Read an annotation value off the deployment. Empty output means
     # the annotation is absent (first observation) — distinct from an
     # explicit empty string, which the chart never writes.
+    #
+    # Uses jq because kubectl-go's jsonpath parser returns empty for
+    # bracket-notation keys that contain `.` or `/` — verified on
+    # alpine/k8s 1.30.5 against a real annotation with key
+    # `tracebloc.io/last-refreshed-jobs-manager-digest`. Dot-escape
+    # syntax (`.tracebloc\.io/...`) is the other working form, but jq
+    # is unambiguous and won't surprise us on future kubectl versions.
+    # alpine/k8s ships jq, so adding one jq call doesn't pull a new
+    # dependency (the script remains awk/sed/grep elsewhere; jq is
+    # used ONLY for this read because JSON-with-dotted-keys is what
+    # actually motivates jq's existence).
     get_annotation() {
       _key="$1"
-      # jsonpath treats '.' / '/' as separators; brace-escape the key.
-      kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" \
-        -o "jsonpath={.metadata.annotations['$_key']}" \
-        | tr -d '\r\n'
+      kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" -o json \
+        | jq -r --arg k "$_key" '.metadata.annotations[$k] // empty'
     }
 
     restart_needed=0

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -148,6 +148,19 @@ tests:
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: "tracebloc\\.io/last-refreshed-pods-monitor-digest"
+      # Regression guard: read annotations with jq, not kubectl
+      # bracket-notation jsonpath. kubectl-go's jsonpath parser returns
+      # empty for `annotations['key.with.dots']` — verified on
+      # alpine/k8s 1.30.5 in dev-cluster smoke test. Switching to
+      # `kubectl get -o json | jq` made the read work.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "jq -r --arg k"
+      # And the script must NOT regress back to bracket-notation
+      # jsonpath for reading annotations.
+      - notMatchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "annotations\\[.\\$_key.\\]"
       # The script must NOT reach into pod containerStatuses to read
       # imageIDs — that's the runtime-variant data shape we explicitly
       # designed around. Pattern targets the only call shape that could


### PR DESCRIPTION
## Summary

Follow-up to #155 — bug caught in the dev-cluster smoke test on `tb-client-dev-templates`.

`kubectl get -o jsonpath=\"{.metadata.annotations['key.with.dots']}\"` returns empty when the key contains `.` or `/`, on kubectl-go 1.30.x (alpine/k8s 1.30.5). Verified directly: a separate `kubectl get -o jsonpath='{.metadata.annotations}'` showed the annotation present and correctly persisted, but the script's bracket-notation read returned empty.

**Effect:** every image-refresh tick saw `recorded=<unset>` and re-entered the first-observation path. The deployment was repeatedly re-annotated with the same digest on every run. No spurious restarts (first-observation skips restart), but the script could never transition to the \"unchanged; no-op\" path, and a real image update would have been indistinguishable from first observation.

## Fix

Switch `get_annotation` to `kubectl get -o json | jq -r --arg k \"\$_key\" '.metadata.annotations[\$k] // empty'`. alpine/k8s ships jq so no new dependency. jq's behaviour is locked against the kubectl-go jsonpath flakiness around dotted keys.

## Regression tests

- Positive: script must include `jq -r --arg k`
- Negative: script must NOT include `annotations['\$_key']` bracket-notation jsonpath

136/136 unit tests pass.

## Test plan

- [x] Confirmed annotation persistence via direct `kubectl get` on dev cluster
- [ ] Re-upgrade dev release, re-run image-refresh CronJob, verify second tick logs \"digest unchanged since last refresh; no-op\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the auto-refresh CronJob decides no-op vs rollout by fixing annotation reads; narrow script change with tests, but wrong reads previously blocked correct drift detection.
> 
> **Overview**
> Fixes the image-refresh CronJob so it can **read** deployment annotations whose keys contain dots (e.g. `tracebloc.io/last-refreshed-*-digest`). **`get_annotation`** now uses `kubectl get … -o json` piped to **`jq`** instead of kubectl **jsonpath** with `annotations['$_key']`, which returned empty on alpine/k8s 1.30.x for those keys.
> 
> Without this, every tick treated the stored digest as unset, stayed on the **first-observation** path (re-annotate, no restart), and never reached **digest unchanged; no-op**—so a real registry update would not be compared correctly against the last recorded value.
> 
> Helm unit tests assert the script includes **`jq -r --arg k`** and must not regress to bracket-notation jsonpath for annotation reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36134d7140785f123e93b8e03cc64210dcf8fcf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->