### PR TITLE
Sync develop → main for v1.4.0 chart release

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.3.5
-appVersion: "1.3.5"
+version: 1.4.0
+appVersion: "1.4.0"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -106,6 +106,49 @@ mysql-pvc
 {{- end }}
 
 {{/*
+  Release-scoped name shared by the image-refresh CronJob, ServiceAccount,
+  Role, RoleBinding, and ConfigMap. Same lockstep reasoning as
+  tracebloc.autoUpgradeName above. Distinct from auto-upgrade because the
+  two CronJobs have different cadences, different RBAC scopes (image-refresh
+  is namespace-scoped, auto-upgrade is cluster-admin), and customers may
+  reasonably disable one but not the other.
+*/}}
+{{- define "tracebloc.imageRefreshName" -}}
+{{ .Release.Name }}-image-refresh
+{{- end }}
+
+{{/*
+  Whether the image-refresh CronJob has anything to do. When BOTH
+  jobs-manager and pods-monitor are digest-pinned, the customer has
+  explicitly opted into reproducible pinning and we must not fight that
+  by restarting on tag changes. In that case we render nothing — no
+  CronJob, no RBAC, no ConfigMap. If only one is pinned, the other can
+  still drift, so the CronJob is rendered and the script skips the
+  pinned image at runtime via env flags.
+
+  Nil-guarded with `default dict` on every dereference: this is a new
+  top-level key in 1.4.0, and a customer who runs
+  `helm upgrade --reuse-values` (instead of the recommended
+  --reset-then-reuse-values that autoUpgrade itself uses) would replay
+  stored 1.3.x values that have no `imageRefresh` block. Without the
+  guard, `.Values.imageRefresh.enabled` would still nil-coalesce safely,
+  but `.Values.images.jobsManager.digest` could crash if `.Values.images`
+  were ever absent. Belt-and-suspenders — see the "nil-guard every new
+  top-level value key" rule in CLAUDE.md.
+*/}}
+{{- define "tracebloc.imageRefreshEnabled" -}}
+{{- $ir := default dict .Values.imageRefresh -}}
+{{- $imgs := default dict .Values.images -}}
+{{- $jm := default dict $imgs.jobsManager -}}
+{{- $pm := default dict $imgs.podsMonitor -}}
+{{- if not $ir.enabled -}}
+{{- else if and $jm.digest $pm.digest -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
   StorageClass name: when storageClass.create is true, use a release-unique name
   so each release gets its own StorageClass (avoids Helm ownership conflicts).
   When create is false, use the user-provided storageClass.name for an existing class.

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -92,12 +92,21 @@ data:
     # Read an annotation value off the deployment. Empty output means
     # the annotation is absent (first observation) — distinct from an
     # explicit empty string, which the chart never writes.
+    #
+    # Uses jq because kubectl-go's jsonpath parser returns empty for
+    # bracket-notation keys that contain `.` or `/` — verified on
+    # alpine/k8s 1.30.5 against a real annotation with key
+    # `tracebloc.io/last-refreshed-jobs-manager-digest`. Dot-escape
+    # syntax (`.tracebloc\.io/...`) is the other working form, but jq
+    # is unambiguous and won't surprise us on future kubectl versions.
+    # alpine/k8s ships jq, so adding one jq call doesn't pull a new
+    # dependency (the script remains awk/sed/grep elsewhere; jq is
+    # used ONLY for this read because JSON-with-dotted-keys is what
+    # actually motivates jq's existence).
     get_annotation() {
       _key="$1"
-      # jsonpath treats '.' / '/' as separators; brace-escape the key.
-      kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" \
-        -o "jsonpath={.metadata.annotations['$_key']}" \
-        | tr -d '\r\n'
+      kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" -o json \
+        | jq -r --arg k "$_key" '.metadata.annotations[$k] // empty'
     }
 
     restart_needed=0

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -1,0 +1,277 @@
+{{- if include "tracebloc.imageRefreshEnabled" . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-refresh
+data:
+  image-refresh.sh: |
+    #!/bin/sh
+    # Polls Docker Hub for new manifest digests of tracebloc/jobs-manager
+    # and tracebloc/pods-monitor under the floating CLIENT_ENV tag, and
+    # rolls the jobs-manager Deployment whenever a published digest
+    # differs from the one we last successfully rolled to.
+    #
+    # Source of truth: an annotation on the deployment itself
+    # (`tracebloc.io/last-refreshed-<image>-digest`) records the digest
+    # the last successful refresh restarted to. We compare what the
+    # registry publishes today to that recorded value, NOT to the running
+    # pod's containerStatuses[].imageID. This sidesteps:
+    #   * imageID format variation across container runtimes
+    #     (kubernetes/kubernetes#108689 + #115199 — containerd records
+    #     platform-specific manifest digests, dockershim records other
+    #     things, value is documented as inconsistent).
+    #   * multi-arch manifest-list vs platform-manifest divergence — the
+    #     registry returns the index digest under the tag, the runtime
+    #     records a per-platform digest, the two never match.
+    # Both classes of bug disappear when the comparison is "what the
+    # registry says today" vs "what we wrote into the annotation last
+    # time we acted on a change."
+    #
+    # First-tick contract: when an annotation is absent, we record the
+    # current digest WITHOUT restarting. The customer just installed (or
+    # someone manually wiped the annotation) — no evidence of drift, so
+    # no churn. Subsequent ticks compare to the recorded value normally.
+    #
+    # Parsing is sed/awk-only on purpose: alpine/k8s ships jq, but
+    # keeping the script jq-free means it survives image swaps to leaner
+    # bases — same constraint as the auto-upgrade script in this chart.
+    #
+    # All log() output goes to stderr so it can never pollute a
+    # command-substitution capture site like `latest="$(...)"`.
+    set -eu
+
+    log() { printf '[image-refresh] %s\n' "$*" >&2; }
+
+    log "release=$RELEASE_NAME namespace=$RELEASE_NAMESPACE tag=$IMAGE_TAG deployment=$DEPLOYMENT_NAME"
+
+    # Get an anonymous pull-scope token for one repository on Docker Hub.
+    get_token() {
+      _repo="$1"
+      # tr cleanup handles the trailing newline some curl builds emit.
+      curl -fsS --max-time 10 \
+        "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${_repo}:pull" \
+        | sed -n 's/.*"token":"\([^"]*\)".*/\1/p' \
+        | tr -d '\r\n'
+    }
+
+    # Resolve the manifest digest for repo:tag from Docker Hub. We HEAD
+    # the manifest endpoint with all four manifest media types in a
+    # single comma-separated Accept header (registry v2 spec form; some
+    # TLS-terminating proxies have been observed dropping repeated
+    # Accept headers). The value returned in Docker-Content-Digest is
+    # whatever the registry serves for that tag — for multi-arch tags
+    # the index digest, for single-arch the manifest digest. Both work
+    # here because we compare to OUR annotation, not to a runtime
+    # imageID; consistency tick-over-tick is all we need.
+    #
+    # Case-fold with tr BEFORE awk: alpine/k8s ships BusyBox awk which
+    # silently ignores gawk's IGNORECASE=1, and the header case differs
+    # between HTTP/1.1 and HTTP/2. Digest values are lowercase-by-spec
+    # (sha256:<64 hex>) so the value is unaffected.
+    get_latest_digest() {
+      _repo="$1"
+      _token="$(get_token "$_repo")"
+      if [ -z "$_token" ]; then
+        log "  WARN: could not fetch auth token for $_repo"
+        return 1
+      fi
+      curl -fsSI --max-time 10 \
+        -H "Authorization: Bearer $_token" \
+        -H "Accept: application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json" \
+        "https://registry-1.docker.io/v2/${_repo}/manifests/${IMAGE_TAG}" \
+        | tr '[:upper:]' '[:lower:]' \
+        | awk '/^docker-content-digest:/ {print $2}' \
+        | tr -d '\r\n'
+    }
+
+    # Read an annotation value off the deployment. Empty output means
+    # the annotation is absent (first observation) — distinct from an
+    # explicit empty string, which the chart never writes.
+    get_annotation() {
+      _key="$1"
+      # jsonpath treats '.' / '/' as separators; brace-escape the key.
+      kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" \
+        -o "jsonpath={.metadata.annotations['$_key']}" \
+        | tr -d '\r\n'
+    }
+
+    restart_needed=0
+    annotate_args=""
+
+    # Each entry: "<docker-hub-repo>|<annotation-key>|<digest-pin-flag>".
+    # digest-pin-flag is "1" when values.images.*.digest is set — the
+    # deployment uses imagePullPolicy: IfNotPresent for that container
+    # and auto-refresh must not fight the customer's opt-in pinning.
+    set -- \
+      "tracebloc/jobs-manager|tracebloc.io/last-refreshed-jobs-manager-digest|${JOBS_MANAGER_PINNED}" \
+      "tracebloc/pods-monitor|tracebloc.io/last-refreshed-pods-monitor-digest|${PODS_MONITOR_PINNED}"
+
+    for entry in "$@"; do
+      repo="${entry%%|*}"
+      rest="${entry#*|}"
+      key="${rest%%|*}"
+      pinned="${rest#*|}"
+
+      log "checking ${repo}:${IMAGE_TAG} (annotation=${key})"
+
+      if [ "$pinned" = "1" ]; then
+        log "  pinned by digest in values; skipping (auto-refresh disabled for this image)"
+        continue
+      fi
+
+      latest="$(get_latest_digest "$repo" || true)"
+      if [ -z "$latest" ]; then
+        log "  WARN: could not resolve latest digest (rate-limited or transient); skipping this tick"
+        continue
+      fi
+
+      recorded="$(get_annotation "$key" || true)"
+
+      log "  latest=$latest"
+      log "  recorded=${recorded:-<unset>}"
+
+      if [ -z "$recorded" ]; then
+        # First-observation path: record without restarting. We have no
+        # evidence the running pod is on an older digest, and a spurious
+        # restart on install would surprise operators.
+        log "  first observation; recording without restart"
+        annotate_args="$annotate_args ${key}=${latest}"
+      elif [ "$recorded" = "$latest" ]; then
+        log "  digest unchanged since last refresh; no-op"
+      else
+        log "  digest changed (${recorded} -> ${latest}); restart needed"
+        annotate_args="$annotate_args ${key}=${latest}"
+        restart_needed=1
+      fi
+    done
+
+    # Order matters: rollout FIRST, annotate AFTER `rollout status`
+    # succeeds. If the rollout fails or times out, we leave the
+    # annotation stale so the next tick retries the same digest. If we
+    # annotated first and then the rollout failed, the next tick would
+    # see recorded == latest and skip — leaving the deployment frozen
+    # on the old image with no signal that anything went wrong.
+    if [ "$restart_needed" -eq 1 ]; then
+      log "rolling restart of deployment/${DEPLOYMENT_NAME}"
+      kubectl rollout restart -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}"
+      kubectl rollout status  -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" \
+        --timeout="$ROLLOUT_TIMEOUT"
+      log "rollout complete"
+    fi
+
+    # Apply all pending annotation updates in a single kubectl call.
+    # Both restart-then-annotate (after a successful rollout) and
+    # first-observation (without restart) go through here.
+    if [ -n "$annotate_args" ]; then
+      log "updating deployment annotations:$annotate_args"
+      # shellcheck disable=SC2086  # word-split annotate_args intentional
+      kubectl annotate deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" \
+        $annotate_args --overwrite
+    else
+      log "nothing to record or restart"
+    fi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-refresh
+spec:
+  schedule: {{ .Values.imageRefresh.schedule | quote }}
+  suspend: {{ .Values.imageRefresh.suspend }}
+  # Forbid: never run two checks at once. A long rollout that crosses the
+  # next scheduled tick must not stack a second `rollout restart` on top
+  # of itself — that would orphan the in-flight rollout's new ReplicaSet.
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.imageRefresh.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.imageRefresh.failedJobsHistoryLimit }}
+  startingDeadlineSeconds: {{ .Values.imageRefresh.startingDeadlineSeconds }}
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            {{- include "tracebloc.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: image-refresh
+        spec:
+          serviceAccountName: {{ include "tracebloc.imageRefreshName" . }}
+          restartPolicy: OnFailure
+          {{- if include "tracebloc.useImagePullSecrets" . }}
+          imagePullSecrets:
+            - name: {{ include "tracebloc.registrySecretName" . }}
+          {{- end }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: refresh
+              image: "{{ .Values.imageRefresh.image.repository }}:{{ .Values.imageRefresh.image.tag }}"
+              imagePullPolicy: {{ .Values.imageRefresh.image.pullPolicy }}
+              # alpine/k8s entrypoint is kubectl; override to run our script.
+              command: ["/bin/sh", "/scripts/image-refresh.sh"]
+              env:
+                # alpine/k8s's kubectl writes a discovery cache under
+                # $HOME/.kube. The pod runs uid 1000 with
+                # readOnlyRootFilesystem, so point HOME at the writable
+                # emptyDir mounted at /home/kubectl.
+                - name: HOME
+                  value: "/home/kubectl"
+                - name: RELEASE_NAME
+                  value: {{ .Release.Name | quote }}
+                - name: RELEASE_NAMESPACE
+                  value: {{ .Release.Namespace | quote }}
+                - name: DEPLOYMENT_NAME
+                  value: {{ printf "%s-jobs-manager" .Release.Name | quote }}
+                - name: IMAGE_TAG
+                  value: {{ .Values.env.CLIENT_ENV | default "prod" | quote }}
+                - name: ROLLOUT_TIMEOUT
+                  value: {{ .Values.imageRefresh.rolloutTimeout | quote }}
+                # Per-image opt-out flags. When the operator pins by digest
+                # in values.images.*.digest, skip that image — auto-refresh
+                # is incompatible with the reproducibility contract digest
+                # pinning provides.
+                - name: JOBS_MANAGER_PINNED
+                  value: {{ ternary "1" "0" (not (empty .Values.images.jobsManager.digest)) | quote }}
+                - name: PODS_MONITOR_PINNED
+                  value: {{ ternary "1" "0" (not (empty .Values.images.podsMonitor.digest)) | quote }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                {{- toYaml .Values.imageRefresh.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+                # alpine/k8s's kubectl writes a cache under $HOME (default
+                # /root). The pod runs as uid 1000 with readOnlyRootFilesystem,
+                # so HOME=/home/kubectl needs to be writable; emptyDir mount.
+                - name: home
+                  mountPath: /home/kubectl
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "tracebloc.imageRefreshName" . }}
+                defaultMode: 0555
+            - name: tmp
+              emptyDir: {}
+            - name: home
+              emptyDir: {}
+{{- end }}

--- a/client/templates/image-refresh-rbac.yaml
+++ b/client/templates/image-refresh-rbac.yaml
@@ -1,0 +1,56 @@
+{{- if include "tracebloc.imageRefreshEnabled" . }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-refresh
+---
+{{/*
+  Namespace-scoped Role — narrower than autoUpgrade's cluster-admin
+  binding on purpose. This CronJob only touches the jobs-manager
+  Deployment in {{ .Release.Namespace }}: read it to compare the recorded
+  refresh digest, and patch it for `rollout restart` + annotation
+  update. No pods, no other resources, no cluster scope. A compromise
+  of this Pod is bounded to kicking and annotating one Deployment.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-refresh
+rules:
+  # `kubectl rollout restart` + `kubectl annotate` are both patches on
+  # the deployment. `rollout status` uses a ListWatch on the deployment
+  # to wait for completion; a ListWatch reflector needs BOTH `list`
+  # (initial sync) and `watch` (incremental updates). Missing either
+  # one drops the call into a 403 retry loop until --timeout fires
+  # (kubectl#580), marking every successful restart as a failed Job.
+  # Both caught in PR #155 review.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-refresh
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "tracebloc.imageRefreshName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -1,0 +1,344 @@
+suite: image-refresh CronJob and RBAC
+templates:
+  - templates/image-refresh-cronjob.yaml
+  - templates/image-refresh-rbac.yaml
+release:
+  name: stg
+  namespace: tracebloc
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: cronjob template renders ConfigMap + CronJob by default
+    template: templates/image-refresh-cronjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: rbac template renders ServiceAccount + Role + RoleBinding by default
+    template: templates/image-refresh-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: cronjob template renders nothing when imageRefresh.enabled=false
+    template: templates/image-refresh-cronjob.yaml
+    set:
+      imageRefresh:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rbac template renders nothing when imageRefresh.enabled=false
+    template: templates/image-refresh-rbac.yaml
+    set:
+      imageRefresh:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: cronjob template renders nothing when BOTH images are digest-pinned
+    # Digest pinning is an explicit opt-out from drift. If both images
+    # are pinned, auto-refresh has nothing to do and the resources
+    # should not be created at all.
+    template: templates/image-refresh-cronjob.yaml
+    set:
+      images:
+        jobsManager:
+          digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        podsMonitor:
+          digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rbac template renders nothing when BOTH images are digest-pinned
+    template: templates/image-refresh-rbac.yaml
+    set:
+      images:
+        jobsManager:
+          digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        podsMonitor:
+          digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: cronjob still renders when only ONE image is digest-pinned
+    # The other image can still drift, so the CronJob must run and the
+    # script will skip the pinned image via env flags.
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    set:
+      images:
+        jobsManager:
+          digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    asserts:
+      - isKind:
+          of: CronJob
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: JOBS_MANAGER_PINNED
+            value: "1"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PODS_MONITOR_PINNED
+            value: "0"
+
+  - it: ConfigMap holds the digest-poll script
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: stg-image-refresh
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "kubectl rollout restart"
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "registry-1.docker.io"
+      # Regression guard: the digest-pinned skip MUST stay in the script.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "pinned by digest in values"
+      # Regression guard: the script must HEAD the manifest with all
+      # four Accept media types in a SINGLE comma-separated Accept
+      # header per the Docker registry v2 spec (some proxies have been
+      # observed dropping repeated Accept headers — caught in PR #155
+      # review, bugbot medium severity).
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'Accept: application/vnd\.docker\.distribution\.manifest\.v2\+json,application/vnd\.docker\.distribution\.manifest\.list\.v2\+json,application/vnd\.oci\.image\.manifest\.v1\+json,application/vnd\.oci\.image\.index\.v1\+json'
+      # Regression guard: case-fold response headers with tr BEFORE awk.
+      # alpine/k8s ships BusyBox awk which silently ignores gawk's
+      # IGNORECASE=1; a mixed-case `Docker-Content-Digest` from an
+      # HTTP/1.1 proxy would otherwise never match. Caught in PR #155
+      # review (bugbot medium severity).
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "tr '\\[:upper:\\]' '\\[:lower:\\]'"
+      - notMatchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "BEGIN[{ ]IGNORECASE"
+      # Regression guard: log() MUST write to stderr (>&2) so log lines
+      # cannot pollute command-substitution capture sites like
+      # `latest="$(get_latest_digest "$repo")"`. Caught in PR #155
+      # review (bugbot medium severity).
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'log\(\) \{ printf .*>&2'
+      # Regression guards for the annotation-based comparison model.
+      # Source of truth is `tracebloc.io/last-refreshed-*-digest`
+      # annotations on the deployment, NOT the pod's
+      # containerStatuses[].imageID. This shape is deliberate — it
+      # sidesteps imageID format variance across runtimes and the
+      # multi-arch index-vs-platform-digest divergence. A future
+      # refactor that re-introduces imageID comparison would re-
+      # introduce that whole class of bugs.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "tracebloc\\.io/last-refreshed-jobs-manager-digest"
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "tracebloc\\.io/last-refreshed-pods-monitor-digest"
+      # The script must NOT reach into pod containerStatuses to read
+      # imageIDs — that's the runtime-variant data shape we explicitly
+      # designed around. Pattern targets the only call shape that could
+      # do it (`kubectl get pod`) rather than the words, so the design-
+      # rationale comments are free to keep mentioning containerStatuses
+      # / imageID as history.
+      - notMatchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "kubectl get pod"
+      # First-observation contract: when an annotation is absent
+      # (recorded is empty), the script must record the current digest
+      # WITHOUT triggering a restart. A spurious first-tick restart
+      # would churn the deployment on every fresh install.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "first observation; recording without restart"
+      # Order-of-operations contract: `rollout restart` + `rollout
+      # status` MUST run before `kubectl annotate`. If we annotated
+      # first and the rollout then failed, the next tick would see
+      # recorded == latest and skip — leaving the deployment frozen
+      # on the old image with no signal. The test asserts that the
+      # rollout block appears in the script BEFORE the annotate block.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: '(?s)kubectl rollout restart.*kubectl annotate deployment'
+
+  - it: CronJob has the right schedule, concurrency, and SA wiring
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: stg-image-refresh
+      - equal:
+          path: spec.schedule
+          value: "7,22,37,52 * * * *"
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: stg-image-refresh
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.restartPolicy
+          value: OnFailure
+
+  - it: CronJob env carries release identity and tag to the script
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    set:
+      env:
+        CLIENT_ENV: "prod"
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: RELEASE_NAME
+            value: stg
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: RELEASE_NAMESPACE
+            value: tracebloc
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: DEPLOYMENT_NAME
+            value: stg-jobs-manager
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: IMAGE_TAG
+            value: prod
+
+  - it: CronJob pod satisfies PSA restricted (runAsNonRoot, dropped caps, RO root, seccomp)
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+
+  - it: Role is namespace-scoped, deployments-only (no pods, no cluster-admin)
+    # The annotation pattern eliminated the need to read pods entirely —
+    # the script reads the recorded digest from a deployment annotation,
+    # not from containerStatuses[].imageID. Tightening RBAC to just
+    # apps/deployments shrinks the blast radius of a compromised refresh
+    # Pod to one resource type in one namespace. Lock the rule list
+    # with `equal` so a regression that adds back a pods rule (or worse,
+    # a cluster role) fails loudly.
+    template: templates/image-refresh-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 3
+      - isKind:
+          of: ServiceAccount
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: stg-image-refresh
+        documentIndex: 0
+      - isKind:
+          of: Role
+        documentIndex: 1
+      - equal:
+          path: rules
+          value:
+            - apiGroups: ["apps"]
+              resources: ["deployments"]
+              verbs: ["get", "list", "patch", "watch"]
+        documentIndex: 1
+      - equal:
+          path: roleRef.kind
+          value: Role
+        documentIndex: 2
+      - equal:
+          path: subjects[0].name
+          value: stg-image-refresh
+        documentIndex: 2
+
+  - it: should accept operator overrides for schedule, image, and timeout
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    set:
+      imageRefresh:
+        enabled: true
+        schedule: "*/5 * * * *"
+        rolloutTimeout: "20m"
+        image:
+          repository: my-mirror/k8s
+          tag: "1.30.5"
+          pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "*/5 * * * *"
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: my-mirror/k8s:1.30.5
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: ROLLOUT_TIMEOUT
+            value: "20m"
+
+  - it: schema rejects image.tag=latest (image-refresh behaviour must not drift)
+    template: templates/image-refresh-cronjob.yaml
+    set:
+      imageRefresh:
+        image:
+          tag: "latest"
+    asserts:
+      - failedTemplate:
+          errorPattern: "must not be valid against schema"
+
+  - it: cronjob template renders nothing (no crash) when imageRefresh key is entirely absent
+    # Regression guard for the --reuse-values upgrade path. Customers
+    # who upgrade with `helm upgrade --reuse-values --version 1.4.0`
+    # (instead of the autoUpgrade-recommended --reset-then-reuse-values)
+    # replay stored 1.3.x values that have NO `imageRefresh` block at
+    # all. The template must degrade silently (no resources rendered)
+    # rather than crash with nil-pointer — see the "nil-guard every new
+    # top-level value key" rule in CLAUDE.md.
+    template: templates/image-refresh-cronjob.yaml
+    set:
+      imageRefresh: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rbac template renders nothing (no crash) when imageRefresh key is entirely absent
+    template: templates/image-refresh-rbac.yaml
+    set:
+      imageRefresh: null
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -148,6 +148,19 @@ tests:
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: "tracebloc\\.io/last-refreshed-pods-monitor-digest"
+      # Regression guard: read annotations with jq, not kubectl
+      # bracket-notation jsonpath. kubectl-go's jsonpath parser returns
+      # empty for `annotations['key.with.dots']` — verified on
+      # alpine/k8s 1.30.5 in dev-cluster smoke test. Switching to
+      # `kubectl get -o json | jq` made the read work.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "jq -r --arg k"
+      # And the script must NOT regress back to bracket-notation
+      # jsonpath for reading annotations.
+      - notMatchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "annotations\\[.\\$_key.\\]"
       # The script must NOT reach into pod containerStatuses to read
       # imageIDs — that's the runtime-variant data shape we explicitly
       # designed around. Pattern targets the only call shape that could

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -555,6 +555,80 @@
         }
       }
     },
+    "imageRefresh": {
+      "type": "object",
+      "description": "Image-refresh CronJob (issue tracebloc/client#154). Polls Docker Hub for jobs-manager and pods-monitor digests under the floating CLIENT_ENV tag and rolls the deployment when a new image is published. Disable to keep the running image in place until manual restart.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "When false, no CronJob, ServiceAccount, Role, or RoleBinding is rendered. The deployment will not auto-refresh on new image pushes."
+        },
+        "schedule": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Cron expression. Keep the tick rate compatible with Docker Hub's 100/6h anonymous pull-rate limit (each tick HEADs two manifests)."
+        },
+        "rolloutTimeout": {
+          "type": "string",
+          "pattern": "^[0-9]+(s|m|h)$",
+          "description": "Passed to `kubectl rollout status --timeout`. Allow headroom for bare-metal image pull."
+        },
+        "suspend": {
+          "type": "boolean",
+          "default": false,
+          "description": "CronJob.spec.suspend. Set true to pause without removing the resources."
+        },
+        "successfulJobsHistoryLimit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failedJobsHistoryLimit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "startingDeadlineSeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "image": {
+          "type": "object",
+          "required": ["repository", "tag"],
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": {
+              "type": "string",
+              "minLength": 1,
+              "not": { "const": "latest" },
+              "description": "Pin the alpine/k8s version. `latest` is rejected — image-refresh behaviour must not drift."
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+              }
+            }
+          }
+        }
+      }
+    },
     "dockerRegistry": {
       "type": ["object", "null"],
       "description": "Optional. Omit entirely or set null for public images (no secret or imagePullSecrets). Only create when set and create is true.",

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -370,6 +370,99 @@ autoUpgrade:
       cpu: "500m"
       memory: "256Mi"
 
+# -- Image-refresh CronJob (closes tracebloc/client#154).
+# Auto-restarts the jobs-manager Deployment when a new image digest is
+# published to Docker Hub under the floating CLIENT_ENV tag. Without
+# this, `imagePullPolicy: Always` only pulls on pod creation — running
+# pods stay on the old image until someone manually
+# `kubectl rollout restart`s them, which is exactly the
+# customer-runs-no-commands UX we want to avoid.
+#
+# How it works:
+#   - A CronJob in this namespace polls Docker Hub for the current
+#     manifest digest of tracebloc/jobs-manager:<CLIENT_ENV> and
+#     tracebloc/pods-monitor:<CLIENT_ENV> (both containers live in one
+#     deployment).
+#   - The script compares each fetched digest to an annotation on the
+#     deployment (`tracebloc.io/last-refreshed-<image>-digest`) that
+#     records the digest the LAST successful refresh restarted to. Not
+#     to the running pod's imageID — that value's format varies across
+#     container runtimes (kubernetes/kubernetes#108689 + #115199) and
+#     diverges from the registry's index digest on multi-arch tags.
+#     The annotation makes the comparison entirely server-vs-our-record
+#     with no client-side runtime variation in the loop.
+#   - On a real change: `kubectl rollout restart` + `kubectl rollout
+#     status` to wait for completion, then patch the annotation to the
+#     new digest. (Order matters — annotating first would let a failed
+#     rollout silently freeze the deployment.)
+#   - First observation (annotation absent on a fresh install): record
+#     the current digest without restarting. No evidence of drift, no
+#     reason to churn the pod.
+#   - Idle-cheap: when the recorded digest matches today's digest, the
+#     script exits without touching the deployment. Steady state is one
+#     HEAD per image per tick, well under Docker Hub's 100/6h anonymous
+#     pull-rate limit.
+#
+# Pinned-digest interaction: if BOTH images.jobsManager.digest and
+# images.podsMonitor.digest are set, the chart skips rendering this
+# CronJob entirely — digest pinning is an explicit opt-out from drift,
+# and auto-restart would defeat the purpose. If only one is pinned the
+# CronJob still runs but the script skips the pinned image at runtime.
+#
+# Trust boundary: this CronJob's ServiceAccount is bound to a
+# namespace-scoped Role with get/list/patch/watch on the deployment
+# resource ONLY (no pods, no other resources, no cluster scope). Much
+# narrower than autoUpgrade — a compromise of this Pod can only kick
+# and annotate the jobs-manager Deployment in this one namespace. The
+# script reaches out only to docker.io's public registry endpoints; if
+# your cluster requires egress through a proxy, set HTTPS_PROXY via env
+# or disable this CronJob.
+#
+# Disabled-on-this-cluster check after install:
+#   kubectl get cronjob -n <namespace> -l app.kubernetes.io/component=image-refresh
+#
+# Inspect what the controller has recorded so far:
+#   kubectl get deployment <release>-jobs-manager -n <namespace> \
+#     -o jsonpath='{.metadata.annotations}' | tr ',' '\n' \
+#     | grep tracebloc.io/last-refreshed
+imageRefresh:
+  # Default ON: the whole point of #154 is that customers don't have to
+  # run any commands when we publish a new jobs-manager image.
+  enabled: true
+  # Every 15 minutes at minute :07. The off-hour minute spreads load
+  # across Docker Hub's registry-1 origin; 15m balances drift latency
+  # against the 100/6h anonymous pull-rate limit (2 images × 4/hr = 8/hr,
+  # well under the cap even shared with other workloads on the same IP).
+  schedule: "7,22,37,52 * * * *"
+  # `kubectl rollout status --timeout`. Generous; jobs-manager image pulls
+  # on bare-metal first-boot can take minutes, and the CronJob slot
+  # shouldn't hold all night if a rollout genuinely wedges.
+  rolloutTimeout: "10m"
+  # CronJob spec knobs. Override per-cluster if needed.
+  suspend: false
+  # Lower history limits than autoUpgrade — this Job runs ~96x/day, the
+  # successful runs aren't interesting and 1 is enough for an at-a-glance
+  # "last run succeeded" check.
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  # Pod image: needs `sh`, `kubectl`, and `curl`. alpine/k8s ships all
+  # three in a small image and we pin the tag so behaviour cannot drift
+  # if upstream re-tags.
+  image:
+    repository: alpine/k8s
+    tag: "1.30.5"
+    pullPolicy: IfNotPresent
+  # Tiny — the pod is mostly idle waiting on network I/O for the digest
+  # HEADs and the rollout-status watch.
+  resources:
+    requests:
+      cpu: "20m"
+      memory: "64Mi"
+    limits:
+      cpu: "200m"
+      memory: "128Mi"
+
 # ============================================================
 # Ingestion endpoint authorization (client-runtime#21)
 # ============================================================


### PR DESCRIPTION
## Summary

Brings the **image-refresh CronJob** feature to `main` ahead of cutting the `v1.4.0` release tag.

## What's included

- **#155** — `feat(#154): auto-refresh jobs-manager image on Docker Hub publish`
- **#156** — `fix(#154): read annotations via jq, not kubectl jsonpath bracket notation`

Together they deliver the closure for [#154](https://github.com/tracebloc/client/issues/154): existing customers' jobs-manager (and pods-monitor) deployments now auto-refresh on Docker Hub tag publishes with no manual `kubectl rollout restart` needed. Source of truth is a `tracebloc.io/last-refreshed-<image>-digest` annotation on the deployment, comparing against the registry's HEAD digest each tick.

## Dev verification

Smoke-tested end-to-end on `tb-client-dev-templates` EKS:

| Test | Expected | Actual |
|---|---|---|
| Fresh `helm upgrade` from 1.3.5 → 1.4.0 with `--reset-then-reuse-values` | new image-refresh resources install, nothing else churns | ✅ |
| First image-refresh tick (no annotation) | records both digests, no restart | ✅ |
| Second tick (annotation matches) | `digest unchanged; no-op`, no annotate, no rollout | ✅ |
| Forced annotation clobber (simulates new image push) | `digest changed → restart needed`, rollout, then re-annotate to current digest | ✅ |
| Rollout history | bumped by 1 only on the forced-change test | ✅ |

## After merging

Cut `v1.4.0` release tag from `main` — that fires [release-helm-chart.yaml](.github/workflows/release-helm-chart.yaml) which publishes `client-1.4.0.tgz` to gh-pages. Existing customers' `autoUpgrade` CronJobs pick it up at the next `:23` tick.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The CronJob can restart the jobs-manager deployment and holds patch RBAC on it; blast radius is one deployment in one namespace, but unintended restarts or registry/API failures could cause brief outages.
> 
> **Overview**
> Releases the Helm chart at **v1.4.0** and adds an **image-refresh** path so `jobs-manager` (and `pods-monitor` via the same deployment) can pick up new Docker Hub images under the floating `CLIENT_ENV` tag without manual `kubectl rollout restart`.
> 
> A scheduled CronJob runs a shell script that HEADs Docker Hub for manifest digests, compares them to `tracebloc.io/last-refreshed-*-digest` annotations on the deployment (not pod `imageID`), records digests on first run without restarting, and on change runs `kubectl rollout restart` then `rollout status` before updating annotations. Rendering is gated by `tracebloc.imageRefreshEnabled` (off when disabled or both images are digest-pinned); namespace-scoped RBAC limits the job to patch/watch that deployment. New `imageRefresh` values and schema defaults, plus helm-unittest coverage for script/RBAC contracts and upgrade safety when `imageRefresh` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e78d9aa4cff456fe1cceea9a12a4ed475c06cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->