### PR TITLE
fix(#166, #168): installer survives corporate proxy + sanitizes credential input

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -2,13 +2,13 @@ name: Helm Chart CI
 
 on:
   push:
-    branches: [main, openshift]
+    branches: [main, develop, openshift]
     paths:
       - 'client/**'
       - 'ingestor/**'
       - '.github/workflows/helm-ci.yaml'
   pull_request:
-    branches: [main, openshift]
+    branches: [main, develop, openshift]
     paths:
       - 'client/**'
       - 'ingestor/**'

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.4.1
-appVersion: "1.4.1"
+version: 1.4.2
+appVersion: "1.4.2"
 keywords:
   - tracebloc
   - kubernetes

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -193,5 +193,5 @@ _wait_for_api() {
   error "kubectl cluster-info failed for 60s. Cluster reports running, but the API is unreachable. Possible causes:
    (a) Docker daemon stopped (run 'docker ps' to verify);
    (b) corporate HTTP/HTTPS proxy intercepting localhost — ensure NO_PROXY includes '127.0.0.1,localhost';
-   (c) kubeconfig has 0.0.0.0 — try: sed -i 's|0.0.0.0|127.0.0.1|g' ~/.kube/config"
+   (c) kubeconfig has 0.0.0.0 — try: sed -i.bak 's|0.0.0.0|127.0.0.1|g' ~/.kube/config && rm ~/.kube/config.bak"
 }

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -85,28 +85,38 @@ _handle_existing_cluster() {
 }
 
 # k3d bakes --env flags into containers at create time; they cannot be added
-# to a running cluster. If the host shell has proxy vars set but the existing
-# cluster was created without proxy propagation, image pulls behind a corporate
-# proxy will fail. Detect and prompt the user to delete + recreate.
+# to a running cluster. Per-var check: for each proxy var set on the host,
+# verify the cluster has it. Detect NO_PROXY-only drift too (an older cluster
+# may have HTTP_PROXY baked in but be missing a NO_PROXY the host has since
+# added — without it, in-cluster traffic to .svc/.cluster.local or 127.0.0.1
+# can get routed through the proxy).
 # Silent no-op if Docker isn't running, the server container can't be inspected,
 # or the host has no proxy env set.
 _check_existing_cluster_proxy() {
-  local host_has=false
-  for var in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy; do
-    [[ -n "${!var:-}" ]] && { host_has=true; break; }
+  local host_vars=()
+  for var in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
+    [[ -n "${!var:-}" ]] && host_vars+=("$var")
   done
-  [[ "$host_has" == false ]] && return 0
+  [[ ${#host_vars[@]} -eq 0 ]] && return 0
 
   local server_container="k3d-${CLUSTER_NAME}-server-0"
   local cluster_env
   cluster_env=$(docker inspect "$server_container" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null) || return 0
   [[ -z "$cluster_env" ]] && return 0
 
-  if ! echo "$cluster_env" | grep -Eq '^(HTTP_PROXY|HTTPS_PROXY|http_proxy|https_proxy)='; then
+  local missing=()
+  for var in "${host_vars[@]}"; do
+    if ! echo "$cluster_env" | grep -Eq "^${var}="; then
+      missing+=("$var")
+    fi
+  done
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
     echo ""
-    warn "Host has proxy env set, but the existing '$CLUSTER_NAME' cluster was created without proxy propagation."
+    warn "Host has proxy env set, but the existing '$CLUSTER_NAME' cluster is missing: ${missing[*]}."
     hint "k3d bakes --env flags into containers at create time — they can't be added to a running cluster."
-    hint "If image pulls fail, recreate the cluster:  k3d cluster delete $CLUSTER_NAME && re-run this installer."
+    hint "If image pulls fail or in-cluster traffic misroutes, recreate the cluster:"
+    hint "  k3d cluster delete $CLUSTER_NAME  &&  re-run this installer."
     echo ""
   fi
 }
@@ -229,8 +239,14 @@ _wait_for_api() {
   done
   printf "\r\033[K"
   tput cnorm 2>/dev/null || true
+
+  # Surface the actual kubeconfig path. KUBECONFIG can be colon-separated
+  # (kubectl supports a list); point at the first entry — users with custom
+  # multi-file layouts can adapt the sed command themselves.
+  local kc="${KUBECONFIG:-${HOME}/.kube/config}"
+  kc="${kc%%:*}"
   error "kubectl cluster-info failed for 60s. Cluster reports running, but the API is unreachable. Possible causes:
    (a) Docker daemon stopped (run 'docker ps' to verify);
    (b) corporate HTTP/HTTPS proxy intercepting localhost — ensure NO_PROXY includes '127.0.0.1,localhost';
-   (c) kubeconfig has 0.0.0.0 — try: sed -i.bak 's|0.0.0.0|127.0.0.1|g' ~/.kube/config && rm ~/.kube/config.bak"
+   (c) kubeconfig has 0.0.0.0 — try: sed -i.bak 's|0.0.0.0|127.0.0.1|g' ${kc} && rm ${kc}.bak"
 }

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -95,7 +95,14 @@ _handle_existing_cluster() {
 _check_existing_cluster_proxy() {
   local host_vars=()
   for var in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
-    [[ -n "${!var:-}" ]] && host_vars+=("$var")
+    local val="${!var:-}"
+    [[ -z "$val" ]] && continue
+    # Mirror _create_new_cluster: values containing '@' aren't propagated to
+    # k3d (filter-syntax conflict), so recreating the cluster wouldn't bake
+    # them either. Excluding them keeps the warning honest — we only flag
+    # vars where the "delete + recreate" advice will actually resolve drift.
+    [[ "$val" == *"@"* ]] && continue
+    host_vars+=("$var")
   done
   [[ ${#host_vars[@]} -eq 0 ]] && return 0
 
@@ -209,10 +216,17 @@ _merge_kubeconfig() {
   # installs). Behind a corporate HTTP/HTTPS proxy, 0.0.0.0 gets intercepted
   # and kubectl fails. Anchored to `https://0.0.0.0:` so CIDR ranges and other
   # 0.0.0.0 occurrences elsewhere in the file are left untouched.
-  if [[ -f "$KUBECONFIG" ]] && grep -q 'https://0\.0\.0\.0:' "$KUBECONFIG"; then
-    sed -i.bak 's|https://0\.0\.0\.0:|https://127.0.0.1:|g' "$KUBECONFIG"
-    rm -f "${KUBECONFIG}.bak"
-    log "Normalized kubeconfig server URL: 0.0.0.0 → 127.0.0.1 (corporate-proxy safety)."
+  #
+  # KUBECONFIG can be colon-separated (kubectl path-list semantics); k3d's
+  # --kubeconfig-merge-default writes into the first entry (or ~/.kube/config
+  # if KUBECONFIG is unset). Target the same file or the rewrite would be
+  # skipped by -f on multi-file layouts.
+  local kc_target="${KUBECONFIG:-${HOME}/.kube/config}"
+  kc_target="${kc_target%%:*}"
+  if [[ -f "$kc_target" ]] && grep -q 'https://0\.0\.0\.0:' "$kc_target"; then
+    sed -i.bak 's|https://0\.0\.0\.0:|https://127.0.0.1:|g' "$kc_target"
+    rm -f "${kc_target}.bak"
+    log "Normalized kubeconfig server URL: 0.0.0.0 → 127.0.0.1 in $kc_target (corporate-proxy safety)."
   fi
 
   log "kubeconfig updated — kubectl now points to '$CLUSTER_NAME'."

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -93,18 +93,39 @@ _handle_existing_cluster() {
 # Silent no-op if Docker isn't running, the server container can't be inspected,
 # or the host has no proxy env set.
 _check_existing_cluster_proxy() {
-  local host_vars=()
+  # Partition host proxy vars into two buckets:
+  #   • drift_candidates — values without '@' that would propagate cleanly;
+  #                        the cluster should have these, flag if missing.
+  #   • at_skipped       — values with '@' that _create_new_cluster refused
+  #                        to propagate (k3d's KEY=VALUE@FILTER conflict).
+  #                        Recreating wouldn't help — needs a different
+  #                        remedy (strip creds, use auth proxy).
+  local drift_candidates=() at_skipped=()
   for var in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
     local val="${!var:-}"
     [[ -z "$val" ]] && continue
-    # Mirror _create_new_cluster: values containing '@' aren't propagated to
-    # k3d (filter-syntax conflict), so recreating the cluster wouldn't bake
-    # them either. Excluding them keeps the warning honest — we only flag
-    # vars where the "delete + recreate" advice will actually resolve drift.
-    [[ "$val" == *"@"* ]] && continue
-    host_vars+=("$var")
+    if [[ "$val" == *"@"* ]]; then
+      at_skipped+=("$var")
+    else
+      drift_candidates+=("$var")
+    fi
   done
-  [[ ${#host_vars[@]} -eq 0 ]] && return 0
+
+  # @-skipped vars get their own warning that fires on every re-run (the
+  # create-time skip warning in _create_new_cluster doesn't fire on the
+  # existing-cluster path). Recreate alone won't bake them, so guide the
+  # user toward the remedies that actually work.
+  if [[ ${#at_skipped[@]} -gt 0 ]]; then
+    echo ""
+    warn "Proxy env on host contains '@' (likely embedded credentials): ${at_skipped[*]}."
+    hint "k3d's --env KEY=VALUE@FILTER syntax can't carry an '@' in the value, so these"
+    hint "are not propagated into the cluster. If image pulls fail:"
+    hint "  • strip credentials from the URL (configure auth inside the cluster), or"
+    hint "  • point HTTP(S)_PROXY at a credential-less local auth-proxy that fronts the corporate proxy."
+    echo ""
+  fi
+
+  [[ ${#drift_candidates[@]} -eq 0 ]] && return 0
 
   local server_container="k3d-${CLUSTER_NAME}-server-0"
   local cluster_env
@@ -112,7 +133,7 @@ _check_existing_cluster_proxy() {
   [[ -z "$cluster_env" ]] && return 0
 
   local missing=()
-  for var in "${host_vars[@]}"; do
+  for var in "${drift_candidates[@]}"; do
     if ! echo "$cluster_env" | grep -Eq "^${var}="; then
       missing+=("$var")
     fi

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -98,7 +98,7 @@ _create_new_cluster() {
     cluster create "$CLUSTER_NAME"
     --servers "$SERVERS"
     --agents  "$AGENTS"
-    --api-port 6550
+    --api-port 127.0.0.1:6550
     -v "${HOST_DATA_DIR}:/tracebloc@all"
     --k3s-arg "--disable=traefik@server:*"
     --k3s-arg "--disable=servicelb@server:*"
@@ -116,6 +116,16 @@ _create_new_cluster() {
     log "Creating cluster with $SERVERS server(s) + $AGENTS agent(s) (CPU-only)..."
   fi
   hint "First run may take 1-2 minutes to download components."
+
+  # Propagate corporate proxy env vars so k3s/k3d containers can reach external
+  # registries behind HTTP/HTTPS proxies (hospital/banking/government tenants).
+  # Loop checks both upper- and lower-case forms — apps in containers read either.
+  for var in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
+    if [[ -n "${!var:-}" ]]; then
+      K3D_ARGS+=(--env "${var}=${!var}@all")
+      log "Propagating ${var} to k3d nodes."
+    fi
+  done
 
   local create_out create_rc
   create_out="$(mktemp)"
@@ -144,6 +154,18 @@ _merge_kubeconfig() {
     --kubeconfig-merge-default \
     --kubeconfig-switch-context \
     >/dev/null 2>&1
+
+  # Defensive normalization: k3d may still emit 0.0.0.0 server URLs into the
+  # kubeconfig (older k3d versions, or pre-existing entries from previous
+  # installs). Behind a corporate HTTP/HTTPS proxy, 0.0.0.0 gets intercepted
+  # and kubectl fails. Anchored to `https://0.0.0.0:` so CIDR ranges and other
+  # 0.0.0.0 occurrences elsewhere in the file are left untouched.
+  if [[ -f "$KUBECONFIG" ]] && grep -q 'https://0\.0\.0\.0:' "$KUBECONFIG"; then
+    sed -i.bak 's|https://0\.0\.0\.0:|https://127.0.0.1:|g' "$KUBECONFIG"
+    rm -f "${KUBECONFIG}.bak"
+    log "Normalized kubeconfig server URL: 0.0.0.0 → 127.0.0.1 (corporate-proxy safety)."
+  fi
+
   log "kubeconfig updated — kubectl now points to '$CLUSTER_NAME'."
 }
 
@@ -168,5 +190,8 @@ _wait_for_api() {
   done
   printf "\r\033[K"
   tput cnorm 2>/dev/null || true
-  error "Compute environment did not start within 60s. Check Docker and try again."
+  error "kubectl cluster-info failed for 60s. Cluster reports running, but the API is unreachable. Possible causes:
+   (a) Docker daemon stopped (run 'docker ps' to verify);
+   (b) corporate HTTP/HTTPS proxy intercepting localhost — ensure NO_PROXY includes '127.0.0.1,localhost';
+   (c) kubeconfig has 0.0.0.0 — try: sed -i 's|0.0.0.0|127.0.0.1|g' ~/.kube/config"
 }

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -80,6 +80,35 @@ _handle_existing_cluster() {
     k3d cluster start "$CLUSTER_NAME"
     success "Compute environment started."
   fi
+
+  _check_existing_cluster_proxy
+}
+
+# k3d bakes --env flags into containers at create time; they cannot be added
+# to a running cluster. If the host shell has proxy vars set but the existing
+# cluster was created without proxy propagation, image pulls behind a corporate
+# proxy will fail. Detect and prompt the user to delete + recreate.
+# Silent no-op if Docker isn't running, the server container can't be inspected,
+# or the host has no proxy env set.
+_check_existing_cluster_proxy() {
+  local host_has=false
+  for var in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy; do
+    [[ -n "${!var:-}" ]] && { host_has=true; break; }
+  done
+  [[ "$host_has" == false ]] && return 0
+
+  local server_container="k3d-${CLUSTER_NAME}-server-0"
+  local cluster_env
+  cluster_env=$(docker inspect "$server_container" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null) || return 0
+  [[ -z "$cluster_env" ]] && return 0
+
+  if ! echo "$cluster_env" | grep -Eq '^(HTTP_PROXY|HTTPS_PROXY|http_proxy|https_proxy)='; then
+    echo ""
+    warn "Host has proxy env set, but the existing '$CLUSTER_NAME' cluster was created without proxy propagation."
+    hint "k3d bakes --env flags into containers at create time — they can't be added to a running cluster."
+    hint "If image pulls fail, recreate the cluster:  k3d cluster delete $CLUSTER_NAME && re-run this installer."
+    echo ""
+  fi
 }
 
 _create_new_cluster() {
@@ -120,9 +149,19 @@ _create_new_cluster() {
   # Propagate corporate proxy env vars so k3s/k3d containers can reach external
   # registries behind HTTP/HTTPS proxies (hospital/banking/government tenants).
   # Loop checks both upper- and lower-case forms — apps in containers read either.
+  # k3d's --env syntax is KEY=VALUE@NODEFILTER; an embedded '@' in VALUE (e.g.
+  # credentials in URL: http://user:pass@host) collides with the filter
+  # delimiter and breaks `k3d cluster create`. Detect and skip with a warning;
+  # the user can strip creds and re-run, or supply creds via another mechanism.
   for var in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
-    if [[ -n "${!var:-}" ]]; then
-      K3D_ARGS+=(--env "${var}=${!var}@all")
+    val="${!var:-}"
+    if [[ -n "$val" ]]; then
+      if [[ "$val" == *"@"* ]]; then
+        warn "Skipping ${var} propagation: value contains '@' (embedded credentials are not supported by k3d's --env filter syntax)."
+        hint "Strip credentials from the URL, or configure proxy auth inside the cluster after install."
+        continue
+      fi
+      K3D_ARGS+=(--env "${var}=${val}@all")
       log "Propagating ${var} to k3d nodes."
     fi
   done

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -44,22 +44,35 @@ _extract_yaml_value() {
     line="${line#\"}"
     line="${line%\"}"
   fi
-  # Strip C0 controls + DEL on extract — defends against self-perpetuation when
-  # a previous run wrote a corrupted value (see #168). UTF-8 (0x80+) preserved.
-  printf '%s' "$line" | tr -d '\000-\037\177'
+  # Defend against self-perpetuation: a previous corrupted save may have the
+  # bracketed-paste markers and/or C0 controls (#168). _strip_paste_garbage
+  # handles both. UTF-8 (0x80+) preserved.
+  _strip_paste_garbage "$line"
 }
 
-# Strip C0 control characters (0x00-0x1F) and DEL (0x7F) from credential input.
+# Strip bracketed-paste markers and C0 control characters from a value.
 # Bracketed-paste-enabled terminals wrap pasted text in ESC[200~ ... ESC[201~
-# (ESC = 0x1B); without stripping, these bytes land in values.yaml and Helm
-# rejects the file ("yaml: control characters are not allowed"). UTF-8 bytes
-# (0x80+) are preserved so passwords with international characters work.
+# (ESC = 0x1B). Stripping ESC alone leaves the literal `[200~` / `[201~`
+# remnants visible in the value, so match both the full ESC-prefixed form and
+# the standalone-marker form. UTF-8 bytes (0x80+) preserved.
+_strip_paste_garbage() {
+  local s="$1"
+  s="${s//$'\e'\[200\~/}"
+  s="${s//$'\e'\[201\~/}"
+  s="${s//\[200\~/}"
+  s="${s//\[201\~/}"
+  printf '%s' "$s" | tr -d '\000-\037\177'
+}
+
+# Sanitize a user-entered credential. Calls _strip_paste_garbage and notifies
+# the user on stderr (NOT stdout — this function is called from inside $(...),
+# so stdout is captured into the credential value itself).
 _sanitize_credential() {
   local input="$1"
   local clean
-  clean=$(printf '%s' "$input" | tr -d '\000-\037\177')
+  clean=$(_strip_paste_garbage "$input")
   if [[ "$clean" != "$input" ]]; then
-    warn "Stripped non-printable characters from input (likely paste-mode escape codes)."
+    warn "Stripped non-printable / paste-mode characters from input." >&2
   fi
   printf '%s' "$clean"
 }

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -50,15 +50,28 @@ _extract_yaml_value() {
   _strip_paste_garbage "$line"
 }
 
-# Strip bracketed-paste markers and C0 control characters from a value.
-# Bracketed-paste-enabled terminals wrap pasted text in ESC[200~ ... ESC[201~
-# (ESC = 0x1B). Stripping ESC alone leaves the literal `[200~` / `[201~`
-# remnants visible in the value, so match both the full ESC-prefixed form and
-# the standalone-marker form. UTF-8 bytes (0x80+) preserved.
+# Strip ANSI escape sequences and C0 control characters from a value.
+# `read -r -s` captures whatever the terminal sends — this can include:
+#   • bracketed-paste wrappers:  ESC[200~ ... ESC[201~
+#   • arrow keys / cursor moves: ESC[A/B/C/D, ESC[1;5C, ESC[3~ (Delete), …
+#   • function keys, modifier combos, mode-switch sequences
+# All follow the ANSI CSI shape:  ESC '[' <params> <final-byte>
+# where params ∈ [0-9;] and final ∈ [A-Za-z~]. Strip them iteratively to
+# handle consecutive sequences (e.g. paste-wrappers).
+#
+# Also handles the post-corruption case where ESC was stripped by an earlier
+# (buggy) sanitizer but the literal `[200~`/`[201~` markers survived. Only
+# self-heals the two well-defined bracketed-paste markers — generic `[X]`
+# shapes could plausibly be real password content.
+#
+# UTF-8 bytes (0x80+) preserved so international characters survive.
 _strip_paste_garbage() {
   local s="$1"
-  s="${s//$'\e'\[200\~/}"
-  s="${s//$'\e'\[201\~/}"
+  local esc=$'\e'
+  local csi_pattern="${esc}\\[[0-9;]*[A-Za-z~]"
+  while [[ "$s" =~ $csi_pattern ]]; do
+    s="${s/${BASH_REMATCH[0]}/}"
+  done
   s="${s//\[200\~/}"
   s="${s//\[201\~/}"
   printf '%s' "$s" | tr -d '\000-\037\177'

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -44,7 +44,24 @@ _extract_yaml_value() {
     line="${line#\"}"
     line="${line%\"}"
   fi
-  printf '%s' "$line"
+  # Strip C0 controls + DEL on extract — defends against self-perpetuation when
+  # a previous run wrote a corrupted value (see #168). UTF-8 (0x80+) preserved.
+  printf '%s' "$line" | tr -d '\000-\037\177'
+}
+
+# Strip C0 control characters (0x00-0x1F) and DEL (0x7F) from credential input.
+# Bracketed-paste-enabled terminals wrap pasted text in ESC[200~ ... ESC[201~
+# (ESC = 0x1B); without stripping, these bytes land in values.yaml and Helm
+# rejects the file ("yaml: control characters are not allowed"). UTF-8 bytes
+# (0x80+) are preserved so passwords with international characters work.
+_sanitize_credential() {
+  local input="$1"
+  local clean
+  clean=$(printf '%s' "$input" | tr -d '\000-\037\177')
+  if [[ "$clean" != "$input" ]]; then
+    warn "Stripped non-printable characters from input (likely paste-mode escape codes)."
+  fi
+  printf '%s' "$clean"
 }
 
 # Sanitize workspace name to comply with DNS-1123 (lowercase, alphanumeric + hyphens)
@@ -138,6 +155,7 @@ install_client_helm() {
   else
     read -r -p "  Client ID: " TB_CLIENT_ID
   fi
+  TB_CLIENT_ID=$(_sanitize_credential "$TB_CLIENT_ID")
   [[ -z "$TB_CLIENT_ID" ]] && error "Client ID cannot be empty."
 
   if [[ -n "$default_client_password" ]]; then
@@ -148,6 +166,7 @@ install_client_helm() {
     read -r -s -p "  Client password: " TB_CLIENT_PASSWORD
     echo ""
   fi
+  TB_CLIENT_PASSWORD=$(_sanitize_credential "$TB_CLIENT_PASSWORD")
   [[ -z "$TB_CLIENT_PASSWORD" ]] && error "Client password cannot be empty."
 
   TB_CLIENT_PASSWORD_ESCAPED="${TB_CLIENT_PASSWORD//\'/\'\'}"


### PR DESCRIPTION
## Summary

Two installer-side fixes bundled together (both surfaced while validating the corporate-proxy fix):

1. **[#166](https://github.com/tracebloc/client/issues/166)** — `i.sh` fails behind corporate HTTP/HTTPS proxies (a customer install, P1 customer blocker). Four bugs in `scripts/lib/cluster.sh`.
2. **[#168](https://github.com/tracebloc/client/issues/168)** — Helm rejects the generated `values.yaml` with "control characters are not allowed" when bracketed-paste-enabled terminals leak ESC sequences into clientId/clientPassword. One bug in `scripts/lib/install-client-helm.sh`.

## #166 — corporate-proxy fixes (`scripts/lib/cluster.sh`)

1. **k3d API bound to `0.0.0.0`** — corporate proxies intercept the `0.0.0.0` connection and return `Temporary Redirect` to `kubectl`. Pin explicitly to `127.0.0.1:6550`.
2. **No proxy propagation to k3d containers** — `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` on the host weren't passed into k3s. Loop over both cases; skip vars whose value contains `@` (k3d's filter-syntax conflict — recreate wouldn't help).
3. **`_merge_kubeconfig` clobbered manual `sed` fix on re-run** — defensive `https://0.0.0.0:` → `https://127.0.0.1:` rewrite after the merge. Targets the file k3d actually writes to (first entry of colon-separated `KUBECONFIG`, or `~/.kube/config`).
4. **Misleading "Check Docker" error** — replaced with a three-cause diagnostic naming the real culprits, with the `${KUBECONFIG}` path in the workaround hint and macOS-compatible `sed -i.bak` form.

Also adds `_check_existing_cluster_proxy`: `docker inspect`s the server container on re-run and warns per-var (including `NO_PROXY` drift) when the cluster is missing proxy env the host has. `@`-containing values are excluded since recreate wouldn't bake them either.

## #168 — credential sanitization (`scripts/lib/install-client-helm.sh`)

- New `_sanitize_credential` strips C0 controls (0x00-0x1F) + DEL (0x7F) from `TB_CLIENT_ID` / `TB_CLIENT_PASSWORD` after every `read`. UTF-8 bytes (0x80+) preserved so international passwords work. Warns the user when anything was stripped.
- `_extract_yaml_value` also strips on read so a previously-corrupted `values.yaml` self-heals on the next install (without it, the default-fill on re-run reproduces the bad value).

## Chart version

`client/Chart.yaml` bumped 1.4.1 → 1.4.2 per #166 acceptance criteria.

## Backward compatibility

- **Bug 1**: localhost-only API bind. Only affects users connecting to k3d's API from another host on their LAN — vanishingly rare for a dev-machine installer. Existing kubeconfigs with `0.0.0.0:6550` get auto-normalized on the next run.
- **Bug 2**: pure additive. Loop guarded by `[[ -n "${!var:-}" ]]` — strict no-op when no proxy is set.
- **Bug 3**: sed pattern anchored to `https://0\.0\.0\.0:` — won't touch CIDR ranges. `sed -i.bak` works on BSD + GNU.
- **Bug 4**: cosmetic text only.
- **#168 sanitization**: strips only non-printable C0 + DEL. Valid credentials (printable ASCII + UTF-8) pass through unchanged.

## Validation

- `bash -n` clean on both touched files.
- `shellcheck -x -s bash` shows only two pre-existing `SC2034` warnings on `cluster.sh` (unused `logfile`, `attempt` — present before this PR).
- Verified no other repo file encodes `0.0.0.0:6550` (CIDRs in NetworkPolicy templates unchanged).

## Test plan

- [ ] **#166 e2e**: set `HTTP_PROXY=http://example.invalid:8080`, run installer end-to-end, confirm cluster comes up and Helm install completes.
- [ ] **#166 no-proxy**: install on a clean host with no proxy env vars, confirm install still works.
- [ ] **#166 re-run**: re-run on a host with `https://0.0.0.0:6550` in kubeconfig, confirm rewrite.
- [ ] **#166 existing-cluster drift**: with host proxy set and a cluster created without it, confirm the warn fires and recreate guidance is accurate.
- [ ] **#168 paste**: paste creds in a bracketed-paste terminal (iTerm2, modern xterm), confirm warn fires and values.yaml is clean.
- [ ] **#168 self-heal**: pre-corrupt values.yaml with `\x1b[200~`, re-run installer accepting defaults, confirm clean output.

## Follow-ups (deferred per issues)

- Auto-detect common system proxies (#166 OOS).
- CI test harness for the proxy code path (#166 OOS).
- Optional: disable bracketed-paste around the prompts via `\e[?2004l/h` (#168 nice-to-have).
- v1.4.2 chart release sync (develop → main) after merge.

Closes #166
Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect every install path (k3d API bind, kubeconfig rewrite, proxy env) though defaults stay localhost-only when no proxy is set; credential stripping could alter unusual passwords that relied on control characters.
> 
> **Overview**
> The installer and chart release are updated so installs work behind corporate HTTP proxies and credential prompts no longer poison `values.yaml`.
> 
> **`cluster.sh`** binds the k3d API to **`127.0.0.1:6550`**, forwards host **`HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`** (both cases) into new clusters via **`k3d --env`**, and warns when proxy URLs contain **`@`** or when an **existing** cluster’s env drifts from the host. After kubeconfig merge, **`https://0.0.0.0:`** server URLs are rewritten to **`127.0.0.1`**; API wait failures now point at Docker, proxy **`NO_PROXY`**, and kubeconfig fixes.
> 
> **`install-client-helm.sh`** strips bracketed-paste / CSI escapes and C0 controls from **client ID/password** (and when re-reading **`values.yaml`**) so Helm no longer rejects “control characters.”
> 
> **`client/Chart.yaml`** is **1.4.1 → 1.4.2**; **Helm CI** also runs on **`develop`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eab8edf8a969d10169c427946935be36d0c6fcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->