### PR TITLE
Sync develop → main for v1.4.2 chart release

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -2,13 +2,13 @@ name: Helm Chart CI
 
 on:
   push:
-    branches: [main, openshift]
+    branches: [main, develop, openshift]
     paths:
       - 'client/**'
       - 'ingestor/**'
       - '.github/workflows/helm-ci.yaml'
   pull_request:
-    branches: [main, openshift]
+    branches: [main, develop, openshift]
     paths:
       - 'client/**'
       - 'ingestor/**'

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.4.1
-appVersion: "1.4.1"
+version: 1.4.2
+appVersion: "1.4.2"
 keywords:
   - tracebloc
   - kubernetes

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -80,6 +80,73 @@ _handle_existing_cluster() {
     k3d cluster start "$CLUSTER_NAME"
     success "Compute environment started."
   fi
+
+  _check_existing_cluster_proxy
+}
+
+# k3d bakes --env flags into containers at create time; they cannot be added
+# to a running cluster. Per-var check: for each proxy var set on the host,
+# verify the cluster has it. Detect NO_PROXY-only drift too (an older cluster
+# may have HTTP_PROXY baked in but be missing a NO_PROXY the host has since
+# added — without it, in-cluster traffic to .svc/.cluster.local or 127.0.0.1
+# can get routed through the proxy).
+# Silent no-op if Docker isn't running, the server container can't be inspected,
+# or the host has no proxy env set.
+_check_existing_cluster_proxy() {
+  # Partition host proxy vars into two buckets:
+  #   • drift_candidates — values without '@' that would propagate cleanly;
+  #                        the cluster should have these, flag if missing.
+  #   • at_skipped       — values with '@' that _create_new_cluster refused
+  #                        to propagate (k3d's KEY=VALUE@FILTER conflict).
+  #                        Recreating wouldn't help — needs a different
+  #                        remedy (strip creds, use auth proxy).
+  local drift_candidates=() at_skipped=()
+  for var in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
+    local val="${!var:-}"
+    [[ -z "$val" ]] && continue
+    if [[ "$val" == *"@"* ]]; then
+      at_skipped+=("$var")
+    else
+      drift_candidates+=("$var")
+    fi
+  done
+
+  # @-skipped vars get their own warning that fires on every re-run (the
+  # create-time skip warning in _create_new_cluster doesn't fire on the
+  # existing-cluster path). Recreate alone won't bake them, so guide the
+  # user toward the remedies that actually work.
+  if [[ ${#at_skipped[@]} -gt 0 ]]; then
+    echo ""
+    warn "Proxy env on host contains '@' (likely embedded credentials): ${at_skipped[*]}."
+    hint "k3d's --env KEY=VALUE@FILTER syntax can't carry an '@' in the value, so these"
+    hint "are not propagated into the cluster. If image pulls fail:"
+    hint "  • strip credentials from the URL (configure auth inside the cluster), or"
+    hint "  • point HTTP(S)_PROXY at a credential-less local auth-proxy that fronts the corporate proxy."
+    echo ""
+  fi
+
+  [[ ${#drift_candidates[@]} -eq 0 ]] && return 0
+
+  local server_container="k3d-${CLUSTER_NAME}-server-0"
+  local cluster_env
+  cluster_env=$(docker inspect "$server_container" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null) || return 0
+  [[ -z "$cluster_env" ]] && return 0
+
+  local missing=()
+  for var in "${drift_candidates[@]}"; do
+    if ! echo "$cluster_env" | grep -Eq "^${var}="; then
+      missing+=("$var")
+    fi
+  done
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo ""
+    warn "Host has proxy env set, but the existing '$CLUSTER_NAME' cluster is missing: ${missing[*]}."
+    hint "k3d bakes --env flags into containers at create time — they can't be added to a running cluster."
+    hint "If image pulls fail or in-cluster traffic misroutes, recreate the cluster:"
+    hint "  k3d cluster delete $CLUSTER_NAME  &&  re-run this installer."
+    echo ""
+  fi
 }
 
 _create_new_cluster() {
@@ -98,7 +165,7 @@ _create_new_cluster() {
     cluster create "$CLUSTER_NAME"
     --servers "$SERVERS"
     --agents  "$AGENTS"
-    --api-port 6550
+    --api-port 127.0.0.1:6550
     -v "${HOST_DATA_DIR}:/tracebloc@all"
     --k3s-arg "--disable=traefik@server:*"
     --k3s-arg "--disable=servicelb@server:*"
@@ -116,6 +183,26 @@ _create_new_cluster() {
     log "Creating cluster with $SERVERS server(s) + $AGENTS agent(s) (CPU-only)..."
   fi
   hint "First run may take 1-2 minutes to download components."
+
+  # Propagate corporate proxy env vars so k3s/k3d containers can reach external
+  # registries behind HTTP/HTTPS proxies (hospital/banking/government tenants).
+  # Loop checks both upper- and lower-case forms — apps in containers read either.
+  # k3d's --env syntax is KEY=VALUE@NODEFILTER; an embedded '@' in VALUE (e.g.
+  # credentials in URL: http://user:pass@host) collides with the filter
+  # delimiter and breaks `k3d cluster create`. Detect and skip with a warning;
+  # the user can strip creds and re-run, or supply creds via another mechanism.
+  for var in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
+    val="${!var:-}"
+    if [[ -n "$val" ]]; then
+      if [[ "$val" == *"@"* ]]; then
+        warn "Skipping ${var} propagation: value contains '@' (embedded credentials are not supported by k3d's --env filter syntax)."
+        hint "Strip credentials from the URL, or configure proxy auth inside the cluster after install."
+        continue
+      fi
+      K3D_ARGS+=(--env "${var}=${val}@all")
+      log "Propagating ${var} to k3d nodes."
+    fi
+  done
 
   local create_out create_rc
   create_out="$(mktemp)"
@@ -144,6 +231,25 @@ _merge_kubeconfig() {
     --kubeconfig-merge-default \
     --kubeconfig-switch-context \
     >/dev/null 2>&1
+
+  # Defensive normalization: k3d may still emit 0.0.0.0 server URLs into the
+  # kubeconfig (older k3d versions, or pre-existing entries from previous
+  # installs). Behind a corporate HTTP/HTTPS proxy, 0.0.0.0 gets intercepted
+  # and kubectl fails. Anchored to `https://0.0.0.0:` so CIDR ranges and other
+  # 0.0.0.0 occurrences elsewhere in the file are left untouched.
+  #
+  # KUBECONFIG can be colon-separated (kubectl path-list semantics); k3d's
+  # --kubeconfig-merge-default writes into the first entry (or ~/.kube/config
+  # if KUBECONFIG is unset). Target the same file or the rewrite would be
+  # skipped by -f on multi-file layouts.
+  local kc_target="${KUBECONFIG:-${HOME}/.kube/config}"
+  kc_target="${kc_target%%:*}"
+  if [[ -f "$kc_target" ]] && grep -q 'https://0\.0\.0\.0:' "$kc_target"; then
+    sed -i.bak 's|https://0\.0\.0\.0:|https://127.0.0.1:|g' "$kc_target"
+    rm -f "${kc_target}.bak"
+    log "Normalized kubeconfig server URL: 0.0.0.0 → 127.0.0.1 in $kc_target (corporate-proxy safety)."
+  fi
+
   log "kubeconfig updated — kubectl now points to '$CLUSTER_NAME'."
 }
 
@@ -168,5 +274,14 @@ _wait_for_api() {
   done
   printf "\r\033[K"
   tput cnorm 2>/dev/null || true
-  error "Compute environment did not start within 60s. Check Docker and try again."
+
+  # Surface the actual kubeconfig path. KUBECONFIG can be colon-separated
+  # (kubectl supports a list); point at the first entry — users with custom
+  # multi-file layouts can adapt the sed command themselves.
+  local kc="${KUBECONFIG:-${HOME}/.kube/config}"
+  kc="${kc%%:*}"
+  error "kubectl cluster-info failed for 60s. Cluster reports running, but the API is unreachable. Possible causes:
+   (a) Docker daemon stopped (run 'docker ps' to verify);
+   (b) corporate HTTP/HTTPS proxy intercepting localhost — ensure NO_PROXY includes '127.0.0.1,localhost';
+   (c) kubeconfig has 0.0.0.0 — try: sed -i.bak 's|0.0.0.0|127.0.0.1|g' ${kc} && rm ${kc}.bak"
 }

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -44,7 +44,50 @@ _extract_yaml_value() {
     line="${line#\"}"
     line="${line%\"}"
   fi
-  printf '%s' "$line"
+  # Defend against self-perpetuation: a previous corrupted save may have the
+  # bracketed-paste markers and/or C0 controls (#168). _strip_paste_garbage
+  # handles both. UTF-8 (0x80+) preserved.
+  _strip_paste_garbage "$line"
+}
+
+# Strip ANSI escape sequences and C0 control characters from a value.
+# `read -r -s` captures whatever the terminal sends — this can include:
+#   • bracketed-paste wrappers:  ESC[200~ ... ESC[201~
+#   • arrow keys / cursor moves: ESC[A/B/C/D, ESC[1;5C, ESC[3~ (Delete), …
+#   • function keys, modifier combos, mode-switch sequences
+# All follow the ANSI CSI shape:  ESC '[' <params> <final-byte>
+# where params ∈ [0-9;] and final ∈ [A-Za-z~]. Strip them iteratively to
+# handle consecutive sequences (e.g. paste-wrappers).
+#
+# Also handles the post-corruption case where ESC was stripped by an earlier
+# (buggy) sanitizer but the literal `[200~`/`[201~` markers survived. Only
+# self-heals the two well-defined bracketed-paste markers — generic `[X]`
+# shapes could plausibly be real password content.
+#
+# UTF-8 bytes (0x80+) preserved so international characters survive.
+_strip_paste_garbage() {
+  local s="$1"
+  local esc=$'\e'
+  local csi_pattern="${esc}\\[[0-9;]*[A-Za-z~]"
+  while [[ "$s" =~ $csi_pattern ]]; do
+    s="${s/${BASH_REMATCH[0]}/}"
+  done
+  s="${s//\[200\~/}"
+  s="${s//\[201\~/}"
+  printf '%s' "$s" | tr -d '\000-\037\177'
+}
+
+# Sanitize a user-entered credential. Calls _strip_paste_garbage and notifies
+# the user on stderr (NOT stdout — this function is called from inside $(...),
+# so stdout is captured into the credential value itself).
+_sanitize_credential() {
+  local input="$1"
+  local clean
+  clean=$(_strip_paste_garbage "$input")
+  if [[ "$clean" != "$input" ]]; then
+    warn "Stripped non-printable / paste-mode characters from input." >&2
+  fi
+  printf '%s' "$clean"
 }
 
 # Sanitize workspace name to comply with DNS-1123 (lowercase, alphanumeric + hyphens)
@@ -138,6 +181,7 @@ install_client_helm() {
   else
     read -r -p "  Client ID: " TB_CLIENT_ID
   fi
+  TB_CLIENT_ID=$(_sanitize_credential "$TB_CLIENT_ID")
   [[ -z "$TB_CLIENT_ID" ]] && error "Client ID cannot be empty."
 
   if [[ -n "$default_client_password" ]]; then
@@ -148,6 +192,7 @@ install_client_helm() {
     read -r -s -p "  Client password: " TB_CLIENT_PASSWORD
     echo ""
   fi
+  TB_CLIENT_PASSWORD=$(_sanitize_credential "$TB_CLIENT_PASSWORD")
   [[ -z "$TB_CLIENT_PASSWORD" ]] && error "Client password cannot be empty."
 
   TB_CLIENT_PASSWORD_ESCAPED="${TB_CLIENT_PASSWORD//\'/\'\'}"


### PR DESCRIPTION
## Summary

Brings the `develop` work to `main` ahead of cutting the **v1.4.2** release tag. Single user-facing change: PR [#167](https://github.com/tracebloc/client/pull/167) — installer survives corporate HTTP/HTTPS proxies + sanitizes credential input.

Other commits in the range are the post-v1.4.1 main→develop sync (#163 / 80d2f37) — main's own state mirrored back, no net additions to main from those.

## What's included

- **[#167](https://github.com/tracebloc/client/pull/167)** — `fix(#166, #168): installer survives corporate proxy + sanitizes credential input`. Two issues, ten commits:
  - **#166** — Corporate-proxy fixes in `scripts/lib/cluster.sh`: pin k3d API to `127.0.0.1:6550`; propagate `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` (with `@`-in-value skip + dedicated re-run warning); defensive kubeconfig `0.0.0.0 → 127.0.0.1` normalization (handles colon-separated `KUBECONFIG`); replace misleading "Check Docker" error with a three-cause diagnostic. New `_check_existing_cluster_proxy` warns on per-var drift when host proxy env doesn't match an existing cluster's baked-in env.
  - **#168** — `_sanitize_credential` + `_strip_paste_garbage` in `scripts/lib/install-client-helm.sh`. Strips ANSI CSI sequences (bracketed paste, arrow keys, cursor moves, function keys) plus C0 controls + DEL from `clientId`/`clientPassword`. `_extract_yaml_value` strips too so previously-corrupted values.yaml self-heals. UTF-8 preserved.
  - **CI gap** — Added `develop` to `helm-ci.yaml` branches filter so chart-touching PRs to develop actually run Lint / Template / Schema / Unit checks instead of getting stuck in "Expected — Waiting".

Closes **#166** and **#168** on merge (main is the default branch).

## Chart version

`client/Chart.yaml` already bumped to `1.4.2` in #167.

## Dev verification

End-to-end smoke test on customer-side EC2 by @saadqbal:
- **#166**: Cluster came up cleanly with `127.0.0.1` kubeconfig URL. No more `0.0.0.0` issue. (Full corporate-proxy test still to be run by the a customer install — out-of-band.)
- **#168**: Confirmed twice in vivo. First the C0-strip-only fix shipped (c237721) caught one paste shape but missed cursor-arrow-key leaks; second commit (ab1b35b) added the full ANSI CSI strip. Customer's actual password `rypveP-sumwac-5siqra` now writes clean even when `read -r -s` captures a stray `ESC[C` from an arrow-key press during the prompt. Eight unit tests pass locally.

Ten rounds of bugbot review on #167; all findings addressed, all threads resolved.

## Skip FR gate

Adding `skip-fr-gate` label preemptively — same pattern as [#162](https://github.com/tracebloc/client/pull/162). Kanban automation has already advanced this card to `Prod` because it's release-prep, which trips the FR gate's meta-check. Same audit-logged escape hatch.

## After merging

1. Cut GitHub Release `v1.4.2` from `main` HEAD — `release-helm-chart.yaml` fires on `release: types: [published]` and packages/publishes the chart.
2. Post-release sync `main → develop` (mirror of #163's pattern).
3. Email the customer contact (a customer) with the v1.4.2 install link, per #166 acceptance criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect on-prem install paths (k3d/kubeconfig/proxy env and how client credentials are written to values.yaml); misconfiguration could block installs or alter stored secrets, but runtime chart auth logic is unchanged.
> 
> **Overview**
> Syncs **develop** into **main** for the **v1.4.2** Helm release (`client/Chart.yaml` **1.4.1 → 1.4.2**).
> 
> The installer is hardened for **corporate HTTP/HTTPS proxies** in `cluster.sh`: k3d API is bound to **`127.0.0.1:6550`**, host **`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`** (and lowercase variants) are passed into new clusters when safe, **`@` in proxy URLs** is skipped with guidance, and re-runs on existing clusters get **`_check_existing_cluster_proxy`** drift warnings. **kubeconfig** server URLs **`https://0.0.0.0:` → `https://127.0.0.1:`** are normalized (first file in colon-separated **`KUBECONFIG`**), and API wait failures now surface proxy/Docker/kubeconfig diagnostics instead of a generic Docker message.
> 
> **Credential prompts** in `install-client-helm.sh` strip ANSI/paste/C0 garbage via **`_sanitize_credential`** / **`_strip_paste_garbage`**; **`_extract_yaml_value`** applies the same cleanup so corrupted saved values self-heal.
> 
> **Helm CI** now runs on pushes/PRs targeting **`develop`** as well as **`main`** and **`openshift`** when chart paths change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6b077bf84a9f7469d88de9456fc9c99626dc37d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->