### PR TITLE
chore: pin client chart's ingestor digest to v0.3.1

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.4.0
-appVersion: "1.4.0"
+version: 1.4.1
+appVersion: "1.4.1"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -187,15 +187,28 @@ images:
   # subchart's `image.digest` (for pinning / debugging), but the
   # dominant path uses this value.
   #
-  # Bumped to v0.3.0 (2026-05-20) — first production-ready release of
-  # the declarative-YAML ingestor with schema-packaging, image-validator,
-  # and file-transfer fixes from tracebloc/data-ingestors#106.
+  # Bumped to v0.3.1 (2026-05-25) — patch on top of v0.3.0 carrying two
+  # customer-impacting fixes:
+  #   * tracebloc/data-ingestors#108 — copy tokenizer.json to the
+  #     training pod for MLM datasets. Without this fix, the client
+  #     fell back to bert-base-uncased (vocab=30522), which exceeded
+  #     user models' nn.Embedding and crashed training with a CUDA
+  #     device-side assert.
+  #   * tracebloc/data-ingestors#119 — close YAML-vs-template parity
+  #     gaps in per-category metadata (tabular number_of_columns,
+  #     keypoint target_size / number_of_keypoints, tabular na_values).
+  #     Backend metadata diverged silently depending on ingestion path.
+  # First release exercised by the digest-level smoke probes from
+  # tracebloc/data-ingestors#96 (schema-load + entrypoint resolution
+  # before cosign signing).
   # Bump this on each ingestor release; chart `version` in Chart.yaml must
   # also bump so the auto-upgrade cronjob detects the change. Future
   # automation in tracebloc/data-ingestors (release-image.yml) can
-  # raise a PR to this file when a new image is published.
+  # raise a PR to this file when a new image is published — see
+  # client#159 for the runtime-side variant (image-refresh CronJob)
+  # that will obsolete this manual-bump pattern altogether.
   ingestor:
-    digest: "sha256:463e236748708a5e3564569eec9173ea8cb3bcf515992d4939c5b610f3807a4a"
+    digest: "sha256:a0861ea9fbf4653279351ee30af9ebe2b75fcacd391923b681631312f4a85ee4"
   podsMonitor:
     digest: ""
   resourceMonitor:


### PR DESCRIPTION
## Summary

- Bumps `images.ingestor.digest` in `client/values.yaml` from v0.3.0's sha to **v0.3.1**'s — see [data-ingestors release notes](https://github.com/tracebloc/data-ingestors/releases/tag/v0.3.1).
- Bumps chart version 1.4.0 → 1.4.1 (and `appVersion`) so the auto-upgrade CronJob detects the change.
- Refreshes the explanatory comment to point at v0.3.1's fixes and flags that #159 will obsolete this manual pattern once it lands.

Closes #160. Unblocks customer access to two real fixes from data-ingestors v0.3.1.

## What v0.3.1 carries

- **[data-ingestors#108](https://github.com/tracebloc/data-ingestors/pull/108)** — copy `tokenizer.json` to the training pod for MLM datasets. Without this fix, the client fell back to `bert-base-uncased` (vocab=30522), which exceeded user models' `nn.Embedding` and crashed training with a CUDA device-side assert. Hard crash for any customer training MLM with a custom tokenizer.
- **[data-ingestors#119](https://github.com/tracebloc/data-ingestors/pull/119)** — close YAML-vs-template parity gaps in per-category metadata (tabular `number_of_columns`, keypoint `target_size` / `number_of_keypoints`, tabular `na_values`). Backend metadata diverged silently depending on ingestion path.
- v0.3.1 is also the first release exercised end-to-end by the digest-level smoke probes from [data-ingestors#96](https://github.com/tracebloc/data-ingestors/pull/96).

## Conflict heads-up for #159

This PR bumps the chart to **1.4.1**, which is the same version #159 currently targets. #159 will need to rebase onto `1.4.2` after this lands — sequencing nuisance, not a substantive conflict. The two PRs touch different files for the version field's purpose, and once #159 merges its image-refresh CronJob will keep `INGESTOR_IMAGE_DIGEST` current on live clusters without further manual pins.

## Test plan

- [x] `helm unittest client` — 136/136 pass on this branch (no template-logic touched, but rerun anyway).
- [x] `git grep` confirms the old v0.3.0 digest is no longer referenced anywhere in the tree.
- [x] `helm lint` — fails only on the pre-existing `clientId`/`clientPassword` required-fields check, same as on `origin/develop`. Not introduced by this PR.
- [ ] **Dev-cluster smoke** — upgrade `tracebloc` chart release on dev to 1.4.1 in a values file overlay; confirm `INGESTOR_IMAGE_DIGEST` env on the jobs-manager api container becomes `sha256:a0861ea9...`; run a quick MLM ingestion to confirm `tokenizer.json` lands in the training pod's DEST_PATH.
- [ ] Promote to stg + selected prod tenants via the autoUpgrade flow once dev validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Values-only digest and version bump with no deployment template changes; risk is rollout timing and coordination with PR #159 on the same chart version.
> 
> **Overview**
> Bumps the unified **client** Helm chart from **1.4.0** to **1.4.1** so the existing **auto-upgrade** CronJob can pick up a new release, and pins **`images.ingestor.digest`** to the **data-ingestors v0.3.1** image (replacing the v0.3.0 SHA). That digest is what **jobs-manager** exposes as **`INGESTOR_IMAGE_DIGEST`** for ingestion jobs—no template changes.
> 
> The comment block in **`values.yaml`** is refreshed to describe why v0.3.1 matters: MLM **`tokenizer.json`** propagation to training pods (avoids wrong-vocab CUDA crashes) and YAML-vs-template metadata parity for tabular/keypoint fields, plus a note that **#159** will automate digest updates later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4b6251c6cadb0dd3174050112ed29add66416ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->