### PR TITLE
feat(installer): guarantee reboot persistence + make it visible

### DIFF
--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -738,6 +738,22 @@ function Write-K3dProxyConfig {
   return $cfg
 }
 
+# Guarantee the cluster returns after a reboot: ensure the k3d node containers
+# restart when Docker starts. k3d already sets unless-stopped; this is defensive
+# and also covers externally-created clusters. On Windows the remaining piece is
+# Docker Desktop starting on login, which the summary tells the user to enable.
+# Opt out with TRACEBLOC_NO_AUTOSTART=1.
+function Set-ClusterAutostart {
+  if ($env:TRACEBLOC_NO_AUTOSTART) { return }
+  try {
+    $nodes = docker ps -a --filter "name=k3d-$CLUSTER_NAME-" --format "{{.Names}}" 2>$null
+    foreach ($n in $nodes) {
+      if ($n) { docker update --restart unless-stopped $n 2>&1 | Out-Null }
+    }
+    if ($nodes) { Log "Set restart=unless-stopped on k3d nodes (auto-restart after reboot)." }
+  } catch {}
+}
+
 function New-K3dCluster {
   Log "Creating k3d cluster: '$CLUSTER_NAME'"
 
@@ -865,6 +881,8 @@ function New-K3dCluster {
   }
 
   Log "kubeconfig updated -- kubectl now points to '$CLUSTER_NAME'."
+
+  Set-ClusterAutostart
 }
 
 # =============================================================================
@@ -1243,6 +1261,8 @@ function Print-Summary {
       Write-Host "    https://ai.tracebloc.io/clients" -ForegroundColor Cyan
       Write-Host ""
       Hint "Models that vendors submit train on this machine -- your data never leaves it."
+      Write-Host ""
+      Hint "After a reboot, start Docker Desktop to bring your client back (enable 'Start Docker Desktop when you sign in' in Settings -> General to automate)."
       Write-Host ""
       Write-Host "  What to do next" -ForegroundColor White
       Write-Host "  1. Ingest your training and test data"

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -125,9 +125,40 @@ create_cluster() {
     _create_new_cluster
   fi
 
+  ensure_cluster_autostart
   _merge_kubeconfig
   _export_host_no_proxy
   _wait_for_api
+}
+
+# Guarantee the cluster returns after a host reboot. On Linux this already works
+# by default — k3d sets `--restart unless-stopped` on its node containers and the
+# Docker install enables docker.service on boot — but we harden both so it holds
+# even on a re-run where Docker was installed-but-disabled, or for an externally-
+# created cluster. On macOS/Windows the restart policy is set too, but Docker
+# Desktop must be configured to start on login (the summary tells the user).
+# Opt out with TRACEBLOC_NO_AUTOSTART=1.
+ensure_cluster_autostart() {
+  if [[ -n "${TRACEBLOC_NO_AUTOSTART:-}" ]]; then return 0; fi
+
+  local nodes node
+  nodes=$(docker ps -a --filter "name=k3d-${CLUSTER_NAME}-" --format '{{.Names}}' 2>/dev/null) || return 0
+  if [[ -n "$nodes" ]]; then
+    for node in $nodes; do
+      docker update --restart unless-stopped "$node" >/dev/null 2>&1 || true
+    done
+    log "Set restart=unless-stopped on k3d nodes so the cluster returns after a reboot."
+  fi
+
+  # On Linux, make sure Docker itself starts on boot. The fresh-install path only
+  # enables docker.service when Docker was absent; this also covers the
+  # installed-but-disabled re-run case. Idempotent.
+  if [[ "$OS" == "Linux" ]] && has systemctl; then
+    if sudo systemctl enable docker >/dev/null 2>&1; then
+      log "Ensured docker.service is enabled on boot."
+    fi
+  fi
+  return 0
 }
 
 _handle_existing_cluster() {

--- a/scripts/lib/summary.sh
+++ b/scripts/lib/summary.sh
@@ -70,6 +70,17 @@ _diagnose_not_ready() {
 # Reports the outcome based on CLIENT_STATE (set by wait_for_client_ready).
 # The "secure compute environment / your data never leaves" claim is printed
 # ONLY when the client is verifiably connected — never on a partial/failed run.
+# One-line note in the success summary so the user knows the client survives a
+# reboot — automatic on Linux; needs Docker Desktop start-on-login on macOS/Win.
+_reboot_note() {
+  if [[ "$OS" == "Linux" ]]; then
+    echo -e "  ${GREEN}✔${RESET} ${DIM}Survives reboot — Docker and your client restart automatically.${RESET}"
+  else
+    echo -e "  ${DIM}After a reboot, start Docker Desktop to bring your client back —${RESET}"
+    echo -e "  ${DIM}enable Settings → General → \"Start Docker Desktop when you sign in\" to automate.${RESET}"
+  fi
+}
+
 print_summary() {
   local mode="CPU"
   [[ "$GPU_VENDOR" == "nvidia" ]] && mode="NVIDIA GPU"
@@ -92,6 +103,8 @@ print_summary() {
       echo ""
       echo -e "  ${DIM}Models that vendors submit train on this machine —${RESET}"
       echo -e "  ${DIM}your data never leaves it.${RESET}"
+      echo ""
+      _reboot_note
       echo ""
       echo -e "  ${BOLD}What to do next${RESET}"
       echo -e "  ${WHITE}1.${RESET} Ingest your training and test data"

--- a/scripts/tests/cluster.bats
+++ b/scripts/tests/cluster.bats
@@ -160,3 +160,44 @@ setup() {
   run _check_existing_cluster_proxy
   [[ "$output" == *"missing: HTTP_PROXY"* ]]
 }
+
+# ── ensure_cluster_autostart (reboot persistence) ───────────────────────────
+@test "ensure_cluster_autostart: unless-stopped per node + enables docker (Linux)" {
+  OS=Linux
+  docker() { if [[ "$1 $2" == "ps -a" ]]; then printf '%s\n' "k3d-tracebloc-server-0" "k3d-tracebloc-serverlb"; else record "docker $*"; fi; }
+  sudo()   { record "sudo $*"; }
+  has()    { return 0; }
+  ensure_cluster_autostart
+  run mock_calls
+  [[ "$output" == *"docker update --restart unless-stopped k3d-tracebloc-server-0"* ]]
+  [[ "$output" == *"docker update --restart unless-stopped k3d-tracebloc-serverlb"* ]]
+  [[ "$output" == *"sudo systemctl enable docker"* ]]
+}
+
+@test "ensure_cluster_autostart: macOS does not enable docker.service" {
+  OS=Darwin
+  docker() { if [[ "$1 $2" == "ps -a" ]]; then echo "k3d-tracebloc-server-0"; else record "docker $*"; fi; }
+  sudo()   { record "sudo $*"; }
+  has()    { return 0; }
+  ensure_cluster_autostart
+  run mock_calls
+  [[ "$output" == *"docker update --restart unless-stopped"* ]]
+  [[ "$output" != *"systemctl enable docker"* ]]
+}
+
+@test "ensure_cluster_autostart: TRACEBLOC_NO_AUTOSTART -> no-op" {
+  OS=Linux
+  docker() { if [[ "$1 $2" == "ps -a" ]]; then echo "k3d-tracebloc-server-0"; else record "docker $*"; fi; }
+  sudo()   { record "sudo $*"; }
+  TRACEBLOC_NO_AUTOSTART=1 ensure_cluster_autostart
+  run mock_calls
+  [ -z "$output" ]
+}
+
+@test "ensure_cluster_autostart: no nodes -> no docker update" {
+  OS=Darwin
+  docker() { if [[ "$1 $2" == "ps -a" ]]; then echo ""; else record "docker $*"; fi; }
+  ensure_cluster_autostart
+  run mock_calls
+  [[ "$output" != *"docker update"* ]]
+}

--- a/scripts/tests/install-k8s.Tests.ps1
+++ b/scripts/tests/install-k8s.Tests.ps1
@@ -7,6 +7,7 @@ BeforeAll {
   . "$PSScriptRoot/../install-k8s.ps1"
   # Stubs so Pester can mock external commands that the functions invoke.
   function kubectl { }
+  function docker { }
 }
 
 Describe "Get-BackendUrl" {
@@ -357,5 +358,23 @@ Describe "Test-Preflight" {
     Mock Get-WindowsArch { "arm64" }
     Mock Test-PfUrl { "ok" }
     { Test-Preflight } | Should -Not -Throw
+  }
+}
+
+# --- reboot persistence (Set-ClusterAutostart) -------------------------------
+Describe "Set-ClusterAutostart" {
+  AfterEach { $env:TRACEBLOC_NO_AUTOSTART = $null }
+  It "sets unless-stopped on each k3d node" {
+    Mock docker {
+      if (($args -join ' ') -match 'ps -a') { return @("k3d-tracebloc-server-0", "k3d-tracebloc-serverlb") }
+    }
+    Set-ClusterAutostart
+    Should -Invoke docker -ParameterFilter { ($args -join ' ') -match 'update --restart unless-stopped' } -Times 2
+  }
+  It "TRACEBLOC_NO_AUTOSTART -> no docker calls" {
+    $env:TRACEBLOC_NO_AUTOSTART = "1"
+    Mock docker { }
+    Set-ClusterAutostart
+    Should -Invoke docker -Times 0 -Exactly
   }
 }

--- a/scripts/tests/summary.bats
+++ b/scripts/tests/summary.bats
@@ -91,3 +91,24 @@ setup() {
   [[ "$output" == *"crash loop"* ]]
   [[ "$output" != *"data never leaves"* ]]
 }
+
+# ── _reboot_note (reboot persistence) ───────────────────────────────────────
+@test "_reboot_note: Linux -> survives-reboot line" {
+  OS=Linux
+  run _reboot_note
+  [[ "$output" == *"Survives reboot"* ]]
+  [[ "$output" != *"Docker Desktop"* ]]
+}
+
+@test "_reboot_note: macOS -> Docker Desktop start-on-login instruction" {
+  OS=Darwin
+  run _reboot_note
+  [[ "$output" == *"Docker Desktop"* ]]
+  [[ "$output" == *"sign in"* ]]
+}
+
+@test "print_summary connected: includes the reboot note" {
+  CLIENT_STATE=connected; OS=Linux
+  run print_summary
+  [[ "$output" == *"Survives reboot"* ]]
+}


### PR DESCRIPTION
> 🚫 **STACKED ON #171 + #172 + #173 — DO NOT MERGE BEFORE THEM.** Branched off `fix/preflight-checks` (#173). Until the stack merges, this PR's range includes their commits — **review only commit `e69b9e1` / the 6 files below.** Flips draft → ready as the stack lands.

## Summary
Guarantees the tracebloc client comes back after a host reboot, and tells the user it does. A **real reboot test** (`limactl stop/start`) proved the cluster **already auto-recovers on Linux** (k3d sets `--restart unless-stopped` on its nodes; the Docker install enables `docker.service` on boot), so this is a light **guarantee + visibility** change — *not* a systemd unit. Installer-only.

## Related
Ref tracebloc/backend#722 · stacked on #171, #172, #173

## Type of change
- [x] Feature / hardening

## What changed
- **`scripts/lib/cluster.sh`** — `ensure_cluster_autostart()` (called from `create_cluster`): `docker update --restart unless-stopped` on the `k3d-<cluster>-*` nodes (covers externally-created clusters + any future k3d default change) + `systemctl enable docker` on Linux (covers the installed-but-disabled re-run edge the fresh-install path misses). Opt out: `TRACEBLOC_NO_AUTOSTART=1`.
- **`scripts/lib/summary.sh`** — `_reboot_note()` in the `connected` summary: Linux → "✔ Survives reboot"; macOS/Windows → "enable Docker Desktop start-on-login".
- **`scripts/install-k8s.ps1`** — `Set-ClusterAutostart` (defensive `unless-stopped` on the nodes) + the Docker-Desktop reboot note in `Print-Summary`.

## Why this, not a systemd unit
The reboot test: created a cluster, then `limactl stop ubuntu && limactl start ubuntu` (a true host reboot). With **no intervention** the containers auto-restarted and the node returned `Ready` — k3d's `unless-stopped` + `docker.service`-on-boot already handle it, so a systemd `k3d cluster start` unit would be redundant on Linux. The real gaps this closes: (a) *guaranteeing* those two defaults hold (re-run with Docker disabled; externally-created cluster without the policy), (b) Docker Desktop not auto-starting on Mac/Win (we instruct — the setting is version-specific), (c) users not *knowing* it persists.

## Test plan
- **`cluster.bats` (+4), `summary.bats` (+3), Pester (+2)** — green.
- **Real reboot on a Linux VM, proving the code matters**: stripped the restart policy (`policy=no`, simulating an externally-created cluster) → `ensure_cluster_autostart` restored `unless-stopped` + enabled docker → deployed a workload (`Running`) → `limactl stop/start` → containers `Up`, node `Ready`, **workload `Running` again, no intervention.**
- **Opt-out** (`TRACEBLOC_NO_AUTOSTART=1`) unit-tested.
- ⚠️ **PowerShell runtime not validated on Windows** (Pester-covered) — Windows reviewer for the live `Set-ClusterAutostart` + summary note.

## Deployment notes
None — installer-only. New opt-out env: `TRACEBLOC_NO_AUTOSTART`.

## Checklist
- [x] Tests added / updated and passing locally
- [x] No secrets / credentials in the diff
- [ ] Windows reviewer for the ps1 runtime
