### PR TITLE
chore(chart): bump to 1.4.3 for installer-hardening release

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.4.2
-appVersion: "1.4.2"
+version: 1.4.3
+appVersion: "1.4.3"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
## Summary
- Bumps `client/Chart.yaml` version + appVersion `1.4.2 → 1.4.3`.
- Prep for promoting the installer-hardening series (#171–#175) to production via develop → main.

## Notes
- **Installer-only patch release** — chart templates/values are unchanged from 1.4.2; published chart artifacts will be byte-identical. The bump exists to mark the installer changes with a version + release notes.
- The public installer one-liner runs from `main`, so this work reaches users only once develop → main is synced and v1.4.3 is published.

Tracking: #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version bump with no template or runtime chart changes.
> 
> **Overview**
> Bumps the unified Helm chart **version** and **appVersion** from `1.4.2` to `1.4.3` in `Chart.yaml` only. No chart templates or values change—this tags an **installer-hardening** release for promotion and release notes, not a behavioral chart update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa3a219f033d85d3e72394e738ad67357595b128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->