### PR TITLE
feat(installer): preflight gate (arch, egress, disk, RAM, CPU) — fail fast

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -23,6 +23,23 @@ This guide covers installing the **tracebloc** unified Helm chart (AKS, EKS, bar
 
 ---
 
+## Network requirements (egress allowlist)
+
+The standalone installer runs a **preflight** check that verifies this connectivity before doing any work, and fails fast (naming the blocked host) if egress is missing. On a locked-down VM, allow outbound **HTTPS (443)** to:
+
+| Host | Why |
+|---|---|
+| `registry-1.docker.io` (Docker Hub) | k3s, mysql-client, busybox + the tracebloc client images |
+| `ghcr.io` | k3d node images + the ingestor image |
+| `api.tracebloc.io` (`dev-api`/`stg-api` for non-prod) | client credential check + the running client's platform connection |
+| `tracebloc.github.io` | the tracebloc Helm chart repository |
+
+On **Linux**, the installer also fetches tooling from `get.docker.com`, `raw.githubusercontent.com`, `dl.k8s.io`, and `get.helm.sh` — but only when Docker / k3d / kubectl / Helm aren't already installed.
+
+**Behind a corporate proxy?** Set `HTTP_PROXY` / `HTTPS_PROXY` before running (the installer auto-augments `NO_PROXY` with the cluster-internal ranges). A **TLS-inspecting** proxy additionally needs its corporate CA trusted on the VM, or HTTPS to the hosts above will fail certificate validation.
+
+---
+
 ## 1. Add the Helm repository (recommended for production)
 
 The chart repository is hosted at [tracebloc/client](https://github.com/tracebloc/client). After the chart is published (see [Publishing the chart](#publishing-the-chart)), add the repo and install from it so you get versioning and `helm upgrade` support.

--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -1301,6 +1301,114 @@ function Print-Summary {
 }
 
 # =============================================================================
+#  PREFLIGHT — fail-fast environment checks (mirrors scripts/lib/preflight.sh)
+# =============================================================================
+
+# Non-exiting failure line (Err exits; preflight must finish all checks first).
+function Write-PfFail($m) { Write-Host "  " -NoNewline; Write-Host ([char]0x2716) -ForegroundColor Red -NoNewline; Write-Host " $m" -ForegroundColor Red }
+
+# Probe a URL for reachability. Returns: ok|tls|dns|timeout|blocked. Any HTTP
+# response (incl. 401/403/404) = reachable (TLS + HTTP completed). Honors the
+# system / HTTP_PROXY proxy automatically.
+function Test-PfUrl([string]$Url) {
+  try {
+    Invoke-WebRequest -Uri $Url -Method Head -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null
+    return "ok"
+  } catch {
+    if ($null -ne $_.Exception.Response) { return "ok" }   # reached the server, got an HTTP error
+    $m = "$($_.Exception.Message)"
+    if ($m -match 'trust|SSL|certificate|TLS|secure channel') { return "tls" }
+    if ($m -match 'resolve|name or service|known')            { return "dns" }
+    if ($m -match 'timed out|timeout')                        { return "timeout" }
+    return "blocked"
+  }
+}
+
+# Free GB on the drive holding $HOST_DATA_DIR (or C:); $null if undeterminable
+# (e.g. non-Windows under Pester — tests mock this).
+function Get-PfFreeGb {
+  try {
+    $qualifier = (Split-Path -Qualifier $HOST_DATA_DIR -ErrorAction SilentlyContinue)
+    if (-not $qualifier) { $qualifier = "C:" }
+    $d = Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='$qualifier'" -ErrorAction Stop
+    return [math]::Floor($d.FreeSpace / 1GB)
+  } catch { return $null }
+}
+
+function Get-PfMemGb {
+  try { return [math]::Floor((Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).TotalPhysicalMemory / 1GB) }
+  catch { return $null }
+}
+
+function Get-PfCpu {
+  try { return [int](Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).NumberOfLogicalProcessors }
+  catch { if ($env:NUMBER_OF_PROCESSORS) { return [int]$env:NUMBER_OF_PROCESSORS } else { return $null } }
+}
+
+function Test-Preflight {
+  if ($env:TRACEBLOC_SKIP_PREFLIGHT) { Info "Preflight checks skipped (TRACEBLOC_SKIP_PREFLIGHT set)."; return }
+
+  $minDiskGb  = if ($env:PF_MIN_DISK_GB)  { [int]$env:PF_MIN_DISK_GB }  else { 5 }
+  $warnDiskGb = if ($env:PF_WARN_DISK_GB) { [int]$env:PF_WARN_DISK_GB } else { 20 }
+  $warnMemGb  = if ($env:PF_WARN_MEM_GB)  { [int]$env:PF_WARN_MEM_GB }  else { 4 }
+  $minCpu     = if ($env:PF_MIN_CPU)      { [int]$env:PF_MIN_CPU }      else { 2 }
+  $hardFail   = 0
+
+  # Architecture — the tracebloc client images (e.g. mysql-client) are amd64-only.
+  $arch = Get-WindowsArch
+  if ($arch -eq "amd64") {
+    Ok "Architecture: amd64"
+  } elseif ($env:TRACEBLOC_ALLOW_ARM64) {
+    Warn "Architecture: $arch - proceeding (TRACEBLOC_ALLOW_ARM64 set); amd64-only images may crash if emulation is unavailable."
+  } else {
+    Info "Architecture: $arch - Docker Desktop runs the amd64 client images under emulation (slower, but works)."
+  }
+
+  $cpu = Get-PfCpu
+  if      ($null -eq $cpu)   { Warn "CPU: couldn't determine core count (skipping)." }
+  elseif  ($cpu -lt $minCpu) { Warn "CPU: $cpu core(s) - recommended >= $minCpu." }
+  else                       { Ok "CPU: $cpu cores" }
+
+  $mem = Get-PfMemGb
+  if      ($null -eq $mem)      { Warn "Memory: couldn't determine total RAM (skipping)." }
+  elseif  ($mem -lt $warnMemGb) { Warn "Memory: $mem GB total - recommended >= $warnMemGb GB; k3s + training may run out of memory." }
+  else                          { Ok "Memory: $mem GB" }
+
+  $disk = Get-PfFreeGb
+  if      ($null -eq $disk)        { Warn "Disk: couldn't determine free space (skipping)." }
+  elseif  ($disk -lt $minDiskGb)   { Write-PfFail "Disk: only $disk GB free - need >= $minDiskGb GB."; $hardFail++; Hint "Free up space or attach a larger disk, then re-run." }
+  elseif  ($disk -lt $warnDiskGb)  { Warn "Disk: $disk GB free - recommended >= $warnDiskGb GB; images + data may fill it." }
+  else                             { Ok "Disk: $disk GB free" }
+
+  Info "Checking outbound connectivity to required services..."
+  $backendHost = (Get-BackendUrl) -replace '^https?://','' -replace '/$',''
+  $criticals = @(
+    @{ label = "Docker Hub (registry-1.docker.io)";           url = "https://registry-1.docker.io/v2/" },
+    @{ label = "GitHub Container Registry (ghcr.io)";         url = "https://ghcr.io/" },
+    @{ label = "tracebloc API ($backendHost)";                url = "https://$backendHost/" },
+    @{ label = "tracebloc Helm charts (tracebloc.github.io)"; url = "https://tracebloc.github.io/" }
+  )
+  $tlsSeen = $false; $cfail = 0
+  foreach ($c in $criticals) {
+    $status = Test-PfUrl $c.url
+    if ($status -ne "ok") { $status = Test-PfUrl $c.url }   # one retry for transient blips
+    if ($status -eq "ok") { Ok "$($c.label) reachable" }
+    else {
+      Write-PfFail "$($c.label) unreachable ($status)"
+      $hardFail++; $cfail++
+      if ($status -eq "tls") { $tlsSeen = $true }
+    }
+  }
+  if ($tlsSeen)    { Hint "A TLS/certificate error usually means a break-and-inspect (TLS-inspecting) proxy whose corporate CA isn't trusted here - see the proxy notes." }
+  if ($cfail -gt 0){ Hint "Allow HTTPS (443) egress to: registry-1.docker.io, ghcr.io, $backendHost, tracebloc.github.io - or configure your corporate proxy." }
+
+  if ($hardFail -gt 0) {
+    Write-Host ""
+    Err "Preflight failed - resolve the items above and re-run. (Override at your own risk with `$env:TRACEBLOC_SKIP_PREFLIGHT=1.)"
+  }
+}
+
+# =============================================================================
 #  MAIN
 # =============================================================================
 
@@ -1316,6 +1424,7 @@ Print-Roadmap
 
 # -- Step 1/4: Check system requirements --
 Step 1 4 "Checking system requirements"
+Test-Preflight
 Find-Gpu
 Enable-VirtualisationFeatures
 Install-Winget

--- a/scripts/install-k8s.sh
+++ b/scripts/install-k8s.sh
@@ -40,6 +40,7 @@ LIB_DIR="${SCRIPT_DIR}/lib"
 
 # ── Source modules ───────────────────────────────────────────────────────────
 source "${LIB_DIR}/common.sh"
+source "${LIB_DIR}/preflight.sh"
 source "${LIB_DIR}/detect-gpu.sh"
 source "${LIB_DIR}/gpu-nvidia.sh"
 source "${LIB_DIR}/gpu-amd.sh"
@@ -63,6 +64,7 @@ main() {
 
   # ── Step 1/4: Check system requirements ──────────────────────────────────
   step 1 4 "Checking system requirements"
+  run_preflight
   detect_gpu
 
   case "$OS" in

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,6 +33,7 @@ mkdir -p "$TMPDIR/lib"
 FILES=(
   "scripts/install-k8s.sh"
   "scripts/lib/common.sh"
+  "scripts/lib/preflight.sh"
   "scripts/lib/detect-gpu.sh"
   "scripts/lib/gpu-nvidia.sh"
   "scripts/lib/gpu-amd.sh"

--- a/scripts/lib/preflight.sh
+++ b/scripts/lib/preflight.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  preflight.sh — fail-fast environment checks (arch, egress, disk, RAM, CPU)
+#
+#  Runs before any install/cluster work. Each check prints a ✔/⚠/✖ line; hard
+#  failures are AGGREGATED so the user sees every problem at once, then we exit
+#  ONCE with a summary. The goal: a run that can't succeed fails in seconds with
+#  a precise, actionable reason instead of a cryptic crash minutes in.
+#
+#  Escape hatches:
+#    TRACEBLOC_SKIP_PREFLIGHT=1   skip all checks
+#    TRACEBLOC_ALLOW_ARM64=1      proceed on arm64 despite amd64-only images
+#
+#  This file is side-effect-safe to source (defaults + function defs only).
+# =============================================================================
+
+# Thresholds (overridable via env — for unusual sites or tests)
+PF_MIN_DISK_GB="${PF_MIN_DISK_GB:-5}"      # hard-fail below this (Linux)
+PF_WARN_DISK_GB="${PF_WARN_DISK_GB:-20}"   # warn below this
+PF_WARN_MEM_GB="${PF_WARN_MEM_GB:-4}"      # warn below this
+PF_MIN_CPU="${PF_MIN_CPU:-2}"              # warn below this
+
+# Non-exiting failure line (common.sh's error() exits; preflight must finish all
+# checks first, so failures print here and are recorded in PF_HARD_FAIL). Writes
+# to stdout (like warn/success/info) so it stays ordered with the hint() lines
+# that follow — only the final aggregated error() writes to stderr.
+_pf_fail_line() { echo -e "  ${RED}✖${RESET} $*"; }
+
+# ── Injectable readers (overridden in bats so checks run without net/df) ─────
+
+# Probe a URL for reachability. Echoes one of: ok|dns|refused|timeout|tls|blocked|nocurl
+# "Reachable" = any HTTP response (200/401/403 all count — TLS + HTTP completed).
+# Respects the caller's HTTP(S)_PROXY env (curl picks it up), so a TLS-inspecting
+# proxy without its CA surfaces here as 'tls'.
+_pf_probe_url() {
+  local url="$1" code ec
+  has curl || { echo "nocurl"; return 0; }
+  code=$(curl -sS $CURL_SECURE -o /dev/null --max-time 8 -w '%{http_code}' "$url" 2>/dev/null) && ec=0 || ec=$?
+  if [[ -n "$code" && "$code" != "000" ]]; then echo "ok"; return 0; fi
+  case "${ec:-1}" in
+    6)     echo "dns" ;;
+    7)     echo "refused" ;;
+    28)    echo "timeout" ;;
+    35|60) echo "tls" ;;
+    *)     echo "blocked" ;;
+  esac
+  return 0
+}
+
+# Free space in KB on the filesystem holding $1.
+_pf_free_kb() { df -Pk "$1" 2>/dev/null | awk 'NR==2 {print $4}'; }
+
+# Total physical RAM in KB.
+_pf_total_mem_kb() {
+  if [[ "$OS" == "Darwin" ]]; then
+    local b; b=$(sysctl -n hw.memsize 2>/dev/null) || b=""
+    [[ -n "$b" ]] && echo $(( b / 1024 ))
+  else
+    awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null
+  fi
+}
+
+# Logical CPU count.
+_pf_ncpu() {
+  if [[ "$OS" == "Darwin" ]]; then
+    sysctl -n hw.ncpu 2>/dev/null
+  else
+    nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null
+  fi
+}
+
+# Docker data root if the daemon is up; else where it will live / a host proxy.
+_pf_docker_root() {
+  if has docker && docker info >/dev/null 2>&1; then
+    docker info --format '{{.DockerRootDir}}' 2>/dev/null || echo "/var/lib/docker"
+  elif [[ "$OS" == "Linux" ]]; then
+    echo "/var/lib/docker"
+  else
+    echo "$HOME"
+  fi
+}
+
+# Backend host per CLIENT_ENV (mirrors install-client-helm.sh::_backend_url;
+# inlined so preflight is self-contained + unit-testable in isolation).
+_pf_backend_host() {
+  case "${CLIENT_ENV:-prod}" in
+    dev) echo "dev-api.tracebloc.io" ;;
+    stg) echo "stg-api.tracebloc.io" ;;
+    *)   echo "api.tracebloc.io" ;;
+  esac
+}
+
+# ── Checks (each ALWAYS returns 0; hard failures go into PF_HARD_FAILS) ───────
+
+# True if the host can run amd64 binaries via QEMU binfmt (wrapped for testing).
+_pf_amd64_emulation_available() { [[ -e /proc/sys/fs/binfmt_misc/qemu-x86_64 ]]; }
+
+_pf_arch() {
+  case "$ARCH" in
+    x86_64|amd64) success "Architecture: ${ARCH} (amd64)"; return 0 ;;
+  esac
+  # Non-amd64 (arm64/aarch64): the tracebloc client images (e.g. mysql-client)
+  # are amd64-only, so they need emulation to run.
+  if [[ -n "${TRACEBLOC_ALLOW_ARM64:-}" ]]; then
+    warn "Architecture: ${ARCH} — proceeding (TRACEBLOC_ALLOW_ARM64 set); amd64-only images may crash if emulation is unavailable."
+    return 0
+  fi
+  if [[ "$OS" != "Linux" ]]; then
+    info "Architecture: ${ARCH} — Docker Desktop runs the amd64 client images under emulation (slower, but works)."
+    return 0
+  fi
+  if _pf_amd64_emulation_available; then
+    info "Architecture: ${ARCH} — amd64 emulation (QEMU binfmt) available; client images run emulated (slower)."
+    return 0
+  fi
+  _pf_fail_line "Architecture: ${ARCH} — the tracebloc client images (e.g. mysql-client) are amd64-only and can't run here."
+  PF_HARD_FAIL=$(( ${PF_HARD_FAIL:-0} + 1 ))
+  hint "Fix: provision an amd64 (x86_64) VM, or enable emulation and re-run:"
+  hint "  docker run --privileged --rm tonistiigi/binfmt --install amd64"
+  hint "  (or set TRACEBLOC_ALLOW_ARM64=1 to proceed anyway)"
+  return 0
+}
+
+_pf_cpu() {
+  local n; n="$(_pf_ncpu)"
+  if [[ -z "$n" ]]; then warn "CPU: couldn't determine core count (skipping)."; return 0; fi
+  if [[ "$n" -lt "$PF_MIN_CPU" ]]; then
+    warn "CPU: ${n} core(s) — recommended ≥ ${PF_MIN_CPU}."
+  else
+    success "CPU: ${n} cores"
+  fi
+  return 0
+}
+
+_pf_memory() {
+  local kb gb; kb="$(_pf_total_mem_kb)"
+  if [[ -z "$kb" ]]; then warn "Memory: couldn't determine total RAM (skipping)."; return 0; fi
+  gb=$(( kb / 1024 / 1024 ))
+  if [[ "$gb" -lt "$PF_WARN_MEM_GB" ]]; then
+    warn "Memory: ${gb} GB total — recommended ≥ ${PF_WARN_MEM_GB} GB; k3s + training may run out of memory."
+  else
+    success "Memory: ${gb} GB"
+  fi
+  return 0
+}
+
+_pf_disk() {
+  local target free_kb free_gb
+  target="$(_pf_docker_root)"
+  if [[ ! -d "$target" ]]; then target="/"; fi
+  if [[ "$OS" != "Linux" ]]; then target="$HOME"; fi   # Desktop VM disk is opaque
+  free_kb="$(_pf_free_kb "$target")"
+  if [[ -z "$free_kb" ]]; then warn "Disk: couldn't determine free space on ${target} (skipping)."; return 0; fi
+  free_gb=$(( free_kb / 1024 / 1024 ))
+  if [[ "$OS" != "Linux" ]]; then
+    info "Disk: ${free_gb} GB free on ${target} (host) — also ensure Docker Desktop's disk image has ≥ ${PF_WARN_DISK_GB} GB."
+    return 0
+  fi
+  if [[ "$free_gb" -lt "$PF_MIN_DISK_GB" ]]; then
+    _pf_fail_line "Disk: only ${free_gb} GB free on ${target} — need ≥ ${PF_MIN_DISK_GB} GB."
+    PF_HARD_FAIL=$(( ${PF_HARD_FAIL:-0} + 1 ))
+    hint "Free up space or attach a larger disk, then re-run."
+  elif [[ "$free_gb" -lt "$PF_WARN_DISK_GB" ]]; then
+    warn "Disk: ${free_gb} GB free on ${target} — recommended ≥ ${PF_WARN_DISK_GB} GB; images + data may fill it."
+  else
+    success "Disk: ${free_gb} GB free on ${target}"
+  fi
+  return 0
+}
+
+_pf_connectivity() {
+  info "Checking outbound connectivity to required services..."
+  local backend_host cfail=0 tls_seen=0 c label url status
+  backend_host="$(_pf_backend_host)"
+
+  # Critical: the install cannot succeed without these (image pulls, creds, chart).
+  local criticals=(
+    "Docker Hub (registry-1.docker.io)|https://registry-1.docker.io/v2/"
+    "GitHub Container Registry (ghcr.io)|https://ghcr.io/"
+    "tracebloc API (${backend_host})|https://${backend_host}/"
+    "tracebloc Helm charts (tracebloc.github.io)|https://tracebloc.github.io/"
+  )
+  for c in "${criticals[@]}"; do
+    label="${c%%|*}"; url="${c#*|}"
+    status="$(_pf_probe_url "$url")"
+    if [[ "$status" != "ok" ]]; then status="$(_pf_probe_url "$url")"; fi   # one retry (transient blips)
+    if [[ "$status" == "ok" ]]; then
+      success "${label} reachable"
+    else
+      _pf_fail_line "${label} unreachable (${status})"
+      PF_HARD_FAIL=$(( ${PF_HARD_FAIL:-0} + 1 ))
+      cfail=$(( cfail + 1 ))
+      if [[ "$status" == "tls" ]]; then tls_seen=1; fi
+    fi
+  done
+
+  # Tool-download hosts: only relevant on Linux when the tool isn't present. Warn-only.
+  if [[ "$OS" == "Linux" ]]; then
+    local conds=()
+    if ! has docker;  then conds+=("Docker install (get.docker.com)|https://get.docker.com/"); fi
+    if ! has k3d;     then conds+=("k3d install (raw.githubusercontent.com)|https://raw.githubusercontent.com/"); fi
+    if ! has kubectl; then conds+=("kubectl (dl.k8s.io)|https://dl.k8s.io/"); fi
+    if ! has helm;    then conds+=("Helm (get.helm.sh)|https://get.helm.sh/"); fi
+    # ${conds[@]+...} guard: expanding an empty array under `set -u` errors on
+    # bash 3.2 (macOS). This expands to nothing when no tools are missing.
+    for c in ${conds[@]+"${conds[@]}"}; do
+      label="${c%%|*}"; url="${c#*|}"
+      status="$(_pf_probe_url "$url")"
+      if [[ "$status" == "ok" ]]; then
+        success "${label} reachable"
+      else
+        warn "${label} unreachable (${status}) — needed only to install that tool."
+      fi
+    done
+  fi
+
+  if [[ "$tls_seen" -eq 1 ]]; then
+    hint "A TLS/certificate error usually means a break-and-inspect (TLS-inspecting) proxy whose corporate CA isn't trusted here — see the proxy notes."
+  fi
+  if [[ "$cfail" -gt 0 ]]; then
+    hint "Allow HTTPS (443) egress to: registry-1.docker.io, ghcr.io, ${backend_host}, tracebloc.github.io — or set HTTP_PROXY if you use a corporate proxy."
+  fi
+  return 0
+}
+
+# ── Orchestrator ─────────────────────────────────────────────────────────────
+run_preflight() {
+  if [[ -n "${TRACEBLOC_SKIP_PREFLIGHT:-}" ]]; then
+    info "Preflight checks skipped (TRACEBLOC_SKIP_PREFLIGHT set)."
+    return 0
+  fi
+  PF_HARD_FAIL=0
+  # '|| true' so a single check returning non-zero can't trip the caller's set -e
+  # before the others run — the aggregated counter below is the source of truth.
+  _pf_arch         || true
+  _pf_cpu          || true
+  _pf_memory       || true
+  _pf_disk         || true
+  _pf_connectivity || true
+
+  if [[ "$PF_HARD_FAIL" -gt 0 ]]; then
+    echo ""
+    error "Preflight failed — resolve the ✖ item(s) above and re-run. (Override at your own risk with TRACEBLOC_SKIP_PREFLIGHT=1.)"
+  fi
+}

--- a/scripts/tests/install-k8s.Tests.ps1
+++ b/scripts/tests/install-k8s.Tests.ps1
@@ -287,3 +287,75 @@ Describe "Write-K3dProxyConfig" {
     Remove-Item (Split-Path $cfg -Parent) -Recurse -Force
   }
 }
+
+# --- Preflight checks (mirrors scripts/lib/preflight.sh) ---------------------
+Describe "Test-PfUrl" {
+  It "HTTP 200 -> ok" {
+    Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 200 } }
+    Test-PfUrl "https://x" | Should -Be "ok"
+  }
+  It "HTTP error response (server reached) -> ok" {
+    Mock Invoke-WebRequest {
+      $ex = [System.Exception]::new("HTTP 401")
+      Add-Member -InputObject $ex -NotePropertyName Response -NotePropertyValue ([pscustomobject]@{ StatusCode = 401 }) -Force
+      throw $ex
+    }
+    Test-PfUrl "https://x" | Should -Be "ok"
+  }
+  It "TLS / certificate error -> tls" {
+    Mock Invoke-WebRequest { throw [System.Exception]::new("The SSL certificate could not be validated - trust failure") }
+    Test-PfUrl "https://x" | Should -Be "tls"
+  }
+  It "connection failure -> blocked" {
+    Mock Invoke-WebRequest { throw [System.Exception]::new("Unable to connect to the remote server") }
+    Test-PfUrl "https://x" | Should -Be "blocked"
+  }
+}
+
+# Get-CimInstance is a Windows-only cmdlet (CimCmdlets module) — it can't be
+# mocked on Linux/macOS pwsh, so these run only on Windows (a Windows reviewer /
+# Windows CI). Off-Windows the readers safely return $null (the catch), which
+# Test-Preflight handles as "couldn't determine (skipping)".
+Describe "Get-Pf* resource readers" -Skip:(-not $IsWindows) {
+  It "Get-PfCpu reads logical processors" {
+    Mock Get-CimInstance { [pscustomobject]@{ NumberOfLogicalProcessors = 4 } }
+    Get-PfCpu | Should -Be 4
+  }
+  It "Get-PfMemGb reads total RAM in GB" {
+    Mock Get-CimInstance { [pscustomobject]@{ TotalPhysicalMemory = 8GB } }
+    Get-PfMemGb | Should -Be 8
+  }
+  It "Get-PfFreeGb reads free disk in GB" {
+    Mock Get-CimInstance { [pscustomobject]@{ FreeSpace = 50GB } }
+    Get-PfFreeGb | Should -Be 50
+  }
+}
+
+Describe "Test-Preflight" {
+  BeforeEach {
+    Mock Err { throw "preflight-failed" }      # Err exits; make it throwable to assert
+    Mock Get-PfCpu { 4 }; Mock Get-PfMemGb { 8 }; Mock Get-PfFreeGb { 50 }
+    Mock Get-WindowsArch { "amd64" }
+  }
+  AfterEach { $env:TRACEBLOC_SKIP_PREFLIGHT = $null; $env:TRACEBLOC_ALLOW_ARM64 = $null }
+
+  It "healthy environment -> does not throw" {
+    Mock Test-PfUrl { "ok" }
+    { Test-Preflight } | Should -Not -Throw
+  }
+  It "a critical host blocked -> fails (Err throws)" {
+    Mock Test-PfUrl { "blocked" }
+    { Test-Preflight } | Should -Throw
+  }
+  It "TRACEBLOC_SKIP_PREFLIGHT -> skipped, no probing" {
+    $env:TRACEBLOC_SKIP_PREFLIGHT = "1"
+    Mock Test-PfUrl { "blocked" }
+    { Test-Preflight } | Should -Not -Throw
+    Should -Invoke Test-PfUrl -Exactly -Times 0
+  }
+  It "arm64 -> info, not a hard fail (Docker Desktop emulates)" {
+    Mock Get-WindowsArch { "arm64" }
+    Mock Test-PfUrl { "ok" }
+    { Test-Preflight } | Should -Not -Throw
+  }
+}

--- a/scripts/tests/preflight.bats
+++ b/scripts/tests/preflight.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+# Tests for scripts/lib/preflight.sh — fail-fast environment checks
+# (arch / connectivity / disk / RAM / CPU). The checks delegate to small
+# injectable readers, which we override here so nothing touches the real
+# network, df, or /proc. Counter assertions call the function directly (bats
+# `run` executes in a subshell, so PF_HARD_FAIL wouldn't propagate back).
+load test_helper
+
+setup() {
+  load_lib preflight.sh
+  PF_HARD_FAIL=0
+  # Default-safe stubs (a healthy amd64 box); individual tests override.
+  _pf_probe_url() { echo ok; }
+  _pf_free_kb() { echo $((50 * 1024 * 1024)); }       # 50 GB
+  _pf_total_mem_kb() { echo $((8 * 1024 * 1024)); }   # 8 GB
+  _pf_ncpu() { echo 4; }
+  _pf_amd64_emulation_available() { return 0; }
+  docker() { return 1; }   # keep _pf_docker_root off the real daemon
+  has() { return 0; }      # pretend tools present (conds empty) unless overridden
+  OS="Linux"; ARCH="x86_64"
+}
+
+# ── _pf_arch ─────────────────────────────────────────────────────────────────
+@test "_pf_arch: amd64 -> success, no hard fail" {
+  ARCH=x86_64
+  run _pf_arch
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"amd64"* ]]
+}
+
+@test "_pf_arch: arm64 Linux without emulation -> hard fail + binfmt remedy" {
+  ARCH=aarch64; OS=Linux
+  _pf_amd64_emulation_available() { return 1; }
+  run _pf_arch
+  [[ "$output" == *"amd64-only"* ]]
+  [[ "$output" == *"tonistiigi/binfmt"* ]]
+  PF_HARD_FAIL=0; _pf_arch >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 1 ]
+}
+
+@test "_pf_arch: arm64 Linux WITH emulation -> info, no hard fail" {
+  ARCH=aarch64; OS=Linux
+  _pf_amd64_emulation_available() { return 0; }
+  PF_HARD_FAIL=0; _pf_arch >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_arch: arm64 macOS -> info (Desktop emulation), no hard fail" {
+  ARCH=arm64; OS=Darwin
+  PF_HARD_FAIL=0; _pf_arch >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_arch: arm64 + TRACEBLOC_ALLOW_ARM64 -> warn, no hard fail" {
+  ARCH=aarch64; OS=Linux; export TRACEBLOC_ALLOW_ARM64=1
+  _pf_amd64_emulation_available() { return 1; }
+  run _pf_arch
+  [[ "$output" == *"proceeding"* ]]
+  PF_HARD_FAIL=0; _pf_arch >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+  unset TRACEBLOC_ALLOW_ARM64
+}
+
+# ── _pf_connectivity ─────────────────────────────────────────────────────────
+@test "_pf_connectivity: all reachable -> no hard fail" {
+  _pf_probe_url() { echo ok; }
+  PF_HARD_FAIL=0; _pf_connectivity >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_connectivity: a critical host blocked -> hard fail + allowlist hint" {
+  _pf_probe_url() { case "$1" in *ghcr*) echo blocked ;; *) echo ok ;; esac; }
+  run _pf_connectivity
+  [[ "$output" == *"ghcr.io) unreachable"* ]]
+  [[ "$output" == *"Allow HTTPS"* ]]
+  PF_HARD_FAIL=0; _pf_connectivity >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 1 ]
+}
+
+@test "_pf_connectivity: TLS error -> break-and-inspect (Gap D) hint" {
+  _pf_probe_url() { case "$1" in *registry-1.docker*) echo tls ;; *) echo ok ;; esac; }
+  run _pf_connectivity
+  [[ "$output" == *"break-and-inspect"* ]]
+}
+
+@test "_pf_connectivity: tool host skipped when the tool is present" {
+  _pf_probe_url() { echo ok; }
+  has() { return 0; }
+  run _pf_connectivity
+  [[ "$output" != *"get.docker.com"* ]]
+}
+
+@test "_pf_connectivity: tool host probed (warn-only) when the tool is missing" {
+  _pf_probe_url() { case "$1" in *get.docker.com*) echo blocked ;; *) echo ok ;; esac; }
+  has() { return 1; }
+  OS=Linux
+  run _pf_connectivity
+  [[ "$output" == *"get.docker.com"* ]]
+  # a missing tool host is warn-only, never a hard fail
+  PF_HARD_FAIL=0; _pf_connectivity >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+# ── _pf_disk / _pf_memory / _pf_cpu ──────────────────────────────────────────
+@test "_pf_disk: ample free space -> success" {
+  OS=Linux; _pf_free_kb() { echo $((50 * 1024 * 1024)); }
+  run _pf_disk; [[ "$output" == *"50 GB free"* ]]
+  PF_HARD_FAIL=0; _pf_disk >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_disk: low (<20 GB) -> warn, no hard fail" {
+  OS=Linux; _pf_free_kb() { echo $((10 * 1024 * 1024)); }
+  run _pf_disk; [[ "$output" == *"recommended"* ]]
+  PF_HARD_FAIL=0; _pf_disk >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_disk: critically low (<5 GB) -> hard fail" {
+  OS=Linux; _pf_free_kb() { echo $((2 * 1024 * 1024)); }
+  run _pf_disk; [[ "$output" == *"need"* ]]
+  PF_HARD_FAIL=0; _pf_disk >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 1 ]
+}
+
+@test "_pf_disk: macOS -> info only (Desktop VM disk is opaque)" {
+  OS=Darwin; _pf_free_kb() { echo $((2 * 1024 * 1024)); }   # even 'low' must not fail
+  PF_HARD_FAIL=0; _pf_disk >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_memory: low RAM -> warn" {
+  _pf_total_mem_kb() { echo $((2 * 1024 * 1024)); }
+  run _pf_memory; [[ "$output" == *"recommended"* ]]
+}
+
+@test "_pf_memory: ample RAM -> success" {
+  _pf_total_mem_kb() { echo $((8 * 1024 * 1024)); }
+  run _pf_memory; [[ "$output" == *"8 GB"* ]]
+}
+
+@test "_pf_cpu: too few cores -> warn" {
+  _pf_ncpu() { echo 1; }
+  run _pf_cpu; [[ "$output" == *"recommended"* ]]
+}
+
+@test "_pf_cpu: enough cores -> success" {
+  _pf_ncpu() { echo 4; }
+  run _pf_cpu; [[ "$output" == *"4 cores"* ]]
+}
+
+# ── run_preflight orchestration ──────────────────────────────────────────────
+@test "run_preflight: TRACEBLOC_SKIP_PREFLIGHT -> skipped, exit 0" {
+  export TRACEBLOC_SKIP_PREFLIGHT=1
+  run run_preflight
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipped"* ]]
+  unset TRACEBLOC_SKIP_PREFLIGHT
+}
+
+@test "run_preflight: a hard failure -> non-zero exit + aggregated summary" {
+  ARCH=x86_64; OS=Linux
+  _pf_probe_url() { case "$1" in *registry-1.docker*) echo blocked ;; *) echo ok ;; esac; }
+  run run_preflight
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Preflight failed"* ]]
+}
+
+@test "run_preflight: healthy environment -> exit 0" {
+  ARCH=x86_64; OS=Linux
+  _pf_probe_url() { echo ok; }
+  run run_preflight
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
> 🚫 **STACKED ON #171 + #172 — DO NOT MERGE BEFORE THEM.** Branched off `fix/proxy-hardening` (#172), which is itself on #171. Until those merge, this PR's commit range includes their commits — **review only commit `a6bddf9` / the 7 files under "What changed".** GitHub auto-reduces the diff as the stack lands; I'll flip draft → ready then.

## Summary
Adds a **preflight gate** that runs before any install/cluster work and fails in seconds with a precise, actionable reason — instead of a cryptic crash minutes in. It attacks the most common failure pattern (the environment can't support the install) systematically, and closes the **arm64** gap (the client images are amd64-only). Installer-only — no chart changes.

## Related
Ref tracebloc/backend#722 · stacked on #171, #172

## Type of change
- [x] Feature
- [x] Bug fix (arm64 guard)
- [x] Security / hardening

## What changed
- **`scripts/lib/preflight.sh`** (new) — `run_preflight()`: architecture (arm64 guard), egress connectivity, disk, RAM, CPU. Runs **all** checks, aggregates, then exits **once** with a summary. Escape hatches `TRACEBLOC_SKIP_PREFLIGHT=1` / `TRACEBLOC_ALLOW_ARM64=1`; `PF_*` threshold overrides.
- **`scripts/install-k8s.sh`** — sources + calls `run_preflight` at the top of Step 1/4.
- **`scripts/install.sh`** — adds `preflight.sh` to the curl-bootstrap download manifest (verified: every sourced lib is downloaded, and `run_preflight` executes via the real bootstrap).
- **`scripts/install-k8s.ps1`** — `Test-Preflight` + `Get-Pf*` helpers mirror the bash logic (Windows parity).
- **`docs/INSTALL.md`** — a "Network requirements (egress allowlist)" section the preflight error points users to.

### The checks
- **Architecture** — `amd64` ✓; arm64 on Docker Desktop → info (emulated); **arm64 Linux without QEMU binfmt → hard-fail** with the `docker run --privileged --rm tonistiigi/binfmt --install amd64` remedy. (This is exactly the `mysql-client: exec format error` we hit.)
- **Egress connectivity** — hard-fail if a *critical* host is unreachable (`registry-1.docker.io`, `ghcr.io`, the `CLIENT_ENV` backend, `tracebloc.github.io`); warn-only on tool-download hosts when the tool isn't already installed. A TLS/cert error → break-and-inspect proxy hint. Probe honors `HTTP_PROXY`.
- **Disk / RAM / CPU** — hard-fail on critically low disk; warn on low disk/RAM/CPU.

## Test plan
- **`scripts/tests/preflight.bats`** (21) + **Pester** `Describe`s (`Test-PfUrl`, `Test-Preflight`) — green. The `Get-Cim*` readers are **Windows-only** (CimCmdlets) so they `-Skip` off-Windows.
- **End-to-end on a Linux VM** (real `run_preflight`): healthy → passes; **`ghcr.io` blocked → hard-fail in ~1 s** naming the host + allowlist; **arm64 without binfmt → hard-fail** with the remedy (then restored).
- **curl-bootstrap**: ran the real `install.sh` from this branch → `preflight.sh` is fetched and `run_preflight` executes in the bootstrap flow.
- ⚠️ **PowerShell runtime not validated on a real Windows host** (logic covered by Pester) — a Windows reviewer should confirm `Test-Preflight` live.

## Deployment notes
None — installer-only. New optional env knobs: `TRACEBLOC_SKIP_PREFLIGHT`, `TRACEBLOC_ALLOW_ARM64`, `PF_MIN_DISK_GB`/`PF_WARN_DISK_GB`/`PF_WARN_MEM_GB`/`PF_MIN_CPU`.

## Checklist
- [x] Tests added / updated and passing locally
- [x] Docs updated (egress allowlist in INSTALL.md)
- [x] No secrets / credentials in the diff
- [ ] For security-sensitive paths: Windows reviewer requested for the ps1 runtime
