### PR TITLE
Sync develop → main for v1.4.3 chart release

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'client/**'
       - 'ingestor/**'
+      - 'scripts/**'
       - '.github/workflows/helm-ci.yaml'
   pull_request:
     branches: [main, develop, openshift]
     paths:
       - 'client/**'
       - 'ingestor/**'
+      - 'scripts/**'
       - '.github/workflows/helm-ci.yaml'
 
 jobs:
@@ -115,3 +117,29 @@ jobs:
             -f client/ci/${{ matrix.platform }}-values.yaml \
             > /dev/null
           echo "Schema validation passed for ${{ matrix.platform }}"
+
+  installer-tests:
+    name: Installer script tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bats
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq bats
+
+      - name: bats unit tests (bash installer)
+        run: bats scripts/tests/*.bats
+
+      - name: Pester unit tests (PowerShell installer)
+        shell: pwsh
+        env:
+          TB_PESTER: "1"
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module Pester -MinimumVersion 5.5.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          Import-Module Pester -MinimumVersion 5.5.0 -Force
+          $cfg = New-PesterConfiguration
+          $cfg.Run.Path = "scripts/tests/install-k8s.Tests.ps1"
+          $cfg.Run.Exit = $true
+          $cfg.Output.Verbosity = "Detailed"
+          Invoke-Pester -Configuration $cfg

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -6,14 +6,12 @@ on:
     paths:
       - 'client/**'
       - 'ingestor/**'
-      - 'scripts/**'
       - '.github/workflows/helm-ci.yaml'
   pull_request:
     branches: [main, develop, openshift]
     paths:
       - 'client/**'
       - 'ingestor/**'
-      - 'scripts/**'
       - '.github/workflows/helm-ci.yaml'
 
 jobs:
@@ -118,28 +116,6 @@ jobs:
             > /dev/null
           echo "Schema validation passed for ${{ matrix.platform }}"
 
-  installer-tests:
-    name: Installer script tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install bats
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq bats
-
-      - name: bats unit tests (bash installer)
-        run: bats scripts/tests/*.bats
-
-      - name: Pester unit tests (PowerShell installer)
-        shell: pwsh
-        env:
-          TB_PESTER: "1"
-        run: |
-          Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -MinimumVersion 5.5.0 -Force -SkipPublisherCheck -Scope CurrentUser
-          Import-Module Pester -MinimumVersion 5.5.0 -Force
-          $cfg = New-PesterConfiguration
-          $cfg.Run.Path = "scripts/tests/install-k8s.Tests.ps1"
-          $cfg.Run.Exit = $true
-          $cfg.Output.Verbosity = "Detailed"
-          Invoke-Pester -Configuration $cfg
+  # Installer script tests (bats + Pester) + the cross-distro prerequisite matrix
+  # live in their own workflow: .github/workflows/installer-tests.yaml
+  # (triggered on scripts/** changes).

--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -1,0 +1,174 @@
+name: Installer tests
+
+# Validates the curl/PowerShell installer (scripts/) across the breadth of
+# environments a customer might actually have:
+#   • static    — shellcheck + bash -n + PSScriptAnalyzer
+#   • unit-bash  — bats (mocked) for the bash installer
+#   • unit-pester— Pester for the PowerShell installer, on Linux AND real Windows
+#   • distro-prereqs — runs the REAL Linux prerequisite-install path (package
+#                  manager, system deps, Docker branch, kernel modules, kubectl/
+#                  k3d/helm) inside a fresh container for each major distro family.
+#                  This is what catches "works on Ubuntu, breaks on minimal RHEL"
+#                  bugs that mocked unit tests can't see.
+on:
+  push:
+    branches: [main, develop, openshift]
+    paths:
+      - 'scripts/**'
+      - '.github/workflows/installer-tests.yaml'
+  pull_request:
+    branches: [main, develop, openshift]
+    paths:
+      - 'scripts/**'
+      - '.github/workflows/installer-tests.yaml'
+  schedule:
+    - cron: '0 3 * * 1'   # Mondays 03:00 UTC — catch drift as distro base images move
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  static:
+    name: Static analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: bash -n (syntax) on every shell script
+        run: |
+          # .bats files are bats DSL (@test "name" { … }), not valid bash — they are
+          # syntax-checked by actually running them in the unit-bash job. Parse the
+          # real shell scripts here.
+          find scripts -type f -name '*.sh' -print0 \
+            | while IFS= read -r -d '' f; do bash -n "$f" || exit 1; done
+          echo "all shell scripts parse"
+
+      - name: ShellCheck (libs + entrypoints)
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+          shellcheck --version | grep version
+          # Gate at error severity. The libs are sourced together as one program,
+          # so single-file shellcheck reports SC2034 "unused" false positives for
+          # shared vars (CURL_SECURE, ARCH_DL, colours…) that are defined in
+          # common.sh and consumed in other sourced files. Warnings are printed
+          # below for visibility but don't fail the gate.
+          shellcheck --severity=error --shell=bash \
+            scripts/install.sh scripts/install-k8s.sh scripts/lib/*.sh \
+            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh
+          echo "── shellcheck warnings (advisory, non-blocking) ──"
+          shellcheck --severity=warning --shell=bash \
+            scripts/install.sh scripts/install-k8s.sh scripts/lib/*.sh \
+            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh || true
+
+      - name: PSScriptAnalyzer (PowerShell installer)
+        shell: pwsh
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module PSScriptAnalyzer -Force -SkipPublisherCheck -Scope CurrentUser
+          $issues = Invoke-ScriptAnalyzer -Path scripts/install-k8s.ps1 -Severity Error,Warning
+          if ($issues) { $issues | Format-Table -AutoSize }
+          $errs = @($issues | Where-Object { $_.Severity -eq 'Error' })
+          if ($errs.Count -gt 0) { Write-Error "PSScriptAnalyzer: $($errs.Count) error(s)"; exit 1 }
+          Write-Host "no PSScriptAnalyzer errors"
+
+  unit-bash:
+    name: bats (bash unit, mocked)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install bats
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq bats
+      - name: Run bats
+        run: bats scripts/tests/*.bats
+
+  unit-pester:
+    # Pester on Linux pwsh (fast) AND real Windows — the .ps1 installer's actual
+    # target. fail-fast:false so a Windows-only surprise doesn't mask Linux signal.
+    name: Pester (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Pester
+        shell: pwsh
+        env:
+          TB_PESTER: "1"
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module Pester -MinimumVersion 5.5.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          Import-Module Pester -MinimumVersion 5.5.0 -Force
+          $cfg = New-PesterConfiguration
+          $cfg.Run.Path = "scripts/tests/install-k8s.Tests.ps1"
+          $cfg.Run.Exit = $true
+          $cfg.Output.Verbosity = "Detailed"
+          Invoke-Pester -Configuration $cfg
+
+  distro-prereqs:
+    # Runs the installer's REAL Linux prerequisite path in a fresh container for
+    # each distro family. Proves the package-manager / Docker / conntrack / helm
+    # branches all resolve and install — the layer where every installer bug we
+    # have shipped lived (#718 PATH, #719 RHEL docker-ce, #720 conntrack-tools,
+    # the AlmaLinux kernel-modules gap, the Amazon Linux openssl/tar gap).
+    # It does NOT start dockerd or create a cluster — that needs a real kernel +
+    # systemd, covered by local VMs and (optionally) a future e2e job. Arch is
+    # omitted: its official image is x86-only and bare containers need keyring
+    # bootstrapping; the pacman branch is covered by the bats unit test.
+    name: Prereqs — ${{ matrix.distro }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - 'ubuntu:22.04'        # apt / get.docker.com — most common server
+          - 'ubuntu:24.04'        # newest LTS
+          - 'debian:12'           # apt
+          - 'almalinux:9'         # dnf + docker-ce repo (RHEL rebuild, #719)
+          - 'almalinux:8'         # older RHEL rebuild
+          - 'rockylinux:9'        # the other RHEL rebuild
+          - 'amazonlinux:2023'    # dnf + 'docker' pkg — common AWS default
+          - 'fedora:latest'       # dnf, falls through to get.docker.com
+          - 'opensuse/leap:15.6'  # zypper
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install prerequisites in ${{ matrix.distro }}
+        env:
+          DISTRO: ${{ matrix.distro }}
+        run: |
+          docker run --rm -v "$PWD:/src:ro" -w /src "$DISTRO" \
+            bash scripts/tests/distro-prereqs.sh
+
+  e2e-cluster:
+    # Highest-fidelity check CI can run: brings up an ACTUAL k3d cluster via the
+    # installer's own create_cluster() on a real kernel (Docker is preinstalled
+    # on the runner), proves it can schedule + run a public workload, then tears
+    # down. Stops BEFORE the tracebloc helm install / backend registration (those
+    # need private images + real credentials), so it needs no secrets. Runs on
+    # both amd64 and arm64 Ubuntu runners (arm64 is free on this public repo).
+    name: E2E cluster (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bring up a real k3d cluster + run a workload
+        run: bash scripts/tests/e2e-cluster.sh
+
+  e2e-proxy:
+    # Authenticated corporate-proxy E2E (the Charité/hospital archetype): stands
+    # up a squid that REQUIRES basic auth, brings the cluster up with the
+    # installer's proxy config pointed at it as user:pass@host, and proves the
+    # nodes pull a workload image THROUGH the authed proxy (the squid log shows an
+    # authenticated auth.docker.io CONNECT, which only a real pull makes). Guards
+    # the #172/#174 proxy hardening end-to-end. Single runner (arch-agnostic). No secrets.
+    name: E2E auth-proxy (squid)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cluster up through an authenticated proxy
+        run: bash scripts/tests/e2e-proxy.sh

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.4.2
-appVersion: "1.4.2"
+version: 1.4.3
+appVersion: "1.4.3"
 keywords:
   - tracebloc
   - kubernetes

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -23,6 +23,23 @@ This guide covers installing the **tracebloc** unified Helm chart (AKS, EKS, bar
 
 ---
 
+## Network requirements (egress allowlist)
+
+The standalone installer runs a **preflight** check that verifies this connectivity before doing any work, and fails fast (naming the blocked host) if egress is missing. On a locked-down VM, allow outbound **HTTPS (443)** to:
+
+| Host | Why |
+|---|---|
+| `registry-1.docker.io` (Docker Hub) | k3s, mysql-client, busybox + the tracebloc client images |
+| `ghcr.io` | k3d node images + the ingestor image |
+| `api.tracebloc.io` (`dev-api`/`stg-api` for non-prod) | client credential check + the running client's platform connection |
+| `tracebloc.github.io` | the tracebloc Helm chart repository |
+
+On **Linux**, the installer also fetches tooling from `get.docker.com`, `raw.githubusercontent.com`, `dl.k8s.io`, and `get.helm.sh` — but only when Docker / k3d / kubectl / Helm aren't already installed.
+
+**Behind a corporate proxy?** Set `HTTP_PROXY` / `HTTPS_PROXY` before running (the installer auto-augments `NO_PROXY` with the cluster-internal ranges). A **TLS-inspecting** proxy additionally needs its corporate CA trusted on the VM, or HTTPS to the hosts above will fail certificate validation.
+
+---
+
 ## 1. Add the Helm repository (recommended for production)
 
 The chart repository is hosted at [tracebloc/client](https://github.com/tracebloc/client). After the chart is published (see [Publishing the chart](#publishing-the-chart)), add the repo and install from it so you get versioning and `helm upgrade` support.

--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -738,6 +738,22 @@ function Write-K3dProxyConfig {
   return $cfg
 }
 
+# Guarantee the cluster returns after a reboot: ensure the k3d node containers
+# restart when Docker starts. k3d already sets unless-stopped; this is defensive
+# and also covers externally-created clusters. On Windows the remaining piece is
+# Docker Desktop starting on login, which the summary tells the user to enable.
+# Opt out with TRACEBLOC_NO_AUTOSTART=1.
+function Set-ClusterAutostart {
+  if ($env:TRACEBLOC_NO_AUTOSTART) { return }
+  try {
+    $nodes = docker ps -a --filter "name=k3d-$CLUSTER_NAME-" --format "{{.Names}}" 2>$null
+    foreach ($n in $nodes) {
+      if ($n) { docker update --restart unless-stopped $n 2>&1 | Out-Null }
+    }
+    if ($nodes) { Log "Set restart=unless-stopped on k3d nodes (auto-restart after reboot)." }
+  } catch {}
+}
+
 function New-K3dCluster {
   Log "Creating k3d cluster: '$CLUSTER_NAME'"
 
@@ -865,6 +881,8 @@ function New-K3dCluster {
   }
 
   Log "kubeconfig updated -- kubectl now points to '$CLUSTER_NAME'."
+
+  Set-ClusterAutostart
 }
 
 # =============================================================================
@@ -1243,6 +1261,8 @@ function Print-Summary {
       Write-Host "    https://ai.tracebloc.io/clients" -ForegroundColor Cyan
       Write-Host ""
       Hint "Models that vendors submit train on this machine -- your data never leaves it."
+      Write-Host ""
+      Hint "After a reboot, start Docker Desktop to bring your client back (enable 'Start Docker Desktop when you sign in' in Settings -> General to automate)."
       Write-Host ""
       Write-Host "  What to do next" -ForegroundColor White
       Write-Host "  1. Ingest your training and test data"

--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -1301,6 +1301,114 @@ function Print-Summary {
 }
 
 # =============================================================================
+#  PREFLIGHT — fail-fast environment checks (mirrors scripts/lib/preflight.sh)
+# =============================================================================
+
+# Non-exiting failure line (Err exits; preflight must finish all checks first).
+function Write-PfFail($m) { Write-Host "  " -NoNewline; Write-Host ([char]0x2716) -ForegroundColor Red -NoNewline; Write-Host " $m" -ForegroundColor Red }
+
+# Probe a URL for reachability. Returns: ok|tls|dns|timeout|blocked. Any HTTP
+# response (incl. 401/403/404) = reachable (TLS + HTTP completed). Honors the
+# system / HTTP_PROXY proxy automatically.
+function Test-PfUrl([string]$Url) {
+  try {
+    Invoke-WebRequest -Uri $Url -Method Head -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null
+    return "ok"
+  } catch {
+    if ($null -ne $_.Exception.Response) { return "ok" }   # reached the server, got an HTTP error
+    $m = "$($_.Exception.Message)"
+    if ($m -match 'trust|SSL|certificate|TLS|secure channel') { return "tls" }
+    if ($m -match 'resolve|name or service|known')            { return "dns" }
+    if ($m -match 'timed out|timeout')                        { return "timeout" }
+    return "blocked"
+  }
+}
+
+# Free GB on the drive holding $HOST_DATA_DIR (or C:); $null if undeterminable
+# (e.g. non-Windows under Pester — tests mock this).
+function Get-PfFreeGb {
+  try {
+    $qualifier = (Split-Path -Qualifier $HOST_DATA_DIR -ErrorAction SilentlyContinue)
+    if (-not $qualifier) { $qualifier = "C:" }
+    $d = Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='$qualifier'" -ErrorAction Stop
+    return [math]::Floor($d.FreeSpace / 1GB)
+  } catch { return $null }
+}
+
+function Get-PfMemGb {
+  try { return [math]::Floor((Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).TotalPhysicalMemory / 1GB) }
+  catch { return $null }
+}
+
+function Get-PfCpu {
+  try { return [int](Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).NumberOfLogicalProcessors }
+  catch { if ($env:NUMBER_OF_PROCESSORS) { return [int]$env:NUMBER_OF_PROCESSORS } else { return $null } }
+}
+
+function Test-Preflight {
+  if ($env:TRACEBLOC_SKIP_PREFLIGHT) { Info "Preflight checks skipped (TRACEBLOC_SKIP_PREFLIGHT set)."; return }
+
+  $minDiskGb  = if ($env:PF_MIN_DISK_GB)  { [int]$env:PF_MIN_DISK_GB }  else { 5 }
+  $warnDiskGb = if ($env:PF_WARN_DISK_GB) { [int]$env:PF_WARN_DISK_GB } else { 20 }
+  $warnMemGb  = if ($env:PF_WARN_MEM_GB)  { [int]$env:PF_WARN_MEM_GB }  else { 4 }
+  $minCpu     = if ($env:PF_MIN_CPU)      { [int]$env:PF_MIN_CPU }      else { 2 }
+  $hardFail   = 0
+
+  # Architecture — the tracebloc client images (e.g. mysql-client) are amd64-only.
+  $arch = Get-WindowsArch
+  if ($arch -eq "amd64") {
+    Ok "Architecture: amd64"
+  } elseif ($env:TRACEBLOC_ALLOW_ARM64) {
+    Warn "Architecture: $arch - proceeding (TRACEBLOC_ALLOW_ARM64 set); amd64-only images may crash if emulation is unavailable."
+  } else {
+    Info "Architecture: $arch - Docker Desktop runs the amd64 client images under emulation (slower, but works)."
+  }
+
+  $cpu = Get-PfCpu
+  if      ($null -eq $cpu)   { Warn "CPU: couldn't determine core count (skipping)." }
+  elseif  ($cpu -lt $minCpu) { Warn "CPU: $cpu core(s) - recommended >= $minCpu." }
+  else                       { Ok "CPU: $cpu cores" }
+
+  $mem = Get-PfMemGb
+  if      ($null -eq $mem)      { Warn "Memory: couldn't determine total RAM (skipping)." }
+  elseif  ($mem -lt $warnMemGb) { Warn "Memory: $mem GB total - recommended >= $warnMemGb GB; k3s + training may run out of memory." }
+  else                          { Ok "Memory: $mem GB" }
+
+  $disk = Get-PfFreeGb
+  if      ($null -eq $disk)        { Warn "Disk: couldn't determine free space (skipping)." }
+  elseif  ($disk -lt $minDiskGb)   { Write-PfFail "Disk: only $disk GB free - need >= $minDiskGb GB."; $hardFail++; Hint "Free up space or attach a larger disk, then re-run." }
+  elseif  ($disk -lt $warnDiskGb)  { Warn "Disk: $disk GB free - recommended >= $warnDiskGb GB; images + data may fill it." }
+  else                             { Ok "Disk: $disk GB free" }
+
+  Info "Checking outbound connectivity to required services..."
+  $backendHost = (Get-BackendUrl) -replace '^https?://','' -replace '/$',''
+  $criticals = @(
+    @{ label = "Docker Hub (registry-1.docker.io)";           url = "https://registry-1.docker.io/v2/" },
+    @{ label = "GitHub Container Registry (ghcr.io)";         url = "https://ghcr.io/" },
+    @{ label = "tracebloc API ($backendHost)";                url = "https://$backendHost/" },
+    @{ label = "tracebloc Helm charts (tracebloc.github.io)"; url = "https://tracebloc.github.io/" }
+  )
+  $tlsSeen = $false; $cfail = 0
+  foreach ($c in $criticals) {
+    $status = Test-PfUrl $c.url
+    if ($status -ne "ok") { $status = Test-PfUrl $c.url }   # one retry for transient blips
+    if ($status -eq "ok") { Ok "$($c.label) reachable" }
+    else {
+      Write-PfFail "$($c.label) unreachable ($status)"
+      $hardFail++; $cfail++
+      if ($status -eq "tls") { $tlsSeen = $true }
+    }
+  }
+  if ($tlsSeen)    { Hint "A TLS/certificate error usually means a break-and-inspect (TLS-inspecting) proxy whose corporate CA isn't trusted here - see the proxy notes." }
+  if ($cfail -gt 0){ Hint "Allow HTTPS (443) egress to: registry-1.docker.io, ghcr.io, $backendHost, tracebloc.github.io - or configure your corporate proxy." }
+
+  if ($hardFail -gt 0) {
+    Write-Host ""
+    Err "Preflight failed - resolve the items above and re-run. (Override at your own risk with `$env:TRACEBLOC_SKIP_PREFLIGHT=1.)"
+  }
+}
+
+# =============================================================================
 #  MAIN
 # =============================================================================
 
@@ -1316,6 +1424,7 @@ Print-Roadmap
 
 # -- Step 1/4: Check system requirements --
 Step 1 4 "Checking system requirements"
+Test-Preflight
 Find-Gpu
 Enable-VirtualisationFeatures
 Install-Winget

--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -23,7 +23,7 @@
 # =============================================================================
 
 #Requires -Version 5.1
-param([switch]$Help, [switch]$NoReboot)
+param([switch]$Help, [switch]$NoReboot, [switch]$Diagnose)
 
 # -- Admin check --------------------------------------------------------------
 # $env:TB_PESTER lets the test suite dot-source this file to load the functions
@@ -965,7 +965,9 @@ function Get-TraceblocYamlValue {
 # Resolve the backend base URL the same way jobs-manager does
 # (client-runtime/controller.py: CLIENT_ENV -> backend), defaulting to prod.
 function Get-BackendUrl {
-  switch ($env:CLIENT_ENV) {
+  # Quote the value so a truly-unset CLIENT_ENV ($null) coerces to "" and the
+  # default (prod) branch reliably fires across PowerShell versions.
+  switch ("$env:CLIENT_ENV") {
     "dev"   { return "https://dev-api.tracebloc.io/" }
     "stg"   { return "https://stg-api.tracebloc.io/" }
     default { return "https://api.tracebloc.io/" }
@@ -1429,12 +1431,97 @@ function Test-Preflight {
 }
 
 # =============================================================================
+#  DIAGNOSE — `-Diagnose` support bundle (mirrors scripts/lib/diagnose.sh)
+# =============================================================================
+
+# Redact secrets from a file IN PLACE. Applied to every collected file before
+# archiving. Single-quoted replacement strings keep $1 literal for the regex.
+# Written UTF-8 without BOM.
+function Edit-Redaction([string]$Path) {
+  if (-not (Test-Path $Path)) { return }
+  try {
+    $t = Get-Content -Path $Path -Raw -ErrorAction Stop
+    # First rule redacts ANY *password key (clientPassword, dockerRegistry
+    # password, HTTP_PROXY_PASSWORD, ...) in : or = form, not just clientPassword.
+    $t = $t -replace '(?i)([A-Za-z0-9_.-]*password\s*[:=]\s*).*', '$1[REDACTED]'
+    $t = $t -replace '([a-zA-Z][a-zA-Z0-9+.-]*://)[^:/@\s]+:[^@/\s]+@', '$1[REDACTED]@'
+    $t = $t -replace '(?i)((token|secret|authorization|api[_-]?key)\s*[:=]\s*).*', '$1[REDACTED]'
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $t, $utf8NoBom)
+  } catch {}
+}
+
+function Invoke-DiagnoseBundle {
+  $ts = Get-Date -Format 'yyyyMMdd-HHmmss'
+  $base = if ($HOST_DATA_DIR) { $HOST_DATA_DIR } else { "$env:USERPROFILE\.tracebloc" }
+  $cn = if ($CLUSTER_NAME) { $CLUSTER_NAME } else { "tracebloc" }
+  New-Item -ItemType Directory -Path $base -Force -ErrorAction SilentlyContinue | Out-Null
+  $work = Join-Path ([System.IO.Path]::GetTempPath()) ("tracebloc-diag-" + [System.IO.Path]::GetRandomFileName())
+  $d = Join-Path $work "tracebloc-diagnose-$ts"
+  New-Item -ItemType Directory -Path (Join-Path $d "logs") -Force | Out-Null
+
+  Info "Collecting diagnostics -- this is safe; credentials are redacted before the file is written."
+
+  # Namespace discovery (TB_NAMESPACE isn't set on a standalone diagnose run).
+  $ns = $TB_NAMESPACE
+  if (-not $ns) {
+    $jm = kubectl get pods -A 2>$null | Select-String '\-jobs-manager' | Select-Object -First 1
+    if ($jm) { $ns = ($jm.ToString().Trim() -split '\s+')[0] }
+  }
+  if (-not $ns) { $ns = "default" }
+
+  # host / versions
+  $h = @("# tracebloc diagnose ($ts)", "OS: Windows  ARCH: $(Get-WindowsArch)",
+         "CLIENT_ENV: $($env:CLIENT_ENV)  CLUSTER_NAME: $cn  NAMESPACE: $ns", "## versions",
+         (k3d version 2>&1 | Out-String), (kubectl version --client 2>&1 | Out-String),
+         (helm version --short 2>&1 | Out-String), (docker version 2>&1 | Out-String))
+  try { $cs = Get-CimInstance Win32_ComputerSystem -ErrorAction Stop; $h += "CPUs=$($cs.NumberOfLogicalProcessors)  MemBytes=$($cs.TotalPhysicalMemory)" } catch {}
+  ($h -join "`n") | Out-File (Join-Path $d "00-host.txt") -Encoding utf8
+
+  ((docker ps -a --filter "name=k3d-$cn-" 2>&1 | Out-String) + "`n" + (k3d cluster list 2>&1 | Out-String)) | Out-File (Join-Path $d "01-docker.txt") -Encoding utf8
+
+  if (Get-Command kubectl -ErrorAction SilentlyContinue) {
+    (@("## nodes", (kubectl get nodes -o wide 2>&1 | Out-String),
+       "## pods", (kubectl get pods -A -o wide 2>&1 | Out-String),
+       "## events", (kubectl get events -A 2>&1 | Out-String)) -join "`n") | Out-File (Join-Path $d "02-kubectl.txt") -Encoding utf8
+    foreach ($w in @("mysql-client", "$ns-jobs-manager", "$ns-requests-proxy")) {
+      kubectl logs -n $ns "deploy/$w" --all-containers --tail=500 2>&1 | Out-File (Join-Path $d "logs/$w.log") -Encoding utf8
+    }
+  }
+  if (Get-Command helm -ErrorAction SilentlyContinue) {
+    (@("## helm list", (helm list -A 2>&1 | Out-String), "## values", (helm get values $ns -n $ns 2>&1 | Out-String)) -join "`n") | Out-File (Join-Path $d "04-helm.txt") -Encoding utf8
+  }
+
+  Get-ChildItem -Path $base -Filter "install-*.log" -ErrorAction SilentlyContinue | ForEach-Object { Copy-Item $_.FullName (Join-Path $d $_.Name) -ErrorAction SilentlyContinue }
+  if (Test-Path "$base\values.yaml") { Copy-Item "$base\values.yaml" (Join-Path $d "values.yaml") -ErrorAction SilentlyContinue }
+
+  (("## proxy env`n") + ((@("HTTP_PROXY","HTTPS_PROXY","NO_PROXY") | ForEach-Object { "$_=" + [Environment]::GetEnvironmentVariable($_) }) -join "`n")) | Out-File (Join-Path $d "05-proxy.txt") -Encoding utf8
+
+  # REDACT every collected file, THEN archive.
+  Get-ChildItem -Path $d -Recurse -File | ForEach-Object { Edit-Redaction $_.FullName }
+  $bundle = Join-Path $base "tracebloc-diagnose-$ts.zip"
+  if (Test-Path $bundle) { Remove-Item $bundle -Force -ErrorAction SilentlyContinue }
+  Compress-Archive -Path $d -DestinationPath $bundle -Force -ErrorAction SilentlyContinue
+  Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
+
+  Write-Host ""
+  if (Test-Path $bundle) {
+    Ok "Diagnostics saved (credentials redacted):"
+    Write-Host "    $bundle"
+    Hint "Send this file to tracebloc support -- it has logs + status with passwords removed."
+  } else {
+    Write-Host "  Could not create the diagnostics archive." -ForegroundColor Red
+  }
+}
+
+# =============================================================================
 #  MAIN
 # =============================================================================
 
 if (-not $env:TB_PESTER) {
 
 if ($Help) { Print-Help }
+if ($Diagnose) { Invoke-DiagnoseBundle; exit 0 }
 
 Confirm-Config
 Initialize-ToolDir

--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -681,6 +681,63 @@ function Install-K3dAndHelm {
 #  CLUSTER CREATION
 # =============================================================================
 
+# --- Corporate-proxy support (mirrors scripts/lib/cluster.sh) ----------------
+# Cluster-internal destinations that must never be routed through a corporate
+# proxy: loopback, all RFC1918 private ranges (the k3s pod CIDR 10.42.0.0/16,
+# service CIDR 10.43.0.0/16, the k3d docker network and node IPs), and the
+# in-cluster DNS suffixes. Echoes host NO_PROXY/no_proxy unioned with these
+# defaults, de-duplicated with host entries first.
+function Get-EffectiveNoProxy {
+  $defaults = @('localhost','127.0.0.1','0.0.0.0','10.0.0.0/8','172.16.0.0/12','192.168.0.0/16','.svc','.svc.cluster.local','.cluster.local','host.k3d.internal')
+  $existing = if ($env:NO_PROXY) { $env:NO_PROXY } elseif ($env:no_proxy) { $env:no_proxy } else { '' }
+  $seen = @{}
+  $out  = New-Object System.Collections.Generic.List[string]
+  foreach ($tok in (($existing -split ',') + $defaults)) {
+    $t = $tok.Trim()
+    if ($t -ne '' -and -not $seen.ContainsKey($t)) { $seen[$t] = $true; $out.Add($t) }
+  }
+  return ($out -join ',')
+}
+
+# Build a k3d config file carrying proxy env as structured YAML entries and
+# return its path ($null when no HTTP(S) proxy is set). We use --config rather
+# than --env KEY=VALUE@FILTER because k3d splits the --env flag on '@', which
+# corrupts authenticated-proxy URLs (http://user:pass@host); the YAML env list
+# preserves them. NO_PROXY is always emitted (auto-augmented) so in-cluster
+# traffic bypasses the proxy. Written UTF-8 without BOM (Windows PowerShell 5.1
+# would otherwise prepend a BOM that breaks the YAML parser). Caller removes the
+# parent temp dir.
+function Write-K3dProxyConfig {
+  $haveHttp = $env:HTTP_PROXY -or $env:HTTPS_PROXY -or $env:http_proxy -or $env:https_proxy
+  if (-not $haveHttp) { return $null }
+
+  $noProxy = Get-EffectiveNoProxy
+  $tmpDir  = Join-Path ([System.IO.Path]::GetTempPath()) ("tracebloc-k3d-" + [System.IO.Path]::GetRandomFileName())
+  New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+  $cfg = Join-Path $tmpDir "config.yaml"
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  $lines.Add('apiVersion: k3d.io/v1alpha5')
+  $lines.Add('kind: Simple')
+  $lines.Add('env:')
+  foreach ($name in @('HTTP_PROXY','HTTPS_PROXY','http_proxy','https_proxy')) {
+    $val = [Environment]::GetEnvironmentVariable($name)
+    if ($val) {
+      $lines.Add('  - envVar: "' + $name + '=' + $val + '"')
+      $lines.Add('    nodeFilters:')
+      $lines.Add('      - all')
+    }
+  }
+  foreach ($name in @('NO_PROXY','no_proxy')) {
+    $lines.Add('  - envVar: "' + $name + '=' + $noProxy + '"')
+    $lines.Add('    nodeFilters:')
+    $lines.Add('      - all')
+  }
+  $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+  [System.IO.File]::WriteAllLines($cfg, $lines, $utf8NoBom)
+  return $cfg
+}
+
 function New-K3dCluster {
   Log "Creating k3d cluster: '$CLUSTER_NAME'"
 
@@ -701,6 +758,19 @@ function New-K3dCluster {
       k3d cluster start $CLUSTER_NAME
       Ok "Compute environment started."
     }
+
+    # Gap C parity: an externally-created cluster may bind its API to 0.0.0.0;
+    # warn (the kubeconfig rewrite below still normalizes it to 127.0.0.1, so
+    # reuse works). Silent if the serverlb can't be inspected.
+    try {
+      $binds = (docker inspect "k3d-$CLUSTER_NAME-serverlb" --format '{{range $p, $c := .NetworkSettings.Ports}}{{range $c}}{{.HostIp}} {{end}}{{end}}' 2>$null | Out-String)
+      if ($binds -match '0\.0\.0\.0' -and $binds -notmatch '127\.0\.0\.1') {
+        Warn "The existing '$CLUSTER_NAME' cluster binds its API to 0.0.0.0 (created outside this installer)."
+        Hint "This installer binds clusters to 127.0.0.1; behind a corporate proxy a 0.0.0.0 bind can be intercepted."
+        Hint "Your kubeconfig is normalized to 127.0.0.1 so reuse works. If kubectl is still intercepted, rebuild it:"
+        Hint "  k3d cluster delete $CLUSTER_NAME  (then re-run this installer)."
+      }
+    } catch {}
   } else {
     if (-not (Test-Path $HOST_DATA_DIR)) {
       New-Item -ItemType Directory -Path $HOST_DATA_DIR -Force | Out-Null
@@ -714,7 +784,7 @@ function New-K3dCluster {
       "cluster", "create", $CLUSTER_NAME,
       "--servers", $SERVERS,
       "--agents",  $AGENTS,
-      "--api-port","6550",
+      "--api-port","127.0.0.1:6550",
       "-v",        "${HOST_DATA_DIR}:/tracebloc@all",
       "--k3s-arg", "--disable=traefik@server:*",
       "--k3s-arg", "--disable=servicelb@server:*",
@@ -726,6 +796,16 @@ function New-K3dCluster {
     if ($K3D_GPU_FLAG -ne "") {
       $k3dArgs += $K3D_GPU_FLAG
       Log "GPU flag active: $K3D_GPU_FLAG"
+    }
+
+    # Corporate-proxy propagation (mirrors scripts/lib/cluster.sh): pass proxy
+    # env via a k3d --config file so authenticated proxies survive and NO_PROXY
+    # is auto-augmented with the cluster-internal ranges (prevents in-cluster
+    # misroute + the create-time --wait hang).
+    $proxyCfg = Write-K3dProxyConfig
+    if ($proxyCfg) {
+      $k3dArgs += @("--config", $proxyCfg)
+      Log "Propagating proxy settings to k3d nodes (authenticated proxies supported; NO_PROXY auto-augmented)."
     }
 
     Log "Creating cluster: $SERVERS server(s) + $AGENTS agent(s)..."
@@ -760,6 +840,7 @@ function New-K3dCluster {
     $k3dStdout = if (Test-Path $k3dOutLog) { Get-Content $k3dOutLog -Raw -ErrorAction SilentlyContinue } else { "" }
     $k3dStderr = if (Test-Path $k3dErrLog) { Get-Content $k3dErrLog -Raw -ErrorAction SilentlyContinue } else { "" }
     Remove-Item $k3dOutLog, $k3dErrLog -Force -ErrorAction SilentlyContinue
+    if ($proxyCfg) { Remove-Item (Split-Path $proxyCfg -Parent) -Recurse -Force -ErrorAction SilentlyContinue }
     if ($k3dStdout) { Log "k3d stdout: $k3dStdout" }
     if ($k3dStderr) { Log "k3d stderr: $k3dStderr" }
 
@@ -771,7 +852,16 @@ function New-K3dCluster {
 
   $kubeConfigPath = "$env:USERPROFILE\.kube\config"
   if (Test-Path $kubeConfigPath) {
-    (Get-Content $kubeConfigPath) -replace 'host\.docker\.internal', '127.0.0.1' | Set-Content $kubeConfigPath -Encoding UTF8
+    (Get-Content $kubeConfigPath) `
+      -replace 'host\.docker\.internal', '127.0.0.1' `
+      -replace 'https://0\.0\.0\.0:', 'https://127.0.0.1:' | Set-Content $kubeConfigPath -Encoding UTF8
+  }
+
+  # Ensure THIS installer's own kubectl bypasses the proxy for the cluster API
+  # (127.0.0.1) + in-cluster ranges (mirrors cluster.sh::_export_host_no_proxy).
+  if ($env:HTTP_PROXY -or $env:HTTPS_PROXY -or $env:http_proxy -or $env:https_proxy) {
+    $env:NO_PROXY = Get-EffectiveNoProxy
+    $env:no_proxy = $env:NO_PROXY
   }
 
   Log "kubeconfig updated -- kubectl now points to '$CLUSTER_NAME'."

--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -26,14 +26,18 @@
 param([switch]$Help, [switch]$NoReboot)
 
 # -- Admin check --------------------------------------------------------------
-$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
-           ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-if (-not $isAdmin) {
-  Write-Host "  " -NoNewline; Write-Host ([char]0x2716) -ForegroundColor Red -NoNewline; Write-Host " Run this script as Administrator (right-click > Run as Administrator)." -ForegroundColor Red
-  exit 1
-}
+# $env:TB_PESTER lets the test suite dot-source this file to load the functions
+# without triggering the admin gate (which throws off-Windows) or running main.
+if (-not $env:TB_PESTER) {
+  $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+             ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+  if (-not $isAdmin) {
+    Write-Host "  " -NoNewline; Write-Host ([char]0x2716) -ForegroundColor Red -NoNewline; Write-Host " Run this script as Administrator (right-click > Run as Administrator)." -ForegroundColor Red
+    exit 1
+  }
 
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+}
 
 # =============================================================================
 #  HELPERS — logging functions matching bash UX
@@ -122,6 +126,8 @@ $CLIENT_ENV    = $env:CLIENT_ENV
 $GPU_VENDOR       = "none"
 $NVIDIA_DRIVER_OK = $false
 $K3D_GPU_FLAG     = ""
+$ReadyTimeout     = if ($env:READY_TIMEOUT) { $env:READY_TIMEOUT } else { "300" }
+$script:ClientState = "starting"
 
 # =============================================================================
 #  HELP
@@ -848,6 +854,39 @@ function Get-TraceblocYamlValue {
   return $val
 }
 
+# Resolve the backend base URL the same way jobs-manager does
+# (client-runtime/controller.py: CLIENT_ENV -> backend), defaulting to prod.
+function Get-BackendUrl {
+  switch ($env:CLIENT_ENV) {
+    "dev"   { return "https://dev-api.tracebloc.io/" }
+    "stg"   { return "https://stg-api.tracebloc.io/" }
+    default { return "https://api.tracebloc.io/" }
+  }
+}
+
+# Validate the entered Client ID / password against the backend's
+# api-token-auth/ endpoint -- the same call jobs-manager makes at runtime.
+# Returns: valid | invalid | inactive | unverified.
+function Test-Credentials {
+  param([string]$ClientId, [string]$ClientPassword)
+  $backend = Get-BackendUrl
+  try {
+    $resp = Invoke-WebRequest -Uri "${backend}api-token-auth/" -Method Post `
+      -Body @{ username = $ClientId; password = $ClientPassword } `
+      -TimeoutSec 60 -UseBasicParsing -ErrorAction Stop
+    if ($resp.StatusCode -eq 200) { return "valid" }
+    return "unverified"
+  } catch {
+    $code = $null
+    if ($_.Exception.Response) { $code = [int]$_.Exception.Response.StatusCode }
+    switch ($code) {
+      400     { return "invalid" }
+      401     { return "inactive" }
+      default { return "unverified" }   # 429 throttled, connection failure, 5xx, …
+    }
+  }
+}
+
 function Install-ClientHelm {
   # -- Step 3/4: Install tracebloc client --
   Step 3 4 "Installing tracebloc client"
@@ -887,6 +926,7 @@ function Install-ClientHelm {
   $nsInput = Read-Host "  Workspace name [$defaultNamespace]"
   $rawName = if ($nsInput) { $nsInput } else { $defaultNamespace }
   $TB_NAMESPACE = ConvertTo-WorkspaceName -Input_ $rawName
+  $script:TB_NAMESPACE = $TB_NAMESPACE   # share with Wait-ForClientReady / Print-Summary
 
   if ($TB_NAMESPACE -ne $rawName) {
     Info "Using workspace: $TB_NAMESPACE"
@@ -903,28 +943,53 @@ function Install-ClientHelm {
   Write-Host "    " -NoNewline; Write-Host "https://ai.tracebloc.io/clients" -ForegroundColor White
   Write-Host ""
 
-  if ($defaultClientId) {
-    $idInput = Read-Host "  Client ID [$defaultClientId]"
-    $TB_CLIENT_ID = if ($idInput) { $idInput } else { $defaultClientId }
-  } else {
-    $TB_CLIENT_ID = Read-Host "  Client ID"
-  }
-  if (-not $TB_CLIENT_ID) { Err "Client ID cannot be empty." }
+  # Collect + verify credentials. The entered Client ID / password are checked
+  # against the backend (the same api-token-auth/ call jobs-manager makes)
+  # before we deploy, so a wrong credential is caught here -- with a re-prompt --
+  # instead of surfacing later as a silently crash-looping pod.
+  $credAttempt = 0; $credMax = 5
+  while ($true) {
+    if ($defaultClientId) {
+      $idInput = Read-Host "  Client ID [$defaultClientId]"
+      $TB_CLIENT_ID = if ($idInput) { $idInput } else { $defaultClientId }
+    } else {
+      $TB_CLIENT_ID = Read-Host "  Client ID"
+    }
+    if (-not $TB_CLIENT_ID) { Warn "Client ID cannot be empty."; continue }
 
-  if ($defaultClientPassword) {
-    $pwInput = Read-Host "  Client password [press Enter to keep existing]" -AsSecureString
-    if ($pwInput -and $pwInput.Length -gt 0) {
+    if ($defaultClientPassword) {
+      $pwInput = Read-Host "  Client password [press Enter to keep existing]" -AsSecureString
+      if ($pwInput -and $pwInput.Length -gt 0) {
+        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($pwInput)
+        try { $TB_CLIENT_PASSWORD = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR) } finally { [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($BSTR) }
+      } else {
+        $TB_CLIENT_PASSWORD = $defaultClientPassword
+      }
+    } else {
+      $pwInput = Read-Host "  Client password" -AsSecureString
       $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($pwInput)
       try { $TB_CLIENT_PASSWORD = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR) } finally { [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($BSTR) }
-    } else {
-      $TB_CLIENT_PASSWORD = $defaultClientPassword
     }
-  } else {
-    $pwInput = Read-Host "  Client password" -AsSecureString
-    $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($pwInput)
-    try { $TB_CLIENT_PASSWORD = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR) } finally { [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($BSTR) }
+    if (-not $TB_CLIENT_PASSWORD) { Warn "Client password cannot be empty."; continue }
+
+    Info "Verifying credentials with tracebloc..."
+    $credStatus = Test-Credentials -ClientId $TB_CLIENT_ID -ClientPassword $TB_CLIENT_PASSWORD
+    if ($credStatus -eq "valid") { Ok "Credentials verified."; break }
+    elseif ($credStatus -eq "inactive") { Err "This tracebloc account is not active yet. Check your email for the activation link, then re-run." }
+    elseif ($credStatus -eq "unverified") {
+      Warn "Couldn't reach tracebloc to verify your credentials right now - continuing."
+      Hint "If they are wrong, your client will stay offline at https://ai.tracebloc.io/clients after install."
+      break
+    } else {
+      Warn "That Client ID / password was rejected by tracebloc - please re-enter."
+      Hint "Find your credentials at https://ai.tracebloc.io/clients"
+    }
+
+    $credAttempt++
+    if ($credAttempt -ge $credMax) { Err "Too many failed attempts. Double-check your credentials at https://ai.tracebloc.io/clients and re-run." }
+    # Force active re-entry on retry (don't silently reuse a rejected default).
+    $defaultClientId = ""; $defaultClientPassword = ""
   }
-  if (-not $TB_CLIENT_PASSWORD) { Err "Client password cannot be empty." }
 
   $passwordEscaped = $TB_CLIENT_PASSWORD -replace "'", "''"
 
@@ -1013,46 +1078,117 @@ function Confirm-Cluster {
   Log $clusterInfo
   $nodes = kubectl get nodes -o wide 2>&1 | Out-String
   Log $nodes
+  $pods = kubectl get pods -n $script:TB_NAMESPACE -o wide 2>&1 | Out-String
+  Log $pods
   Log "--- End Cluster Status ---"
+}
+
+# ── Readiness gate (#716) ─────────────────────────────────────────────────
+# helm install only *applies* manifests; it does not wait for pods. Wait for the
+# client's workloads to actually become Ready and set $script:ClientState so the
+# summary reports the truth: connected | starting | bad_creds | image_pull | crash
+function Wait-ForClientReady {
+  $ns = $script:TB_NAMESPACE
+  $deploys = @("mysql-client", "$ns-jobs-manager", "$ns-requests-proxy")
+  $deadline = (Get-Date).AddSeconds([int]$ReadyTimeout)
+  $allReady = $true
+
+  Write-Host ""
+  Info "Waiting for the client to start - first run downloads images, this can take a few minutes..."
+  foreach ($d in $deploys) {
+    $remaining = [int]((New-TimeSpan -Start (Get-Date) -End $deadline).TotalSeconds)
+    if ($remaining -lt 10) { $remaining = 10 }
+    & kubectl rollout status "deployment/$d" -n $ns "--timeout=${remaining}s" 2>&1 | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+      Ok ("{0} ready" -f ($d -replace "^$ns-", ""))
+    } else {
+      $allReady = $false
+      break
+    }
+  }
+
+  Confirm-Cluster
+  if ($allReady) { $script:ClientState = "connected" }
+  else { $script:ClientState = (Get-NotReadyState -Namespace $ns) }
+}
+
+# Classify why the client isn't Ready, for an accurate message. Returns a state.
+function Get-NotReadyState {
+  param([string]$Namespace)
+  # Wrong credentials: jobs-manager authenticates to the backend on startup and
+  # crash-loops when rejected -- surfaced as an auth error in its logs.
+  $jmLogs = (& kubectl logs -n $Namespace "deployment/$Namespace-jobs-manager" --all-containers --tail=50 2>$null | Out-String)
+  if ($jmLogs -match '(?i)authentication failed|unable to log in') { return "bad_creds" }
+  $pods = (& kubectl get pods -n $Namespace 2>$null | Out-String)
+  if ($pods -match '(?i)ImagePullBackOff|ErrImagePull|InvalidImageName') { return "image_pull" }
+  if ($pods -match '(?i)CrashLoopBackOff') { return "crash" }
+  return "starting"
 }
 
 # =============================================================================
 #  SUMMARY
 # =============================================================================
 
+# Reports the outcome based on $script:ClientState (set by Wait-ForClientReady).
+# The "secure compute environment / your data never leaves" claim is printed
+# ONLY when the client is verifiably connected -- never on a partial/failed run.
 function Print-Summary {
   $mode = "CPU"
   if ($GPU_VENDOR -eq "nvidia" -and $NVIDIA_DRIVER_OK) { $mode = "NVIDIA GPU" }
   elseif ($GPU_VENDOR -eq "nvidia" -and -not $NVIDIA_DRIVER_OK) { $mode = "CPU (NVIDIA driver update needed)" }
+  $ns = $script:TB_NAMESPACE
+  $line = [string]([char]0x2501) * 46
 
   Write-Host ""
-  Write-Host "  " -NoNewline; Write-Host ([string]([char]0x2501) * 46) -ForegroundColor Green
-  Write-Host ""
-  Write-Host "  " -NoNewline; Write-Host "tracebloc client installed successfully" -ForegroundColor Green
-  Write-Host ""
-  Write-Host "  " -NoNewline; Write-Host "Workspace" -ForegroundColor White -NoNewline; Write-Host " : " -NoNewline; Write-Host $TB_NAMESPACE -ForegroundColor Cyan
-  Write-Host "  " -NoNewline; Write-Host "Mode     " -ForegroundColor White -NoNewline; Write-Host " : " -NoNewline; Write-Host $mode -ForegroundColor Cyan
-  Write-Host ""
-  Hint "This machine is now a secure compute environment"
-  Hint "on the tracebloc network. External AI vendors can"
-  Hint "submit models to be trained and evaluated here --"
-  Hint "your data never leaves your infrastructure."
-  Write-Host ""
-  Write-Host "  What to do next" -ForegroundColor White
-  Write-Host ""
-  Write-Host "  1. " -NoNewline; Write-Host "Open the tracebloc dashboard"
-  Write-Host "     " -NoNewline; Write-Host "https://ai.tracebloc.io" -ForegroundColor Cyan
-  Write-Host ""
-  Write-Host "  2. " -NoNewline; Write-Host "Ingest your training and test data"
-  Write-Host ""
-  Write-Host "  3. " -NoNewline; Write-Host "Define your first AI use case and"
-  Write-Host "     invite vendors to submit models"
-  Write-Host ""
-  Hint "Need help?  https://docs.tracebloc.io"
-  Hint "Logs:       ~\.tracebloc\"
-  Hint "Data:       /tracebloc/$TB_NAMESPACE"
-  Write-Host ""
-  Write-Host "  " -NoNewline; Write-Host ([string]([char]0x2501) * 46) -ForegroundColor Green
+  switch ($script:ClientState) {
+    "connected" {
+      Write-Host "  $line" -ForegroundColor Green
+      Write-Host ""
+      Write-Host "  " -NoNewline; Write-Host "$([char]0x2714) Connected to tracebloc" -ForegroundColor Green
+      Write-Host ""
+      Write-Host "  Workspace : " -NoNewline; Write-Host $ns -ForegroundColor Cyan
+      Write-Host "  Mode      : " -NoNewline; Write-Host $mode -ForegroundColor Cyan
+      Write-Host ""
+      Write-Host "  Your client is live. Confirm it shows as Online:"
+      Write-Host "    https://ai.tracebloc.io/clients" -ForegroundColor Cyan
+      Write-Host ""
+      Hint "Models that vendors submit train on this machine -- your data never leaves it."
+      Write-Host ""
+      Write-Host "  What to do next" -ForegroundColor White
+      Write-Host "  1. Ingest your training and test data"
+      Write-Host "  2. Define your first AI use case and invite vendors"
+      Write-Host ""
+      Hint "Dashboard: https://ai.tracebloc.io   Logs: ~\.tracebloc\   Data: /tracebloc/$ns"
+      Write-Host ""
+      Write-Host "  $line" -ForegroundColor Green
+    }
+    "starting" {
+      Write-Host "  " -NoNewline; Write-Host "$([char]0x26A0)  Almost there - tracebloc is installed but still starting." -ForegroundColor Yellow
+      Write-Host ""
+      Write-Host "  Components are still downloading/starting (first run can take a few minutes)."
+      Write-Host "  Check progress:   kubectl get pods -n $ns" -ForegroundColor Cyan
+      Write-Host ""
+      Write-Host "  Your client will show as Online at https://ai.tracebloc.io/clients once it finishes."
+      Hint "Re-running this installer is safe."
+    }
+    "bad_creds" {
+      Write-Host "  " -NoNewline; Write-Host "$([char]0x2716) Couldn't connect - your Client ID or password was rejected." -ForegroundColor Red
+      Write-Host ""
+      Write-Host "  The environment installed, but tracebloc refused those credentials."
+      Write-Host "    1. Re-check them at https://ai.tracebloc.io/clients" -ForegroundColor Cyan
+      Write-Host "    2. Re-run this installer (safe to re-run)"
+    }
+    default {
+      $reason = "a component didn't start"
+      if ($script:ClientState -eq "image_pull") { $reason = "an image couldn't be pulled" }
+      if ($script:ClientState -eq "crash")      { $reason = "a container is restarting (crash loop)" }
+      Write-Host "  " -NoNewline; Write-Host "$([char]0x2716) Setup didn't finish - $reason." -ForegroundColor Red
+      Write-Host ""
+      Write-Host "  Inspect:  kubectl get pods -n $ns" -ForegroundColor Cyan
+      Write-Host "  Logs:     ~\.tracebloc\install-*.log"
+      Hint "Re-running this installer is safe."
+    }
+  }
   Write-Host ""
 
   # Advanced info for log only
@@ -1077,6 +1213,8 @@ function Print-Summary {
 # =============================================================================
 #  MAIN
 # =============================================================================
+
+if (-not $env:TB_PESTER) {
 
 if ($Help) { Print-Help }
 
@@ -1105,7 +1243,13 @@ Confirm-GpuNode
 # -- Steps 3/4 + 4/4 handled inside Install-ClientHelm --
 Install-ClientHelm
 
-Confirm-Cluster
+# Verify the client actually came up before reporting anything
+Wait-ForClientReady
 Print-Summary
 
 try { Stop-Transcript | Out-Null } catch {}
+
+# Exit code reflects reality: connected/starting are OK; failures are non-zero.
+if ($script:ClientState -ne "connected" -and $script:ClientState -ne "starting") { exit 1 }
+
+}  # end TB_PESTER guard (skipped when the test suite dot-sources this file)

--- a/scripts/install-k8s.sh
+++ b/scripts/install-k8s.sh
@@ -40,6 +40,7 @@ LIB_DIR="${SCRIPT_DIR}/lib"
 
 # ── Source modules ───────────────────────────────────────────────────────────
 source "${LIB_DIR}/common.sh"
+source "${LIB_DIR}/preflight.sh"
 source "${LIB_DIR}/detect-gpu.sh"
 source "${LIB_DIR}/gpu-nvidia.sh"
 source "${LIB_DIR}/gpu-amd.sh"
@@ -63,6 +64,7 @@ main() {
 
   # ── Step 1/4: Check system requirements ──────────────────────────────────
   step 1 4 "Checking system requirements"
+  run_preflight
   detect_gpu
 
   case "$OS" in

--- a/scripts/install-k8s.sh
+++ b/scripts/install-k8s.sh
@@ -50,12 +50,17 @@ source "${LIB_DIR}/cluster.sh"
 source "${LIB_DIR}/gpu-plugins.sh"
 source "${LIB_DIR}/install-client-helm.sh"
 source "${LIB_DIR}/summary.sh"
+source "${LIB_DIR}/diagnose.sh"
 
 trap install_cleanup EXIT
 
 # ── Main ─────────────────────────────────────────────────────────────────────
 main() {
   [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && print_help
+  # Support bundle: collect redacted diagnostics and exit, before any install
+  # work (so it works even when the install is broken). Clear the EXIT trap so
+  # the post-install cleanup message doesn't fire after a diagnose run.
+  [[ "${1:-}" == "--diagnose" ]] && { trap - EXIT; run_diagnose; exit $?; }
 
   validate_config
   setup_log_file

--- a/scripts/install-k8s.sh
+++ b/scripts/install-k8s.sh
@@ -83,8 +83,16 @@ main() {
   # ── Step 3/4 + 4/4 are handled inside install_client_helm ────────────────
   install_client_helm
 
-  verify_cluster
+  # ── Verify the client actually came up before reporting anything ─────────
+  wait_for_client_ready
   print_summary
+
+  # Exit code reflects reality: connected/starting are OK; failures are non-zero
+  # so re-runs and automation can tell the difference.
+  case "${CLIENT_STATE:-}" in
+    connected|starting) ;;
+    *) exit 1 ;;
+  esac
 }
 
 main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,6 +33,7 @@ mkdir -p "$TMPDIR/lib"
 FILES=(
   "scripts/install-k8s.sh"
   "scripts/lib/common.sh"
+  "scripts/lib/preflight.sh"
   "scripts/lib/detect-gpu.sh"
   "scripts/lib/gpu-nvidia.sh"
   "scripts/lib/gpu-amd.sh"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,6 +43,7 @@ FILES=(
   "scripts/lib/gpu-plugins.sh"
   "scripts/lib/install-client-helm.sh"
   "scripts/lib/summary.sh"
+  "scripts/lib/diagnose.sh"
 )
 
 download_with_retry() {

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -291,8 +291,10 @@ _create_new_cluster() {
 
   local create_out create_rc
   create_out="$(mktemp)"
-  k3d "${K3D_ARGS[@]}" >"$create_out" 2>&1
-  create_rc=$?
+  # Capture the exit code WITHOUT tripping `set -e`: a bare failing command here
+  # would abort the script immediately, skipping the 'already exists' reuse path,
+  # the error dump, and the temp-dir cleanup below.
+  k3d "${K3D_ARGS[@]}" >"$create_out" 2>&1 && create_rc=0 || create_rc=$?
   [[ -n "$proxy_cfg" ]] && rm -rf "${proxy_cfg%/*}"
   if [[ $create_rc -ne 0 ]]; then
     if grep -qi "already exists\|a cluster with that name already exists" "$create_out" 2>/dev/null; then

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -45,6 +45,75 @@ _ensure_release_dirs() {
   chmod -R 777 "$base/data" "$base/logs" "$base/mysql" 2>/dev/null || true
 }
 
+# --- Corporate-proxy support (authenticated proxies + NO_PROXY hardening) ----
+# Cluster-internal destinations that must NEVER be routed through a corporate
+# proxy: loopback, all RFC1918 private ranges (covers the k3s pod CIDR
+# 10.42.0.0/16, the service CIDR 10.43.0.0/16, the k3d docker network and node
+# IPs in one shot), and the in-cluster DNS suffixes. Sending this traffic out to
+# the proxy misroutes in-cluster calls AND makes `k3d cluster create --wait`
+# hang. We union these into whatever NO_PROXY the host set. (A tenant that needs
+# a *proxied* private-IP destination can narrow this; tracebloc itself only
+# pulls from public registries + dials public api.tracebloc.io, so the broad
+# bypass is safe for the isolated VM the client runs on.)
+TB_NO_PROXY_DEFAULTS="localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.svc.cluster.local,.cluster.local,host.k3d.internal"
+
+# Echo an effective NO_PROXY = host NO_PROXY/no_proxy ∪ TB_NO_PROXY_DEFAULTS,
+# de-duplicated with first-seen order preserved (host entries first).
+_augment_no_proxy() {
+  local existing="${NO_PROXY:-${no_proxy:-}}"
+  printf '%s,%s' "$existing" "$TB_NO_PROXY_DEFAULTS" \
+    | awk -v RS=',' '{ gsub(/[ \t\r\n]/, ""); if ($0 != "" && !seen[$0]++) printf "%s%s", (n++ ? "," : ""), $0 }'
+}
+
+# Build a k3d config file that carries the proxy env vars as structured YAML
+# entries, and echo its path. We use --config rather than --env KEY=VALUE@FILTER
+# because k3d splits the --env flag on '@', which corrupts authenticated-proxy
+# URLs (http://user:pass@host); the YAML env list has no such ambiguity, so
+# credentials survive intact. NO_PROXY is always emitted (auto-augmented) when a
+# proxy is present, so in-cluster traffic bypasses the proxy even if the host
+# set only HTTP_PROXY. Echoes nothing when the host has no HTTP(S) proxy set.
+_write_k3d_proxy_config() {
+  local var have_http=""
+  for var in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy; do
+    [[ -n "${!var:-}" ]] && have_http=1
+  done
+  [[ -z "$have_http" ]] && return 0
+
+  local no_proxy_val; no_proxy_val="$(_augment_no_proxy)"
+  # mktemp -d with trailing X's is portable across GNU + BSD/macOS mktemp; a
+  # plain file template with a '.yaml' suffix is not (BSD needs trailing X's),
+  # and k3d/viper needs the '.yaml' extension to parse the config — so the file
+  # lives inside a temp dir. Caller removes the dir.
+  local td; td="$(mktemp -d "${TMPDIR:-/tmp}/tracebloc-k3d-XXXXXX")" || return 0
+  local cfg="$td/config.yaml"
+  {
+    echo "apiVersion: k3d.io/v1alpha5"
+    echo "kind: Simple"
+    echo "env:"
+    for var in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy; do
+      [[ -z "${!var:-}" ]] && continue
+      printf '  - envVar: "%s=%s"\n    nodeFilters:\n      - all\n' "$var" "${!var}"
+    done
+    printf '  - envVar: "NO_PROXY=%s"\n    nodeFilters:\n      - all\n' "$no_proxy_val"
+    printf '  - envVar: "no_proxy=%s"\n    nodeFilters:\n      - all\n' "$no_proxy_val"
+  } > "$cfg"
+  echo "$cfg"
+}
+
+# When a proxy is configured, ensure THIS installer's own kubectl/helm/curl
+# bypass it for the cluster API (127.0.0.1) and the in-cluster ranges. Go
+# already auto-bypasses loopback, but exporting NO_PROXY also covers helm/curl.
+_export_host_no_proxy() {
+  local var
+  for var in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy; do
+    if [[ -n "${!var:-}" ]]; then
+      local aug; aug="$(_augment_no_proxy)"
+      export NO_PROXY="$aug" no_proxy="$aug"
+      return 0
+    fi
+  done
+}
+
 create_cluster() {
   log "Creating k3d cluster: '$CLUSTER_NAME'"
 
@@ -57,6 +126,7 @@ create_cluster() {
   fi
 
   _merge_kubeconfig
+  _export_host_no_proxy
   _wait_for_api
 }
 
@@ -82,50 +152,21 @@ _handle_existing_cluster() {
   fi
 
   _check_existing_cluster_proxy
+  _check_existing_cluster_bind
 }
 
-# k3d bakes --env flags into containers at create time; they cannot be added
-# to a running cluster. Per-var check: for each proxy var set on the host,
-# verify the cluster has it. Detect NO_PROXY-only drift too (an older cluster
-# may have HTTP_PROXY baked in but be missing a NO_PROXY the host has since
-# added — without it, in-cluster traffic to .svc/.cluster.local or 127.0.0.1
-# can get routed through the proxy).
-# Silent no-op if Docker isn't running, the server container can't be inspected,
-# or the host has no proxy env set.
+# k3d bakes proxy env into containers at create time; it cannot be added to a
+# running cluster. For each proxy var set on the host, verify the existing
+# cluster has it, and warn (with the recreate remedy) on drift. Authenticated
+# proxies are now propagated like any other var (via _write_k3d_proxy_config),
+# so there is no longer a separate '@' bucket. Silent no-op if Docker isn't
+# running, the server container can't be inspected, or no proxy env is set.
 _check_existing_cluster_proxy() {
-  # Partition host proxy vars into two buckets:
-  #   • drift_candidates — values without '@' that would propagate cleanly;
-  #                        the cluster should have these, flag if missing.
-  #   • at_skipped       — values with '@' that _create_new_cluster refused
-  #                        to propagate (k3d's KEY=VALUE@FILTER conflict).
-  #                        Recreating wouldn't help — needs a different
-  #                        remedy (strip creds, use auth proxy).
-  local drift_candidates=() at_skipped=()
+  local var candidates=()
   for var in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
-    local val="${!var:-}"
-    [[ -z "$val" ]] && continue
-    if [[ "$val" == *"@"* ]]; then
-      at_skipped+=("$var")
-    else
-      drift_candidates+=("$var")
-    fi
+    [[ -n "${!var:-}" ]] && candidates+=("$var")
   done
-
-  # @-skipped vars get their own warning that fires on every re-run (the
-  # create-time skip warning in _create_new_cluster doesn't fire on the
-  # existing-cluster path). Recreate alone won't bake them, so guide the
-  # user toward the remedies that actually work.
-  if [[ ${#at_skipped[@]} -gt 0 ]]; then
-    echo ""
-    warn "Proxy env on host contains '@' (likely embedded credentials): ${at_skipped[*]}."
-    hint "k3d's --env KEY=VALUE@FILTER syntax can't carry an '@' in the value, so these"
-    hint "are not propagated into the cluster. If image pulls fail:"
-    hint "  • strip credentials from the URL (configure auth inside the cluster), or"
-    hint "  • point HTTP(S)_PROXY at a credential-less local auth-proxy that fronts the corporate proxy."
-    echo ""
-  fi
-
-  [[ ${#drift_candidates[@]} -eq 0 ]] && return 0
+  [[ ${#candidates[@]} -eq 0 ]] && return 0
 
   local server_container="k3d-${CLUSTER_NAME}-server-0"
   local cluster_env
@@ -133,17 +174,35 @@ _check_existing_cluster_proxy() {
   [[ -z "$cluster_env" ]] && return 0
 
   local missing=()
-  for var in "${drift_candidates[@]}"; do
-    if ! echo "$cluster_env" | grep -Eq "^${var}="; then
-      missing+=("$var")
-    fi
+  for var in "${candidates[@]}"; do
+    echo "$cluster_env" | grep -Eq "^${var}=" || missing+=("$var")
   done
 
   if [[ ${#missing[@]} -gt 0 ]]; then
     echo ""
     warn "Host has proxy env set, but the existing '$CLUSTER_NAME' cluster is missing: ${missing[*]}."
-    hint "k3d bakes --env flags into containers at create time — they can't be added to a running cluster."
+    hint "k3d bakes proxy settings into containers at create time — they can't be added to a running cluster."
     hint "If image pulls fail or in-cluster traffic misroutes, recreate the cluster:"
+    hint "  k3d cluster delete $CLUSTER_NAME  &&  re-run this installer."
+    echo ""
+  fi
+}
+
+# An externally-created cluster may bind its API to 0.0.0.0 rather than the
+# 127.0.0.1 this installer uses. _merge_kubeconfig normalizes the kubeconfig
+# (→127.0.0.1) so reuse still works, but we warn so the user understands their
+# cluster differs and how to rebuild it loopback-bound if a TLS/HTTP proxy still
+# intercepts external kubectl. Silent no-op if the serverlb can't be inspected.
+_check_existing_cluster_bind() {
+  local binds
+  binds=$(docker inspect "k3d-${CLUSTER_NAME}-serverlb" \
+    --format '{{range $p, $conf := .NetworkSettings.Ports}}{{range $conf}}{{.HostIp}} {{end}}{{end}}' 2>/dev/null) || return 0
+  [[ -z "$binds" ]] && return 0
+  if grep -qw '0\.0\.0\.0' <<<"$binds" && ! grep -qw '127\.0\.0\.1' <<<"$binds"; then
+    echo ""
+    warn "The existing '$CLUSTER_NAME' cluster binds its API to 0.0.0.0 (created outside this installer)."
+    hint "This installer binds clusters to 127.0.0.1; behind a corporate proxy a 0.0.0.0 bind can be intercepted."
+    hint "Your kubeconfig is normalized to 127.0.0.1 so reuse works. If kubectl is still intercepted, rebuild it:"
     hint "  k3d cluster delete $CLUSTER_NAME  &&  re-run this installer."
     echo ""
   fi
@@ -184,30 +243,27 @@ _create_new_cluster() {
   fi
   hint "First run may take 1-2 minutes to download components."
 
-  # Propagate corporate proxy env vars so k3s/k3d containers can reach external
-  # registries behind HTTP/HTTPS proxies (hospital/banking/government tenants).
-  # Loop checks both upper- and lower-case forms — apps in containers read either.
-  # k3d's --env syntax is KEY=VALUE@NODEFILTER; an embedded '@' in VALUE (e.g.
-  # credentials in URL: http://user:pass@host) collides with the filter
-  # delimiter and breaks `k3d cluster create`. Detect and skip with a warning;
-  # the user can strip creds and re-run, or supply creds via another mechanism.
-  for var in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
-    val="${!var:-}"
-    if [[ -n "$val" ]]; then
-      if [[ "$val" == *"@"* ]]; then
-        warn "Skipping ${var} propagation: value contains '@' (embedded credentials are not supported by k3d's --env filter syntax)."
-        hint "Strip credentials from the URL, or configure proxy auth inside the cluster after install."
-        continue
-      fi
-      K3D_ARGS+=(--env "${var}=${val}@all")
-      log "Propagating ${var} to k3d nodes."
-    fi
-  done
+  # Propagate corporate proxy env so k3s/containerd can reach external registries
+  # behind an HTTP/HTTPS proxy (hospital/banking/government tenants). Passed via a
+  # k3d --config file rather than --env: k3d splits --env on '@', which corrupts
+  # authenticated-proxy URLs (http://user:pass@host), whereas the YAML env list in
+  # a config file preserves them. NO_PROXY is auto-augmented with the cluster-
+  # internal ranges so in-cluster traffic never traverses the proxy (which would
+  # otherwise misroute it and hang `k3d cluster create --wait`). k3d merges the
+  # --config env with these CLI flags (verified on k3d v5.8.3).
+  local proxy_cfg
+  proxy_cfg="$(_write_k3d_proxy_config)"
+  if [[ -n "$proxy_cfg" ]]; then
+    K3D_ARGS+=(--config "$proxy_cfg")
+    log "Propagating proxy settings to k3d nodes (authenticated proxies supported; NO_PROXY auto-augmented)."
+  fi
 
   local create_out create_rc
   create_out="$(mktemp)"
-  if ! k3d "${K3D_ARGS[@]}" >"$create_out" 2>&1; then
-    create_rc=$?
+  k3d "${K3D_ARGS[@]}" >"$create_out" 2>&1
+  create_rc=$?
+  [[ -n "$proxy_cfg" ]] && rm -rf "${proxy_cfg%/*}"
+  if [[ $create_rc -ne 0 ]]; then
     if grep -qi "already exists\|a cluster with that name already exists" "$create_out" 2>/dev/null; then
       log "Cluster '$CLUSTER_NAME' already exists (detected from k3d message). Using existing cluster."
       rm -f "$create_out"
@@ -282,6 +338,6 @@ _wait_for_api() {
   kc="${kc%%:*}"
   error "kubectl cluster-info failed for 60s. Cluster reports running, but the API is unreachable. Possible causes:
    (a) Docker daemon stopped (run 'docker ps' to verify);
-   (b) corporate HTTP/HTTPS proxy intercepting localhost — ensure NO_PROXY includes '127.0.0.1,localhost';
+   (b) corporate HTTP/HTTPS proxy intercepting localhost — this installer auto-adds 127.0.0.1/localhost + private ranges to NO_PROXY; a custom proxy wrapper may still override it;
    (c) kubeconfig has 0.0.0.0 — try: sed -i.bak 's|0.0.0.0|127.0.0.1|g' ${kc} && rm ${kc}.bak"
 }

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -125,9 +125,40 @@ create_cluster() {
     _create_new_cluster
   fi
 
+  ensure_cluster_autostart
   _merge_kubeconfig
   _export_host_no_proxy
   _wait_for_api
+}
+
+# Guarantee the cluster returns after a host reboot. On Linux this already works
+# by default — k3d sets `--restart unless-stopped` on its node containers and the
+# Docker install enables docker.service on boot — but we harden both so it holds
+# even on a re-run where Docker was installed-but-disabled, or for an externally-
+# created cluster. On macOS/Windows the restart policy is set too, but Docker
+# Desktop must be configured to start on login (the summary tells the user).
+# Opt out with TRACEBLOC_NO_AUTOSTART=1.
+ensure_cluster_autostart() {
+  if [[ -n "${TRACEBLOC_NO_AUTOSTART:-}" ]]; then return 0; fi
+
+  local nodes node
+  nodes=$(docker ps -a --filter "name=k3d-${CLUSTER_NAME}-" --format '{{.Names}}' 2>/dev/null) || return 0
+  if [[ -n "$nodes" ]]; then
+    for node in $nodes; do
+      docker update --restart unless-stopped "$node" >/dev/null 2>&1 || true
+    done
+    log "Set restart=unless-stopped on k3d nodes so the cluster returns after a reboot."
+  fi
+
+  # On Linux, make sure Docker itself starts on boot. The fresh-install path only
+  # enables docker.service when Docker was absent; this also covers the
+  # installed-but-disabled re-run case. Idempotent.
+  if [[ "$OS" == "Linux" ]] && has systemctl; then
+    if sudo systemctl enable docker >/dev/null 2>&1; then
+      log "Ensured docker.service is enabled on boot."
+    fi
+  fi
+  return 0
 }
 
 _handle_existing_cluster() {

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -299,10 +299,14 @@ install_cleanup() {
     fi
     [[ -n "${LOG_FILE:-}" ]] && hint "Logs: $LOG_FILE"
   elif [[ $exit_code -ne 0 ]]; then
-    echo ""
-    warn "Installation did not complete."
-    [[ -n "${LOG_FILE:-}" ]] && hint "Check the install log: $LOG_FILE"
-    hint "This installer is safe to re-run — just try again."
+    # If print_summary already reported a specific outcome (CLIENT_STATE set),
+    # don't tack on a second, generic "did not complete" message.
+    if [[ -z "${CLIENT_STATE:-}" ]]; then
+      echo ""
+      warn "Installation did not complete."
+      [[ -n "${LOG_FILE:-}" ]] && hint "Check the install log: $LOG_FILE"
+      hint "This installer is safe to re-run — just try again."
+    fi
   fi
 }
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -351,7 +351,13 @@ tracebloc — client setup
 
 Usage:
   curl -fsSL https://raw.githubusercontent.com/tracebloc/client/main/scripts/install.sh | bash
-  ./install-k8s.sh [--help]
+  ./install-k8s.sh [--help] [--diagnose]
+
+Commands:
+  --diagnose     Collect a redacted support bundle (logs + cluster/host status)
+                 into ~/.tracebloc/tracebloc-diagnose-<timestamp>.tgz and exit.
+                 Run this if something went wrong, then send the file to support
+                 (passwords and proxy credentials are removed before it is written).
 
 Advanced configuration (environment variables):
   CLUSTER_NAME   Cluster name                   (default: tracebloc)

--- a/scripts/lib/diagnose.sh
+++ b/scripts/lib/diagnose.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  diagnose.sh — `--diagnose` support bundle
+#
+#  Collects logs + cluster/host status into ONE redacted archive the customer
+#  can send to support, collapsing multi-round triage into a single file.
+#
+#  Two guarantees:
+#   • Best-effort — works even when the install is broken (the whole collection
+#     runs under `set +e`; every section is independent).
+#   • Credential-safe — clientPassword, proxy credentials (user:pass@host), and
+#     password=/token/secret values are redacted from EVERY file before it is
+#     archived. clientId is kept (it's the identifier support needs, not a secret).
+#
+#  Side-effect-safe to source (function definitions only).
+# =============================================================================
+
+# Redact secrets from a file IN PLACE. Applied to every collected file before
+# archiving. `sed -i.bak` + `rm .bak` is portable across GNU and BSD/macOS sed.
+_redact_file() {
+  local f="$1"
+  [[ -f "$f" ]] || return 0
+  # Case-insensitive via explicit classes (BSD/macOS sed has no `I` flag). The
+  # first rule redacts ANY *password key (clientPassword, dockerRegistry
+  # `password:`, HTTP_PROXY_PASSWORD, …) in either `:` or `=` form — not just
+  # clientPassword — so registry/proxy/db passwords don't leak into the bundle.
+  sed -i.bak -E \
+    -e 's/([A-Za-z0-9_.-]*[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd][[:space:]]*[:=][[:space:]]*).*/\1[REDACTED]/' \
+    -e 's#([a-zA-Z][a-zA-Z0-9+.-]*://)[^:/@[:space:]]+:[^@/[:space:]]+@#\1[REDACTED]@#g' \
+    -e 's/(([Tt][Oo][Kk][Ee][Nn]|[Ss][Ee][Cc][Rr][Ee][Tt]|[Aa][Uu][Tt][Hh][Oo][Rr][Ii][Zz][Aa][Tt][Ii][Oo][Nn]|[Aa][Pp][Ii][_-]?[Kk][Ee][Yy])[[:space:]]*[:=][[:space:]]*).*/\1[REDACTED]/' \
+    "$f" 2>/dev/null
+  rm -f "${f}.bak" 2>/dev/null
+}
+
+# Redact every regular file under a directory.
+_redact_tree() {
+  local f
+  while IFS= read -r f; do _redact_file "$f"; done < <(find "$1" -type f 2>/dev/null)
+}
+
+run_diagnose() {
+  set +e   # every step is best-effort — never abort the bundle mid-collection
+
+  local ts base outdir d ns cn
+  ts="$(date +%Y%m%d-%H%M%S 2>/dev/null)"; [[ -z "$ts" ]] && ts="bundle"
+  base="${HOST_DATA_DIR:-$HOME/.tracebloc}"; mkdir -p "$base" 2>/dev/null
+  cn="${CLUSTER_NAME:-tracebloc}"
+  outdir="$(mktemp -d "${TMPDIR:-/tmp}/tracebloc-diag-XXXXXX" 2>/dev/null)"
+  if [[ -z "$outdir" || ! -d "$outdir" ]]; then echo "  diagnose: cannot create a temp directory" >&2; return 1; fi
+  d="$outdir/tracebloc-diagnose-$ts"; mkdir -p "$d/logs"
+
+  info "Collecting diagnostics — this is safe; credentials are redacted before the file is written."
+
+  # Namespace discovery — TB_NAMESPACE isn't set on a standalone diagnose run,
+  # so find the namespace of the jobs-manager pod (falls back to "default").
+  ns="${TB_NAMESPACE:-}"
+  if [[ -z "$ns" ]] && has kubectl; then
+    ns="$(kubectl get pods -A 2>/dev/null | awk '/-jobs-manager/{print $1; exit}')"
+  fi
+  [[ -z "$ns" ]] && ns="default"
+
+  # ── host / versions ──
+  {
+    echo "# tracebloc diagnose ($ts)"
+    echo "OS:   $(uname -s) $(uname -r)"
+    echo "ARCH: $(uname -m)"
+    echo "CLIENT_ENV: ${CLIENT_ENV:-<unset>}   CLUSTER_NAME: $cn   NAMESPACE: $ns"
+    echo; echo "## versions"
+    has k3d     && k3d version
+    has kubectl && kubectl version --client 2>/dev/null
+    has helm    && helm version --short 2>/dev/null
+    has docker  && docker version 2>/dev/null
+    echo; echo "## cpu / mem / disk"
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+      echo "ncpu=$(sysctl -n hw.ncpu 2>/dev/null)  memsize=$(sysctl -n hw.memsize 2>/dev/null)"
+    else
+      echo "nproc=$(nproc 2>/dev/null)"; grep -i MemTotal /proc/meminfo 2>/dev/null
+    fi
+    df -h 2>/dev/null | head -20
+    if has docker; then
+      echo; echo "## docker info"
+      docker info 2>/dev/null | grep -iE 'Server Version|Storage Driver|Docker Root|Operating System|Total Memory|CPUs|Cgroup'
+    fi
+  } > "$d/00-host.txt" 2>&1
+
+  # ── docker / k3d ──
+  {
+    echo "## docker ps -a (k3d nodes)"
+    has docker && docker ps -a --filter "name=k3d-${cn}-" --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}'
+    echo; echo "## k3d cluster list"
+    has k3d && k3d cluster list
+    echo; echo "## node restart policy + proxy env"
+    if has docker; then
+      for c in $(docker ps -a --filter "name=k3d-${cn}-" --format '{{.Names}}' 2>/dev/null); do
+        echo "### $c"
+        docker inspect "$c" --format 'RestartPolicy={{.HostConfig.RestartPolicy.Name}}' 2>/dev/null
+        docker inspect "$c" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | grep -iE 'PROXY'
+      done
+    fi
+  } > "$d/01-docker.txt" 2>&1
+
+  # ── kubectl overview + per-pod detail ──
+  if has kubectl; then
+    {
+      echo "## nodes";        kubectl get nodes -o wide 2>&1
+      echo; echo "## pods (all namespaces)"; kubectl get pods -A -o wide 2>&1
+      echo; echo "## workloads"; kubectl get deploy,ds,sts -A 2>&1
+      echo; echo "## recent events"; kubectl get events -A --sort-by=.lastTimestamp 2>&1 | tail -120
+    } > "$d/02-kubectl.txt" 2>&1
+    {
+      echo "## describe of non-Running pods in namespace '$ns'"
+      for p in $(kubectl get pods -n "$ns" --no-headers 2>/dev/null | awk '$3!="Running" && $3!="Completed"{print $1}'); do
+        echo; echo "### $p"; kubectl describe pod -n "$ns" "$p" 2>&1
+      done
+    } > "$d/03-describe.txt" 2>&1
+    # workload logs (current + previous)
+    local w
+    for w in mysql-client "${ns}-jobs-manager" "${ns}-requests-proxy"; do
+      kubectl logs -n "$ns" "deploy/$w" --all-containers --tail=500           > "$d/logs/${w}.log" 2>&1
+      kubectl logs -n "$ns" "deploy/$w" --all-containers --previous --tail=500 > "$d/logs/${w}.previous.log" 2>&1
+    done
+    kubectl logs -n "$ns" "daemonset/tracebloc-resource-monitor" --tail=300   > "$d/logs/resource-monitor.log" 2>&1
+  fi
+
+  # ── helm (redacted afterwards) ──
+  if has helm; then
+    # NOTE: deliberately NOT collecting `helm get manifest` — it renders the
+    # Secret objects with base64-encoded credentials (CLIENT_PASSWORD,
+    # .dockerconfigjson), which the text redaction can't see. `helm get values`
+    # (input values, redacted) + the kubectl output already cover triage.
+    {
+      echo "## helm list -A";          helm list -A 2>&1
+      echo; echo "## helm get values $ns"; helm get values "$ns" -n "$ns" 2>&1
+    } > "$d/04-helm.txt" 2>&1
+  fi
+
+  # ── install artifacts (copied, redacted afterwards) ──
+  cp "$base"/install-*.log "$d/" 2>/dev/null
+  [[ -f "$base/values.yaml" ]] && cp "$base/values.yaml" "$d/values.yaml" 2>/dev/null
+
+  # ── proxy / env ──
+  {
+    echo "## proxy environment"
+    local v
+    for v in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
+      echo "$v=${!v:-<unset>}"
+    done
+  } > "$d/05-proxy.txt" 2>&1
+
+  # ── REDACT every collected file, THEN archive ──
+  _redact_tree "$d"
+
+  local bundle="$base/tracebloc-diagnose-$ts.tgz"
+  tar -czf "$bundle" -C "$outdir" "tracebloc-diagnose-$ts" 2>/dev/null
+  rm -rf "$outdir" 2>/dev/null
+
+  echo ""
+  if [[ -f "$bundle" ]]; then
+    success "Diagnostics saved (credentials redacted):"
+    echo "    $bundle"
+    hint "Send this file to tracebloc support — it has logs + status with passwords removed."
+    return 0
+  fi
+  echo "  Could not create the diagnostics archive." >&2
+  return 1
+}

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -110,6 +110,35 @@ _sanitize_workspace_name() {
   printf '%s' "$sanitized"
 }
 
+# ── Credential verification (#717) ────────────────────────────────────────
+# Resolve the backend base URL the same way jobs-manager does
+# (client-runtime/controller.py: CLIENT_ENV → backend), defaulting to prod.
+_backend_url() {
+  case "${CLIENT_ENV:-prod}" in
+    dev) printf 'https://dev-api.tracebloc.io/' ;;
+    stg) printf 'https://stg-api.tracebloc.io/' ;;
+    *)   printf 'https://api.tracebloc.io/' ;;
+  esac
+}
+
+# Validate the entered Client ID / password against the backend's
+# api-token-auth/ endpoint — the same call jobs-manager makes at runtime —
+# using curl (already a dependency). Echoes: valid | invalid | inactive | unverified.
+verify_credentials() {
+  local client_id="$1" client_password="$2" backend code
+  backend="$(_backend_url)"
+  code=$(curl -sS -m 60 -o /dev/null -w '%{http_code}' \
+    --data-urlencode "username=${client_id}" \
+    --data-urlencode "password=${client_password}" \
+    "${backend}api-token-auth/" 2>/dev/null) || code="000"
+  case "$code" in
+    200) printf 'valid' ;;
+    400) printf 'invalid' ;;
+    401) printf 'inactive' ;;
+    *)   printf 'unverified' ;;   # 429 throttled, 000 unreachable, 5xx, …
+  esac
+}
+
 install_client_helm() {
   # ── Step 3/4: Install tracebloc client ───────────────────────────────────
   step 3 4 "Installing tracebloc client"
@@ -175,25 +204,56 @@ install_client_helm() {
   echo -e "    ${BOLD}${WHITE}https://ai.tracebloc.io/clients${RESET}"
   echo ""
 
-  if [[ -n "$default_client_id" ]]; then
-    read -r -p "  Client ID [${default_client_id}]: " TB_CLIENT_ID_INPUT
-    TB_CLIENT_ID="${TB_CLIENT_ID_INPUT:-$default_client_id}"
-  else
-    read -r -p "  Client ID: " TB_CLIENT_ID
-  fi
-  TB_CLIENT_ID=$(_sanitize_credential "$TB_CLIENT_ID")
-  [[ -z "$TB_CLIENT_ID" ]] && error "Client ID cannot be empty."
+  # Collect + verify credentials. The entered Client ID / password are checked
+  # against the backend (the same api-token-auth/ call jobs-manager makes)
+  # before we deploy, so a wrong credential is caught here — with a re-prompt —
+  # instead of surfacing later as a silently crash-looping pod.
+  local _cred_attempt=0 _cred_max=5 _cred_status
+  while true; do
+    if [[ -n "$default_client_id" ]]; then
+      read -r -p "  Client ID [${default_client_id}]: " TB_CLIENT_ID_INPUT
+      TB_CLIENT_ID="${TB_CLIENT_ID_INPUT:-$default_client_id}"
+    else
+      read -r -p "  Client ID: " TB_CLIENT_ID
+    fi
+    TB_CLIENT_ID=$(_sanitize_credential "$TB_CLIENT_ID")
+    if [[ -z "$TB_CLIENT_ID" ]]; then warn "Client ID cannot be empty."; continue; fi
 
-  if [[ -n "$default_client_password" ]]; then
-    read -r -s -p "  Client password [press Enter to keep existing]: " TB_CLIENT_PASSWORD_INPUT
-    echo ""
-    TB_CLIENT_PASSWORD="${TB_CLIENT_PASSWORD_INPUT:-$default_client_password}"
-  else
-    read -r -s -p "  Client password: " TB_CLIENT_PASSWORD
-    echo ""
-  fi
-  TB_CLIENT_PASSWORD=$(_sanitize_credential "$TB_CLIENT_PASSWORD")
-  [[ -z "$TB_CLIENT_PASSWORD" ]] && error "Client password cannot be empty."
+    if [[ -n "$default_client_password" ]]; then
+      read -r -s -p "  Client password [press Enter to keep existing]: " TB_CLIENT_PASSWORD_INPUT
+      echo ""
+      TB_CLIENT_PASSWORD="${TB_CLIENT_PASSWORD_INPUT:-$default_client_password}"
+    else
+      read -r -s -p "  Client password: " TB_CLIENT_PASSWORD
+      echo ""
+    fi
+    TB_CLIENT_PASSWORD=$(_sanitize_credential "$TB_CLIENT_PASSWORD")
+    if [[ -z "$TB_CLIENT_PASSWORD" ]]; then warn "Client password cannot be empty."; continue; fi
+
+    info "Verifying credentials with tracebloc…"
+    _cred_status=$(verify_credentials "$TB_CLIENT_ID" "$TB_CLIENT_PASSWORD")
+    case "$_cred_status" in
+      valid)
+        success "Credentials verified."
+        break ;;
+      invalid)
+        warn "That Client ID / password was rejected by tracebloc — please re-enter."
+        hint "Find your credentials at https://ai.tracebloc.io/clients" ;;
+      inactive)
+        error "This tracebloc account is not active yet. Check your email for the activation link, then re-run." ;;
+      unverified)
+        warn "Couldn't reach tracebloc to verify your credentials right now — continuing."
+        hint "If they are wrong, your client will stay offline at https://ai.tracebloc.io/clients after install."
+        break ;;
+    esac
+
+    _cred_attempt=$((_cred_attempt + 1))
+    if [[ $_cred_attempt -ge $_cred_max ]]; then
+      error "Too many failed attempts. Double-check your credentials at https://ai.tracebloc.io/clients and re-run."
+    fi
+    # Force an active re-entry on retry (don't silently reuse a rejected default).
+    default_client_id=""; default_client_password=""
+  done
 
   TB_CLIENT_PASSWORD_ESCAPED="${TB_CLIENT_PASSWORD//\'/\'\'}"
 

--- a/scripts/lib/preflight.sh
+++ b/scripts/lib/preflight.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  preflight.sh — fail-fast environment checks (arch, egress, disk, RAM, CPU)
+#
+#  Runs before any install/cluster work. Each check prints a ✔/⚠/✖ line; hard
+#  failures are AGGREGATED so the user sees every problem at once, then we exit
+#  ONCE with a summary. The goal: a run that can't succeed fails in seconds with
+#  a precise, actionable reason instead of a cryptic crash minutes in.
+#
+#  Escape hatches:
+#    TRACEBLOC_SKIP_PREFLIGHT=1   skip all checks
+#    TRACEBLOC_ALLOW_ARM64=1      proceed on arm64 despite amd64-only images
+#
+#  This file is side-effect-safe to source (defaults + function defs only).
+# =============================================================================
+
+# Thresholds (overridable via env — for unusual sites or tests)
+PF_MIN_DISK_GB="${PF_MIN_DISK_GB:-5}"      # hard-fail below this (Linux)
+PF_WARN_DISK_GB="${PF_WARN_DISK_GB:-20}"   # warn below this
+PF_WARN_MEM_GB="${PF_WARN_MEM_GB:-4}"      # warn below this
+PF_MIN_CPU="${PF_MIN_CPU:-2}"              # warn below this
+
+# Non-exiting failure line (common.sh's error() exits; preflight must finish all
+# checks first, so failures print here and are recorded in PF_HARD_FAIL). Writes
+# to stdout (like warn/success/info) so it stays ordered with the hint() lines
+# that follow — only the final aggregated error() writes to stderr.
+_pf_fail_line() { echo -e "  ${RED}✖${RESET} $*"; }
+
+# ── Injectable readers (overridden in bats so checks run without net/df) ─────
+
+# Probe a URL for reachability. Echoes one of: ok|dns|refused|timeout|tls|blocked|nocurl
+# "Reachable" = any HTTP response (200/401/403 all count — TLS + HTTP completed).
+# Respects the caller's HTTP(S)_PROXY env (curl picks it up), so a TLS-inspecting
+# proxy without its CA surfaces here as 'tls'.
+_pf_probe_url() {
+  local url="$1" code ec
+  has curl || { echo "nocurl"; return 0; }
+  code=$(curl -sS $CURL_SECURE -o /dev/null --max-time 8 -w '%{http_code}' "$url" 2>/dev/null) && ec=0 || ec=$?
+  if [[ -n "$code" && "$code" != "000" ]]; then echo "ok"; return 0; fi
+  case "${ec:-1}" in
+    6)     echo "dns" ;;
+    7)     echo "refused" ;;
+    28)    echo "timeout" ;;
+    35|60) echo "tls" ;;
+    *)     echo "blocked" ;;
+  esac
+  return 0
+}
+
+# Free space in KB on the filesystem holding $1.
+_pf_free_kb() { df -Pk "$1" 2>/dev/null | awk 'NR==2 {print $4}'; }
+
+# Total physical RAM in KB.
+_pf_total_mem_kb() {
+  if [[ "$OS" == "Darwin" ]]; then
+    local b; b=$(sysctl -n hw.memsize 2>/dev/null) || b=""
+    [[ -n "$b" ]] && echo $(( b / 1024 ))
+  else
+    awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null
+  fi
+}
+
+# Logical CPU count.
+_pf_ncpu() {
+  if [[ "$OS" == "Darwin" ]]; then
+    sysctl -n hw.ncpu 2>/dev/null
+  else
+    nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null
+  fi
+}
+
+# Docker data root if the daemon is up; else where it will live / a host proxy.
+_pf_docker_root() {
+  if has docker && docker info >/dev/null 2>&1; then
+    docker info --format '{{.DockerRootDir}}' 2>/dev/null || echo "/var/lib/docker"
+  elif [[ "$OS" == "Linux" ]]; then
+    echo "/var/lib/docker"
+  else
+    echo "$HOME"
+  fi
+}
+
+# Backend host per CLIENT_ENV (mirrors install-client-helm.sh::_backend_url;
+# inlined so preflight is self-contained + unit-testable in isolation).
+_pf_backend_host() {
+  case "${CLIENT_ENV:-prod}" in
+    dev) echo "dev-api.tracebloc.io" ;;
+    stg) echo "stg-api.tracebloc.io" ;;
+    *)   echo "api.tracebloc.io" ;;
+  esac
+}
+
+# ── Checks (each ALWAYS returns 0; hard failures go into PF_HARD_FAILS) ───────
+
+# True if the host can run amd64 binaries via QEMU binfmt (wrapped for testing).
+_pf_amd64_emulation_available() { [[ -e /proc/sys/fs/binfmt_misc/qemu-x86_64 ]]; }
+
+_pf_arch() {
+  case "$ARCH" in
+    x86_64|amd64) success "Architecture: ${ARCH} (amd64)"; return 0 ;;
+  esac
+  # Non-amd64 (arm64/aarch64): the tracebloc client images (e.g. mysql-client)
+  # are amd64-only, so they need emulation to run.
+  if [[ -n "${TRACEBLOC_ALLOW_ARM64:-}" ]]; then
+    warn "Architecture: ${ARCH} — proceeding (TRACEBLOC_ALLOW_ARM64 set); amd64-only images may crash if emulation is unavailable."
+    return 0
+  fi
+  if [[ "$OS" != "Linux" ]]; then
+    info "Architecture: ${ARCH} — Docker Desktop runs the amd64 client images under emulation (slower, but works)."
+    return 0
+  fi
+  if _pf_amd64_emulation_available; then
+    info "Architecture: ${ARCH} — amd64 emulation (QEMU binfmt) available; client images run emulated (slower)."
+    return 0
+  fi
+  _pf_fail_line "Architecture: ${ARCH} — the tracebloc client images (e.g. mysql-client) are amd64-only and can't run here."
+  PF_HARD_FAIL=$(( ${PF_HARD_FAIL:-0} + 1 ))
+  hint "Fix: provision an amd64 (x86_64) VM, or enable emulation and re-run:"
+  hint "  docker run --privileged --rm tonistiigi/binfmt --install amd64"
+  hint "  (or set TRACEBLOC_ALLOW_ARM64=1 to proceed anyway)"
+  return 0
+}
+
+_pf_cpu() {
+  local n; n="$(_pf_ncpu)"
+  if [[ -z "$n" ]]; then warn "CPU: couldn't determine core count (skipping)."; return 0; fi
+  if [[ "$n" -lt "$PF_MIN_CPU" ]]; then
+    warn "CPU: ${n} core(s) — recommended ≥ ${PF_MIN_CPU}."
+  else
+    success "CPU: ${n} cores"
+  fi
+  return 0
+}
+
+_pf_memory() {
+  local kb gb; kb="$(_pf_total_mem_kb)"
+  if [[ -z "$kb" ]]; then warn "Memory: couldn't determine total RAM (skipping)."; return 0; fi
+  gb=$(( kb / 1024 / 1024 ))
+  if [[ "$gb" -lt "$PF_WARN_MEM_GB" ]]; then
+    warn "Memory: ${gb} GB total — recommended ≥ ${PF_WARN_MEM_GB} GB; k3s + training may run out of memory."
+  else
+    success "Memory: ${gb} GB"
+  fi
+  return 0
+}
+
+_pf_disk() {
+  local target free_kb free_gb
+  target="$(_pf_docker_root)"
+  if [[ ! -d "$target" ]]; then target="/"; fi
+  if [[ "$OS" != "Linux" ]]; then target="$HOME"; fi   # Desktop VM disk is opaque
+  free_kb="$(_pf_free_kb "$target")"
+  if [[ -z "$free_kb" ]]; then warn "Disk: couldn't determine free space on ${target} (skipping)."; return 0; fi
+  free_gb=$(( free_kb / 1024 / 1024 ))
+  if [[ "$OS" != "Linux" ]]; then
+    info "Disk: ${free_gb} GB free on ${target} (host) — also ensure Docker Desktop's disk image has ≥ ${PF_WARN_DISK_GB} GB."
+    return 0
+  fi
+  if [[ "$free_gb" -lt "$PF_MIN_DISK_GB" ]]; then
+    _pf_fail_line "Disk: only ${free_gb} GB free on ${target} — need ≥ ${PF_MIN_DISK_GB} GB."
+    PF_HARD_FAIL=$(( ${PF_HARD_FAIL:-0} + 1 ))
+    hint "Free up space or attach a larger disk, then re-run."
+  elif [[ "$free_gb" -lt "$PF_WARN_DISK_GB" ]]; then
+    warn "Disk: ${free_gb} GB free on ${target} — recommended ≥ ${PF_WARN_DISK_GB} GB; images + data may fill it."
+  else
+    success "Disk: ${free_gb} GB free on ${target}"
+  fi
+  return 0
+}
+
+_pf_connectivity() {
+  info "Checking outbound connectivity to required services..."
+  local backend_host cfail=0 tls_seen=0 c label url status
+  backend_host="$(_pf_backend_host)"
+
+  # Critical: the install cannot succeed without these (image pulls, creds, chart).
+  local criticals=(
+    "Docker Hub (registry-1.docker.io)|https://registry-1.docker.io/v2/"
+    "GitHub Container Registry (ghcr.io)|https://ghcr.io/"
+    "tracebloc API (${backend_host})|https://${backend_host}/"
+    "tracebloc Helm charts (tracebloc.github.io)|https://tracebloc.github.io/"
+  )
+  for c in "${criticals[@]}"; do
+    label="${c%%|*}"; url="${c#*|}"
+    status="$(_pf_probe_url "$url")"
+    if [[ "$status" != "ok" ]]; then status="$(_pf_probe_url "$url")"; fi   # one retry (transient blips)
+    if [[ "$status" == "ok" ]]; then
+      success "${label} reachable"
+    else
+      _pf_fail_line "${label} unreachable (${status})"
+      PF_HARD_FAIL=$(( ${PF_HARD_FAIL:-0} + 1 ))
+      cfail=$(( cfail + 1 ))
+      if [[ "$status" == "tls" ]]; then tls_seen=1; fi
+    fi
+  done
+
+  # Tool-download hosts: only relevant on Linux when the tool isn't present. Warn-only.
+  if [[ "$OS" == "Linux" ]]; then
+    local conds=()
+    if ! has docker;  then conds+=("Docker install (get.docker.com)|https://get.docker.com/"); fi
+    if ! has k3d;     then conds+=("k3d install (raw.githubusercontent.com)|https://raw.githubusercontent.com/"); fi
+    if ! has kubectl; then conds+=("kubectl (dl.k8s.io)|https://dl.k8s.io/"); fi
+    if ! has helm;    then conds+=("Helm (get.helm.sh)|https://get.helm.sh/"); fi
+    # ${conds[@]+...} guard: expanding an empty array under `set -u` errors on
+    # bash 3.2 (macOS). This expands to nothing when no tools are missing.
+    for c in ${conds[@]+"${conds[@]}"}; do
+      label="${c%%|*}"; url="${c#*|}"
+      status="$(_pf_probe_url "$url")"
+      if [[ "$status" == "ok" ]]; then
+        success "${label} reachable"
+      else
+        warn "${label} unreachable (${status}) — needed only to install that tool."
+      fi
+    done
+  fi
+
+  if [[ "$tls_seen" -eq 1 ]]; then
+    hint "A TLS/certificate error usually means a break-and-inspect (TLS-inspecting) proxy whose corporate CA isn't trusted here — see the proxy notes."
+  fi
+  if [[ "$cfail" -gt 0 ]]; then
+    hint "Allow HTTPS (443) egress to: registry-1.docker.io, ghcr.io, ${backend_host}, tracebloc.github.io — or set HTTP_PROXY if you use a corporate proxy."
+  fi
+  return 0
+}
+
+# ── Orchestrator ─────────────────────────────────────────────────────────────
+run_preflight() {
+  if [[ -n "${TRACEBLOC_SKIP_PREFLIGHT:-}" ]]; then
+    info "Preflight checks skipped (TRACEBLOC_SKIP_PREFLIGHT set)."
+    return 0
+  fi
+  PF_HARD_FAIL=0
+  # '|| true' so a single check returning non-zero can't trip the caller's set -e
+  # before the others run — the aggregated counter below is the source of truth.
+  _pf_arch         || true
+  _pf_cpu          || true
+  _pf_memory       || true
+  _pf_disk         || true
+  _pf_connectivity || true
+
+  if [[ "$PF_HARD_FAIL" -gt 0 ]]; then
+    echo ""
+    error "Preflight failed — resolve the ✖ item(s) above and re-run. (Override at your own risk with TRACEBLOC_SKIP_PREFLIGHT=1.)"
+  fi
+}

--- a/scripts/lib/preflight.sh
+++ b/scripts/lib/preflight.sh
@@ -170,6 +170,13 @@ _pf_disk() {
 
 _pf_connectivity() {
   info "Checking outbound connectivity to required services..."
+  # Can't probe without curl — and on the direct ./install-k8s.sh path the
+  # installer hasn't installed it yet. Skip with a warning rather than hard-fail
+  # with a misleading "egress blocked" (curl is installed downstream).
+  if ! has curl; then
+    warn "Skipping connectivity check — curl isn't available yet (the installer will add it)."
+    return 0
+  fi
   local backend_host cfail=0 tls_seen=0 c label url status
   backend_host="$(_pf_backend_host)"
 

--- a/scripts/lib/setup-linux.sh
+++ b/scripts/lib/setup-linux.sh
@@ -24,6 +24,15 @@ install_docker_engine() {
       spin_cmd "Installing Docker…" sudo pacman -S --noconfirm docker
     elif has zypper; then
       spin_cmd "Installing Docker…" sudo zypper install -y docker
+    elif [[ -f /etc/os-release ]] && grep -qiE '^ID="?(almalinux|rocky|ol|oracle)"?' /etc/os-release; then
+      # get.docker.com rejects RHEL rebuilds (almalinux/rocky/ol) with
+      # "Unsupported distribution". Install docker-ce from Docker's official
+      # CentOS repo instead — it is RHEL-compatible and works on these distros.
+      spin_cmd "Installing Docker…" bash -c '
+        set -e
+        sudo dnf -y -q install dnf-plugins-core
+        sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+        sudo dnf -y -q install docker-ce docker-ce-cli containerd.io'
     else
       local docker_script
       docker_script="$(mktemp)"
@@ -54,9 +63,13 @@ install_docker_engine() {
 
 # ── System dependencies ─────────────────────────────────────────────────────
 install_system_deps() {
+  # conntrack binary ships under different package names per distro:
+  #   Debian/Ubuntu (apt) → "conntrack";  RHEL/SUSE/Arch (dnf/yum/zypper/pacman) → "conntrack-tools"
+  local conntrack_pkg="conntrack-tools"
+  has apt-get && conntrack_pkg="conntrack"
   MISSING_PKGS=()
   has curl      || MISSING_PKGS+=(curl)
-  has conntrack || MISSING_PKGS+=(conntrack-tools)
+  has conntrack || MISSING_PKGS+=("$conntrack_pkg")
   if [[ ${#MISSING_PKGS[@]} -gt 0 ]]; then
     spin_cmd "Updating package index…" $PM_UPDATE
     for pkg in "${MISSING_PKGS[@]}"; do
@@ -107,7 +120,11 @@ install_k3d() {
     https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh -o "$k3d_script"
   chmod +x "$k3d_script"
 
-  if ! spin_cmd "Installing system tools…" sudo bash "$k3d_script"; then
+  # Preserve PATH through sudo: the k3d install script verifies itself with
+  # `command -v k3d` after copying the binary into /usr/local/bin. On RHEL-family
+  # distros sudo's secure_path excludes /usr/local/bin, so that check fails and
+  # the script aborts with "k3d not found". `sudo env PATH=$PATH` keeps it visible.
+  if ! spin_cmd "Installing system tools…" sudo env "PATH=$PATH" bash "$k3d_script"; then
     rm -f "$k3d_script"
     error "System tool installation failed. See the install log for details."
   fi

--- a/scripts/lib/setup-linux.sh
+++ b/scripts/lib/setup-linux.sh
@@ -14,6 +14,45 @@ setup_pm() {
   else error "No supported package manager found."; fi
 }
 
+# ── Kernel modules Docker + k3s need ─────────────────────────────────────────
+# Docker's bridge driver programs iptables NAT rules using the `addrtype` match
+# (xt_addrtype), and k3s needs br_netfilter + overlay. On minimal RHEL/AlmaLinux
+# cloud images (e.g. AWS EC2) these netfilter modules ship in kernel-modules-EXTRA,
+# which is NOT installed by default (the base kernel-modules package does NOT
+# carry xt_addrtype/iptable_nat/br_netfilter) — so dockerd dies on startup with
+# "iptables … addrtype … missing kernel module". Install kernel-modules-extra,
+# (re)load the modules, and persist them for reboots. Best-effort + idempotent.
+#
+# Caveat: kernel-modules-extra is only published for the repo's CURRENT kernel.
+# If the running kernel is older (image hasn't been rebooted into the latest
+# kernel yet), dnf installs the modules for the NEW kernel and they can't be
+# modprobe'd until a reboot. We flag that (KMODS_REBOOT_REQUIRED) so the caller
+# can tell the user to reboot + re-run; the modules-load.d entry then activates
+# them on boot.
+_ensure_kernel_modules() {
+  local mods="overlay br_netfilter xt_addrtype iptable_nat ip_tables"
+  local m missing=""
+  for m in $mods; do sudo modprobe "$m" 2>/dev/null || missing=1; done
+  if [[ -n "$missing" ]] && has dnf; then
+    # The netfilter modules live in kernel-modules-extra, NOT the base
+    # kernel-modules package. Install unversioned so dnf pulls the extra set
+    # (and a matching newer kernel, if the repo has moved on) for the current repo.
+    spin_cmd "Installing kernel modules for Docker/k3s…" \
+      sudo dnf install -y -q kernel-modules-extra || true
+    missing=""
+    for m in $mods; do sudo modprobe "$m" 2>/dev/null || missing=1; done
+  fi
+  printf '%s\n' $mods | sudo tee /etc/modules-load.d/tracebloc.conf >/dev/null 2>&1 || true
+
+  # Still unloadable, but the module file exists for a DIFFERENT (installed but
+  # not-yet-booted) kernel → a reboot will bring it in via modules-load.d.
+  if [[ -n "$missing" ]] \
+     && ! find "/lib/modules/$(uname -r)" -name 'xt_addrtype.ko*' 2>/dev/null | grep -q . \
+     &&   find /lib/modules                -name 'xt_addrtype.ko*' 2>/dev/null | grep -q .; then
+    KMODS_REBOOT_REQUIRED=1
+  fi
+}
+
 # ── Docker Engine ────────────────────────────────────────────────────────────
 install_docker_engine() {
   if ! has docker; then
@@ -41,20 +80,57 @@ install_docker_engine() {
       spin_cmd "Installing Docker…" sudo bash "$docker_script"
       rm -f "$docker_script"
     fi
-    sudo systemctl enable --now docker
+    # Enable for boot only (no --now): starting is handled below, where a start
+    # failure is diagnosed instead of aborting the whole script under `set -e`.
+    sudo systemctl enable docker >/dev/null 2>&1 || true
     sudo usermod -aG docker "$USER"
     success "Docker"
   else
     success "Docker"
   fi
 
+  # Load the kernel modules dockerd's bridge driver + k3s need BEFORE starting,
+  # so minimal RHEL/AlmaLinux images don't fail with the "addrtype" iptables error.
+  _ensure_kernel_modules
+
+  # Clear any failed/throttled state from a previous attempt first — a crashed
+  # daemon leaves the unit in "Start request repeated too quickly", which makes
+  # systemctl refuse a plain start (so a bare re-run can never recover). Both
+  # commands are best-effort; the `docker info` check below is the real gate.
+  sudo systemctl reset-failed docker 2>/dev/null || true
   sudo systemctl start docker 2>/dev/null || true
 
   if ! docker info &>/dev/null 2>&1; then
+    # (a) Group not active in THIS shell yet → re-exec under the docker group.
     if [[ -z "${_K3S_INSTALL_REEXEC:-}" ]] && id -nG "$USER" 2>/dev/null | grep -qw docker; then
       SELF="$(readlink -f "$0" 2>/dev/null || echo "$0")"
       log "Docker group not yet active in this session — re-executing script..."
       exec sg docker -c "_K3S_INSTALL_REEXEC=1 bash '$SELF'"
+    fi
+    # (b) The daemon itself isn't running → a Docker/host problem, not a group
+    # one. Surface Docker's OWN error (a 'log out and back in' hint would just
+    # send the user in circles, as it can't fix a crashing daemon).
+    if ! sudo systemctl is-active --quiet docker 2>/dev/null; then
+      echo ""
+      # Modules were just installed for a newer, not-yet-booted kernel → the only
+      # remedy is a reboot; a re-run without it would loop on the same failure.
+      if [[ -n "${KMODS_REBOOT_REQUIRED:-}" ]]; then
+        warn "Docker can't start yet: the netfilter kernel modules it needs were just installed"
+        hint "for a newer kernel that isn't running. Reboot to load it, then re-run this installer:"
+        hint "    sudo reboot"
+        hint "(The modules are pinned in /etc/modules-load.d/tracebloc.conf and load automatically on boot.)"
+        echo ""
+        error "Reboot required to finish Docker setup. Reboot, then re-run this installer."
+      fi
+      warn "Docker is installed, but its daemon won't start — this is a Docker/host issue, not tracebloc."
+      hint "If the error below mentions 'addrtype' / 'missing kernel module', the host lacks the"
+      hint "netfilter modules Docker needs — try:  sudo dnf install -y kernel-modules-extra && sudo reboot"
+      hint "Other causes: SELinux, an overlay storage-driver issue, or low /var/lib/docker disk. Docker's error:"
+      { sudo systemctl status docker.service --no-pager -l 2>&1 | tail -6
+        sudo journalctl -u docker.service --no-pager 2>/dev/null \
+          | grep -iE 'level=(error|fatal)|failed to|cannot |unable |no such' | tail -12; } | sed 's/^/    /'
+      echo ""
+      error "Start Docker manually (fix the error above), then re-run this installer."
     fi
     error "Could not connect to Docker. Try logging out and back in, then re-run the script."
   fi
@@ -70,6 +146,12 @@ install_system_deps() {
   MISSING_PKGS=()
   has curl      || MISSING_PKGS+=(curl)
   has conntrack || MISSING_PKGS+=("$conntrack_pkg")
+  # helm's get-helm-3 verifies its download checksum with openssl and unpacks a
+  # tarball with tar; minimal cloud images (Amazon Linux 2023, minimal RHEL) ship
+  # neither, so the Helm install fails. Ensure both (package names are uniform
+  # across apt/dnf/yum/zypper/pacman, unlike conntrack).
+  has openssl   || MISSING_PKGS+=(openssl)
+  has tar       || MISSING_PKGS+=(tar)
   if [[ ${#MISSING_PKGS[@]} -gt 0 ]]; then
     spin_cmd "Updating package index…" $PM_UPDATE
     for pkg in "${MISSING_PKGS[@]}"; do

--- a/scripts/lib/summary.sh
+++ b/scripts/lib/summary.sh
@@ -3,47 +3,131 @@
 #  summary.sh — Final success screen + cluster verification (debug only)
 # =============================================================================
 
-verify_cluster() {
+# Cluster status dump (debug log only).
+_log_cluster_status() {
   log "--- Cluster Status ---"
   kubectl cluster-info >> "${LOG_FILE:-/dev/null}" 2>&1 || true
   kubectl get nodes -o wide >> "${LOG_FILE:-/dev/null}" 2>&1 || true
-  kubectl get pods -n "${TB_NAMESPACE:-default}" >> "${LOG_FILE:-/dev/null}" 2>&1 || true
+  kubectl get pods -n "${TB_NAMESPACE:-default}" -o wide >> "${LOG_FILE:-/dev/null}" 2>&1 || true
   log "--- End Cluster Status ---"
 }
 
+# ── Readiness gate (#716) ─────────────────────────────────────────────────
+# helm install only *applies* manifests; it does not wait for pods. After it
+# returns we wait for the client's workloads to actually become Ready and set
+# CLIENT_STATE so the summary reports the truth instead of an unconditional
+# "installed successfully":
+#   connected | starting | bad_creds | image_pull | crash
+CLIENT_STATE="starting"
+READY_TIMEOUT="${READY_TIMEOUT:-300}"
+
+wait_for_client_ready() {
+  local ns="${TB_NAMESPACE:-default}"
+  local deploys=("mysql-client" "${ns}-jobs-manager" "${ns}-requests-proxy")
+  local deadline=$(( $(date +%s) + READY_TIMEOUT ))
+  local all_ready=true d remaining
+
+  echo ""
+  info "Waiting for the client to start — first run downloads images, this can take a few minutes…"
+  for d in "${deploys[@]}"; do
+    remaining=$(( deadline - $(date +%s) )); (( remaining < 10 )) && remaining=10
+    if kubectl rollout status "deployment/${d}" -n "$ns" --timeout="${remaining}s" \
+        >> "${LOG_FILE:-/dev/null}" 2>&1; then
+      success "${d#${ns}-} ready"
+    else
+      all_ready=false; break
+    fi
+  done
+
+  _log_cluster_status
+  if [[ "$all_ready" == true ]]; then
+    CLIENT_STATE="connected"
+  else
+    CLIENT_STATE="$(_diagnose_not_ready "$ns")"
+  fi
+  return 0
+}
+
+# Classify why the client isn't Ready, for an accurate message. Echoes a state.
+_diagnose_not_ready() {
+  local ns="$1" pods jm_logs
+  # Wrong credentials: jobs-manager authenticates to the backend on startup and
+  # crash-loops when rejected — surfaced as an auth error in its logs.
+  jm_logs="$(kubectl logs -n "$ns" "deployment/${ns}-jobs-manager" --all-containers --tail=50 2>/dev/null || true)"
+  if printf '%s' "$jm_logs" | grep -qiE 'authentication failed|unable to log in'; then
+    printf 'bad_creds'; return
+  fi
+  pods="$(kubectl get pods -n "$ns" 2>/dev/null || true)"
+  if printf '%s' "$pods" | grep -qiE 'ImagePullBackOff|ErrImagePull|InvalidImageName'; then
+    printf 'image_pull'; return
+  fi
+  if printf '%s' "$pods" | grep -qiE 'CrashLoopBackOff'; then
+    printf 'crash'; return
+  fi
+  printf 'starting'
+}
+
+# Reports the outcome based on CLIENT_STATE (set by wait_for_client_ready).
+# The "secure compute environment / your data never leaves" claim is printed
+# ONLY when the client is verifiably connected — never on a partial/failed run.
 print_summary() {
   local mode="CPU"
   [[ "$GPU_VENDOR" == "nvidia" ]] && mode="NVIDIA GPU"
   [[ "$GPU_VENDOR" == "amd" ]] && mode="AMD GPU"
+  local ns="${TB_NAMESPACE:-default}"
+  local line="━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
   echo ""
-  echo -e "  ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
-  echo ""
-  echo -e "  ${BOLD}${GREEN}tracebloc client installed successfully${RESET}"
-  echo ""
-  echo -e "  ${BOLD}Workspace${RESET} : ${CYAN}${TB_NAMESPACE:-default}${RESET}"
-  echo -e "  ${BOLD}Mode${RESET}      : ${CYAN}${mode}${RESET}"
-  echo ""
-  echo -e "  ${DIM}This machine is now a secure compute environment${RESET}"
-  echo -e "  ${DIM}on the tracebloc network. External AI vendors can${RESET}"
-  echo -e "  ${DIM}submit models to be trained and evaluated here —${RESET}"
-  echo -e "  ${DIM}your data never leaves your infrastructure.${RESET}"
-  echo ""
-  echo -e "  ${BOLD}What to do next${RESET}"
-  echo ""
-  echo -e "  ${WHITE}1.${RESET} Open the tracebloc dashboard"
-  echo -e "     ${CYAN}https://ai.tracebloc.io${RESET}"
-  echo ""
-  echo -e "  ${WHITE}2.${RESET} Ingest your training and test data"
-  echo ""
-  echo -e "  ${WHITE}3.${RESET} Define your first AI use case and"
-  echo -e "     invite vendors to submit models"
-  echo ""
-  echo -e "  ${DIM}Need help?${RESET}  ${CYAN}https://docs.tracebloc.io${RESET}"
-  echo -e "  ${DIM}Logs:${RESET}       ${DIM}~/.tracebloc/${RESET}"
-  echo -e "  ${DIM}Data:${RESET}       ${DIM}/tracebloc/${TB_NAMESPACE:-default}${RESET}"
-  echo ""
-  echo -e "  ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+  case "$CLIENT_STATE" in
+    connected)
+      echo -e "  ${GREEN}${line}${RESET}"
+      echo ""
+      echo -e "  ${BOLD}${GREEN}✔ Connected to tracebloc${RESET}"
+      echo ""
+      echo -e "  ${BOLD}Workspace${RESET} : ${CYAN}${ns}${RESET}"
+      echo -e "  ${BOLD}Mode${RESET}      : ${CYAN}${mode}${RESET}"
+      echo ""
+      echo -e "  Your client is live. Confirm it shows as ${BOLD}🟢 Online${RESET}:"
+      echo -e "    ${CYAN}https://ai.tracebloc.io/clients${RESET}"
+      echo ""
+      echo -e "  ${DIM}Models that vendors submit train on this machine —${RESET}"
+      echo -e "  ${DIM}your data never leaves it.${RESET}"
+      echo ""
+      echo -e "  ${BOLD}What to do next${RESET}"
+      echo -e "  ${WHITE}1.${RESET} Ingest your training and test data"
+      echo -e "  ${WHITE}2.${RESET} Define your first AI use case and invite vendors"
+      echo ""
+      echo -e "  ${DIM}Dashboard:${RESET} ${CYAN}https://ai.tracebloc.io${RESET}   ${DIM}Logs:${RESET} ${DIM}~/.tracebloc/${RESET}   ${DIM}Data:${RESET} ${DIM}/tracebloc/${ns}${RESET}"
+      echo ""
+      echo -e "  ${GREEN}${line}${RESET}"
+      ;;
+    starting)
+      echo -e "  ${YELLOW}⚠  Almost there — tracebloc is installed but still starting.${RESET}"
+      echo ""
+      echo -e "  Components are still downloading/starting (first run can take a few minutes)."
+      echo -e "  Check progress:   ${CYAN}kubectl get pods -n ${ns}${RESET}"
+      echo ""
+      echo -e "  Your client will show as ${BOLD}🟢 Online${RESET} at ${CYAN}https://ai.tracebloc.io/clients${RESET}"
+      echo -e "  once it finishes. ${DIM}Re-running this installer is safe.${RESET}"
+      ;;
+    bad_creds)
+      echo -e "  ${RED}${BOLD}✖ Couldn't connect — your Client ID or password was rejected.${RESET}" >&2
+      echo ""
+      echo -e "  The environment installed, but tracebloc refused those credentials."
+      echo -e "    1. Re-check them at ${CYAN}https://ai.tracebloc.io/clients${RESET}"
+      echo -e "    2. Re-run this installer ${DIM}(safe to re-run)${RESET}"
+      ;;
+    image_pull|crash)
+      local reason="a component didn't start"
+      [[ "$CLIENT_STATE" == "image_pull" ]] && reason="an image couldn't be pulled"
+      [[ "$CLIENT_STATE" == "crash" ]] && reason="a container is restarting (crash loop)"
+      echo -e "  ${RED}${BOLD}✖ Setup didn't finish — ${reason}.${RESET}" >&2
+      echo ""
+      echo -e "  Inspect:  ${CYAN}kubectl get pods -n ${ns}${RESET}"
+      echo -e "  Logs:     ${DIM}~/.tracebloc/install-*.log${RESET}"
+      echo -e "  ${DIM}Re-running this installer is safe.${RESET}"
+      ;;
+  esac
   echo ""
 
   _log_advanced_info

--- a/scripts/lib/summary.sh
+++ b/scripts/lib/summary.sh
@@ -18,7 +18,10 @@ _log_cluster_status() {
 # CLIENT_STATE so the summary reports the truth instead of an unconditional
 # "installed successfully":
 #   connected | starting | bad_creds | image_pull | crash
-CLIENT_STATE="starting"
+# Empty until wait_for_client_ready runs — so install_cleanup can distinguish an
+# early failure (before the readiness gate, CLIENT_STATE still empty) from a
+# reported outcome, and still print the "check the log / safe to re-run" hint.
+CLIENT_STATE=""
 READY_TIMEOUT="${READY_TIMEOUT:-300}"
 
 wait_for_client_ready() {

--- a/scripts/lib/summary.sh
+++ b/scripts/lib/summary.sh
@@ -70,6 +70,17 @@ _diagnose_not_ready() {
 # Reports the outcome based on CLIENT_STATE (set by wait_for_client_ready).
 # The "secure compute environment / your data never leaves" claim is printed
 # ONLY when the client is verifiably connected — never on a partial/failed run.
+# One-line note in the success summary so the user knows the client survives a
+# reboot — automatic on Linux; needs Docker Desktop start-on-login on macOS/Win.
+_reboot_note() {
+  if [[ "$OS" == "Linux" ]]; then
+    echo -e "  ${GREEN}✔${RESET} ${DIM}Survives reboot — Docker and your client restart automatically.${RESET}"
+  else
+    echo -e "  ${DIM}After a reboot, start Docker Desktop to bring your client back —${RESET}"
+    echo -e "  ${DIM}enable Settings → General → \"Start Docker Desktop when you sign in\" to automate.${RESET}"
+  fi
+}
+
 print_summary() {
   local mode="CPU"
   [[ "$GPU_VENDOR" == "nvidia" ]] && mode="NVIDIA GPU"
@@ -92,6 +103,8 @@ print_summary() {
       echo ""
       echo -e "  ${DIM}Models that vendors submit train on this machine —${RESET}"
       echo -e "  ${DIM}your data never leaves it.${RESET}"
+      echo ""
+      _reboot_note
       echo ""
       echo -e "  ${BOLD}What to do next${RESET}"
       echo -e "  ${WHITE}1.${RESET} Ingest your training and test data"

--- a/scripts/tests/cluster.bats
+++ b/scripts/tests/cluster.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+# Tests for scripts/lib/cluster.sh — corporate-proxy hardening:
+#   Gap A — authenticated proxies propagated via a k3d --config file
+#           (k3d's --env KEY=VALUE@FILTER can't carry an '@' in the value).
+#   Gap B — NO_PROXY auto-augmented with the cluster-internal ranges, both into
+#           the cluster and host-side, so in-cluster traffic never traverses the
+#           proxy (which would misroute it and hang `k3d cluster create --wait`).
+#   Gap C — externally-created clusters that bind 0.0.0.0 are detected + flagged.
+load test_helper
+
+setup() {
+  load_lib cluster.sh
+  MOCK_CALLS="$(mktemp)"
+  CFG_CAPTURE="$(mktemp)"
+  CLUSTER_NAME=tracebloc
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"
+  SERVERS=1; AGENTS=0; K8S_VERSION=""; K3D_GPU_FLAGS=()
+  unset HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy
+
+  # k3d mock: record argv; if a --config <path> is present, snapshot the file so
+  # a test can assert its contents (cluster.sh deletes the temp dir after create).
+  k3d() {
+    record "k3d $*"
+    local prev="" a
+    for a in "$@"; do
+      [[ "$prev" == "--config" ]] && cp "$a" "$CFG_CAPTURE" 2>/dev/null
+      prev="$a"
+    done
+    return 0
+  }
+  docker() { record "docker $*"; return 0; }
+}
+
+# ── _augment_no_proxy (Gap B) ───────────────────────────────────────────────
+@test "_augment_no_proxy: empty host NO_PROXY -> cluster-internal defaults" {
+  run _augment_no_proxy
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"localhost"* ]]
+  [[ "$output" == *"127.0.0.1"* ]]
+  [[ "$output" == *"10.0.0.0/8"* ]]
+  [[ "$output" == *".svc"* ]]
+  [[ "$output" == *".cluster.local"* ]]
+  [[ "$output" == *"host.k3d.internal"* ]]
+}
+
+@test "_augment_no_proxy: host entries kept first and de-duplicated" {
+  NO_PROXY="foo.com,127.0.0.1"
+  run _augment_no_proxy
+  [[ "$output" == "foo.com,127.0.0.1,"* ]]            # host entries first
+  [ "$(grep -o '127\.0\.0\.1' <<<"$output" | wc -l | tr -d ' ')" -eq 1 ]   # deduped
+}
+
+@test "_augment_no_proxy: lowercase no_proxy is honoured" {
+  no_proxy="bar.internal"
+  run _augment_no_proxy
+  [[ "$output" == "bar.internal,"* ]]
+}
+
+# ── _write_k3d_proxy_config (Gap A + B) ─────────────────────────────────────
+@test "_write_k3d_proxy_config: no proxy set -> empty (no file)" {
+  run _write_k3d_proxy_config
+  [ -z "$output" ]
+}
+
+@test "_write_k3d_proxy_config: auth creds preserved (Gap A) + augmented NO_PROXY (Gap B)" {
+  HTTP_PROXY="http://user:pass@proxy.example.com:8080"
+  HTTPS_PROXY="http://user:pass@proxy.example.com:8080"
+  NO_PROXY="corp.internal"
+  run _write_k3d_proxy_config
+  [ -n "$output" ]
+  local cfg="$output"
+  [ -f "$cfg" ]
+  grep -q 'apiVersion: k3d.io/v1alpha5' "$cfg"
+  grep -q 'nodeFilters' "$cfg"
+  # the whole point of Gap A: the embedded '@' credentials survive intact
+  grep -q 'HTTP_PROXY=http://user:pass@proxy.example.com:8080' "$cfg"
+  grep -q 'HTTPS_PROXY=http://user:pass@proxy.example.com:8080' "$cfg"
+  # augmented NO_PROXY: host entry first + cluster-internal ranges
+  grep -q 'NO_PROXY=corp.internal,' "$cfg"
+  grep -Eq 'NO_PROXY=.*127\.0\.0\.1' "$cfg"
+  grep -Eq 'NO_PROXY=.*\.svc' "$cfg"
+  rm -rf "${cfg%/*}"
+}
+
+@test "_write_k3d_proxy_config: HTTP_PROXY only still emits augmented NO_PROXY" {
+  HTTP_PROXY="http://proxy:8080"
+  run _write_k3d_proxy_config
+  local cfg="$output"
+  [ -f "$cfg" ]
+  grep -Eq 'NO_PROXY=.*127\.0\.0\.1' "$cfg"
+  rm -rf "${cfg%/*}"
+}
+
+# ── _export_host_no_proxy (Gap B, host-side) ────────────────────────────────
+@test "_export_host_no_proxy: exports augmented NO_PROXY when a proxy is set" {
+  HTTP_PROXY="http://proxy:8080"
+  _export_host_no_proxy
+  [[ "$NO_PROXY" == *"127.0.0.1"* ]]
+  [[ "$no_proxy" == *".svc"* ]]
+}
+
+@test "_export_host_no_proxy: no-op when no proxy is set" {
+  _export_host_no_proxy
+  [ -z "${NO_PROXY:-}" ]
+}
+
+# ── _create_new_cluster: proxy propagation via --config (Gap A integration) ──
+@test "_create_new_cluster: auth proxy propagated via --config, not skipped" {
+  HTTP_PROXY="http://user:pass@proxy.example.com:8080"
+  run _create_new_cluster
+  [ "$status" -eq 0 ]
+  run mock_calls
+  [[ "$output" == *"k3d cluster create"* ]]
+  [[ "$output" == *"--config"* ]]
+  [[ "$output" != *"Skipping"* ]]                       # old @-skip path is gone
+  grep -q 'user:pass@proxy.example.com' "$CFG_CAPTURE"
+}
+
+@test "_create_new_cluster: no proxy -> no --config flag" {
+  run _create_new_cluster
+  [ "$status" -eq 0 ]
+  run mock_calls
+  [[ "$output" == *"k3d cluster create"* ]]
+  [[ "$output" != *"--config"* ]]
+}
+
+# ── _check_existing_cluster_bind (Gap C) ────────────────────────────────────
+@test "_check_existing_cluster_bind: 0.0.0.0 bind -> warns (created outside installer)" {
+  docker() { echo "0.0.0.0 0.0.0.0 "; }
+  run _check_existing_cluster_bind
+  [[ "$output" == *"0.0.0.0"* ]]
+  [[ "$output" == *"created outside this installer"* ]]
+}
+
+@test "_check_existing_cluster_bind: 127.0.0.1 bind -> silent" {
+  docker() { echo "127.0.0.1 "; }
+  run _check_existing_cluster_bind
+  [ -z "$output" ]
+}
+
+@test "_check_existing_cluster_bind: inspect fails -> silent no-op" {
+  docker() { return 1; }
+  run _check_existing_cluster_bind
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ── _check_existing_cluster_proxy: drift + auth-bucket regression ────────────
+@test "_check_existing_cluster_proxy: auth proxy no longer triggers an @-skip warning" {
+  HTTP_PROXY="http://u:p@proxy:8080"
+  docker() { echo "HTTP_PROXY=http://u:p@proxy:8080"; }   # baked into the cluster
+  run _check_existing_cluster_proxy
+  [[ "$output" != *"embedded credentials"* ]]
+  [[ "$output" != *"can't carry an"* ]]
+}
+
+@test "_check_existing_cluster_proxy: cluster missing a host proxy var -> drift warning" {
+  HTTP_PROXY="http://proxy:8080"
+  docker() { echo "PATH=/usr/bin"; }                      # HTTP_PROXY not baked
+  run _check_existing_cluster_proxy
+  [[ "$output" == *"missing: HTTP_PROXY"* ]]
+}

--- a/scripts/tests/cluster.bats
+++ b/scripts/tests/cluster.bats
@@ -160,3 +160,44 @@ setup() {
   run _check_existing_cluster_proxy
   [[ "$output" == *"missing: HTTP_PROXY"* ]]
 }
+
+# ── ensure_cluster_autostart (reboot persistence) ───────────────────────────
+@test "ensure_cluster_autostart: unless-stopped per node + enables docker (Linux)" {
+  OS=Linux
+  docker() { if [[ "$1 $2" == "ps -a" ]]; then printf '%s\n' "k3d-tracebloc-server-0" "k3d-tracebloc-serverlb"; else record "docker $*"; fi; }
+  sudo()   { record "sudo $*"; }
+  has()    { return 0; }
+  ensure_cluster_autostart
+  run mock_calls
+  [[ "$output" == *"docker update --restart unless-stopped k3d-tracebloc-server-0"* ]]
+  [[ "$output" == *"docker update --restart unless-stopped k3d-tracebloc-serverlb"* ]]
+  [[ "$output" == *"sudo systemctl enable docker"* ]]
+}
+
+@test "ensure_cluster_autostart: macOS does not enable docker.service" {
+  OS=Darwin
+  docker() { if [[ "$1 $2" == "ps -a" ]]; then echo "k3d-tracebloc-server-0"; else record "docker $*"; fi; }
+  sudo()   { record "sudo $*"; }
+  has()    { return 0; }
+  ensure_cluster_autostart
+  run mock_calls
+  [[ "$output" == *"docker update --restart unless-stopped"* ]]
+  [[ "$output" != *"systemctl enable docker"* ]]
+}
+
+@test "ensure_cluster_autostart: TRACEBLOC_NO_AUTOSTART -> no-op" {
+  OS=Linux
+  docker() { if [[ "$1 $2" == "ps -a" ]]; then echo "k3d-tracebloc-server-0"; else record "docker $*"; fi; }
+  sudo()   { record "sudo $*"; }
+  TRACEBLOC_NO_AUTOSTART=1 ensure_cluster_autostart
+  run mock_calls
+  [ -z "$output" ]
+}
+
+@test "ensure_cluster_autostart: no nodes -> no docker update" {
+  OS=Darwin
+  docker() { if [[ "$1 $2" == "ps -a" ]]; then echo ""; else record "docker $*"; fi; }
+  ensure_cluster_autostart
+  run mock_calls
+  [[ "$output" != *"docker update"* ]]
+}

--- a/scripts/tests/common.bats
+++ b/scripts/tests/common.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# Tests for scripts/lib/common.sh — config validation, the install_cleanup
+# CLIENT_STATE guard (#716), retry, has.
+load test_helper
+
+setup() {
+  load_lib
+}
+
+# ── validate_config ────────────────────────────────────────────────────────
+@test "validate_config: valid config passes" {
+  HOME="$BATS_TEST_TMPDIR"; USER=tester
+  CLUSTER_NAME=tracebloc; SERVERS=1; AGENTS=1
+  HOST_DATA_DIR="$HOME/.tracebloc"
+  run validate_config
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_config: invalid CLUSTER_NAME -> error" {
+  HOME="$BATS_TEST_TMPDIR"; USER=tester
+  CLUSTER_NAME="1nope"; SERVERS=1; AGENTS=1; HOST_DATA_DIR="$HOME/x"
+  run validate_config
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"CLUSTER_NAME"* ]]
+}
+
+@test "validate_config: invalid SERVERS -> error" {
+  HOME="$BATS_TEST_TMPDIR"; USER=tester
+  CLUSTER_NAME=ok; SERVERS=0; AGENTS=1; HOST_DATA_DIR="$HOME/x"
+  run validate_config
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SERVERS"* ]]
+}
+
+@test "validate_config: HOST_DATA_DIR outside HOME -> error" {
+  HOME="$BATS_TEST_TMPDIR"; USER=tester
+  CLUSTER_NAME=ok; SERVERS=1; AGENTS=1; HOST_DATA_DIR="/tmp/not-under-home-$$"
+  run validate_config
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"HOST_DATA_DIR"* ]]
+}
+
+# ── install_cleanup: the CLIENT_STATE guard (#716) ─────────────────────────
+@test "install_cleanup: exit 0 -> silent" {
+  out="$( ( exit 0 ); install_cleanup 2>&1 )"
+  [[ "$out" != *"did not complete"* ]]
+}
+
+@test "install_cleanup: failure + CLIENT_STATE set -> suppresses generic message" {
+  CLIENT_STATE=connected
+  out="$( ( exit 1 ); install_cleanup 2>&1 )"
+  [[ "$out" != *"did not complete"* ]]
+}
+
+@test "install_cleanup: failure + CLIENT_STATE unset -> shows generic message" {
+  unset CLIENT_STATE
+  out="$( ( exit 1 ); install_cleanup 2>&1 )"
+  [[ "$out" == *"did not complete"* ]]
+}
+
+@test "install_cleanup: exit 2 -> re-run hint" {
+  unset CLIENT_STATE
+  out="$( ( exit 2 ); install_cleanup 2>&1 )"
+  [[ "$out" == *"Re-run required"* || "$out" == *"Complete the step"* ]]
+}
+
+# ── retry ──────────────────────────────────────────────────────────────────
+@test "retry: succeeds on first attempt" {
+  run retry 3 1 true
+  [ "$status" -eq 0 ]
+}
+
+@test "retry: gives up after max attempts" {
+  run retry 2 0 false
+  [ "$status" -ne 0 ]
+}
+
+@test "retry: succeeds after a transient failure" {
+  marker="$BATS_TEST_TMPDIR/m"
+  flaky() { if [ -f "$marker" ]; then return 0; fi; touch "$marker"; return 1; }
+  run retry 3 0 flaky
+  [ "$status" -eq 0 ]
+}
+
+# ── has ────────────────────────────────────────────────────────────────────
+@test "has: present command" { run has bash; [ "$status" -eq 0 ]; }
+@test "has: absent command" { run has nope-not-a-real-cmd-xyz; [ "$status" -ne 0 ]; }
+
+# ── check_docker_arch_mac (no-op off macOS) ────────────────────────────────
+@test "check_docker_arch_mac: no-op on non-macOS" {
+  run check_docker_arch_mac
+  [ "$status" -eq 0 ]
+}

--- a/scripts/tests/diagnose.bats
+++ b/scripts/tests/diagnose.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# Tests for scripts/lib/diagnose.sh — the --diagnose support bundle.
+# The redaction tests are the SECURITY GATE: a known secret must never survive
+# into the bundle the customer sends to support.
+load test_helper
+
+setup() {
+  load_lib diagnose.sh
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/tb"
+  CLUSTER_NAME=tracebloc
+  mkdir -p "$HOST_DATA_DIR"
+}
+
+# ── _redact_file (security) ─────────────────────────────────────────────────
+@test "_redact_file: clientPassword redacted, clientId kept" {
+  f="$BATS_TEST_TMPDIR/v.yaml"
+  printf 'clientId: "abc-123"\nclientPassword: '\''S3cr3tP@ss'\''\n' > "$f"
+  _redact_file "$f"
+  ! grep -q 'S3cr3tP@ss' "$f"
+  grep -q 'clientPassword: \[REDACTED\]' "$f"
+  grep -q 'abc-123' "$f"
+}
+
+@test "_redact_file: proxy credentials redacted" {
+  f="$BATS_TEST_TMPDIR/p.txt"
+  echo 'HTTP_PROXY=http://user:s3cr3t@proxy.corp:8080' > "$f"
+  _redact_file "$f"
+  ! grep -q 's3cr3t' "$f"
+  grep -q 'http://\[REDACTED\]@proxy.corp:8080' "$f"
+}
+
+@test "_redact_file: password= and token/secret redacted" {
+  f="$BATS_TEST_TMPDIR/l.txt"
+  printf 'POST password=hunter2&x=1\ntoken: ghp_SECRETTOKEN\n' > "$f"
+  _redact_file "$f"
+  ! grep -q 'hunter2' "$f"
+  ! grep -q 'ghp_SECRETTOKEN' "$f"
+}
+
+@test "_redact_file: non-secret content left intact" {
+  f="$BATS_TEST_TMPDIR/n.txt"
+  echo 'NO_PROXY=localhost,127.0.0.1,.svc' > "$f"
+  _redact_file "$f"
+  grep -q '127.0.0.1,.svc' "$f"
+}
+
+# Finding 1 (security review): any *password key must be redacted, not just
+# clientPassword — covers dockerRegistry password, HTTP_PROXY_PASSWORD, caps.
+@test "_redact_file: redacts dockerRegistry/proxy/db password keys (: and =, any case)" {
+  f="$BATS_TEST_TMPDIR/g.yaml"
+  printf 'dockerRegistry:\n  password: dckr_REGTOKEN\nHTTP_PROXY_PASSWORD: PROXYPW123\nMYSQL_ROOT_PASSWORD=ROOTPW123\n' > "$f"
+  _redact_file "$f"
+  ! grep -q 'dckr_REGTOKEN' "$f"
+  ! grep -q 'PROXYPW123' "$f"
+  ! grep -q 'ROOTPW123' "$f"
+}
+
+@test "_redact_file: missing file is a no-op (no error)" {
+  run _redact_file "$BATS_TEST_TMPDIR/nope.txt"
+  [ "$status" -eq 0 ]
+}
+
+# ── run_diagnose (end-to-end, the headline security proof) ──────────────────
+@test "run_diagnose: produces a bundle, and a seeded secret does NOT survive in it" {
+  echo "clientPassword: 'LEAKME123'" > "$HOST_DATA_DIR/values.yaml"
+  echo "installer log line" > "$HOST_DATA_DIR/install-20260101-000000.log"
+  has() { return 1; }                  # no kubectl/docker/helm -> best-effort path
+  run run_diagnose
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Diagnostics saved"* ]]
+  tgz="$(ls "$HOST_DATA_DIR"/tracebloc-diagnose-*.tgz 2>/dev/null | head -1)"
+  [ -n "$tgz" ]
+  # extract to stdout and confirm the secret was redacted before archiving
+  ! tar -xzOf "$tgz" 2>/dev/null | grep -q 'LEAKME123'
+  # but the bundle still contains useful content (the host section)
+  tar -tzf "$tgz" 2>/dev/null | grep -q '00-host.txt'
+}
+
+@test "run_diagnose: best-effort with no cluster (does not crash)" {
+  has() { return 1; }
+  run run_diagnose
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Diagnostics saved"* ]]
+}
+
+@test "run_diagnose: exercises the cluster-data collection when tools are present" {
+  has() { return 0; }                       # kubectl/docker/helm "present"
+  kubectl() {
+    case "$*" in
+      *"get pods -A"*) printf 'default   default-jobs-manager-abc   1/1   Running\n' ;;
+      *)               printf 'kubectl %s\n' "$*" ;;
+    esac
+  }
+  docker() { printf 'docker %s\n' "$*"; }
+  helm()   { printf 'helm %s\n' "$*"; }
+  run run_diagnose
+  [ "$status" -eq 0 ]
+  tgz="$(ls "$HOST_DATA_DIR"/tracebloc-diagnose-*.tgz 2>/dev/null | head -1)"
+  [ -n "$tgz" ]
+  # the kubectl + helm + per-workload-log collection branches ran
+  tar -tzf "$tgz" | grep -q '02-kubectl.txt'
+  tar -tzf "$tgz" | grep -q '04-helm.txt'
+  tar -tzf "$tgz" | grep -q 'logs/mysql-client.log'
+  # Finding 2 (security review): `helm get manifest` (base64 Secrets) is NOT collected
+  ! tar -xzOf "$tgz" 2>/dev/null | grep -q 'get manifest'
+}

--- a/scripts/tests/distro-prereqs.sh
+++ b/scripts/tests/distro-prereqs.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  distro-prereqs.sh — cross-distro prerequisite-install smoke test
+# -----------------------------------------------------------------------------
+#  Runs the installer's REAL Linux prerequisite logic inside a fresh distro
+#  container and asserts every prerequisite binary lands on PATH:
+#
+#    setup_pm            → correct package manager detected for this distro
+#    install_system_deps → conntrack installed under the right package name (#720)
+#    install_docker_engine → correct Docker branch taken (get.docker.com vs the
+#                            docker-ce repo for RHEL rebuilds #719, dnf/yum/zypper/
+#                            pacman), Docker package actually installed
+#    _ensure_kernel_modules → netfilter modules loaded / kernel-modules fallback
+#                            (Asad's AlmaLinux xt_addrtype case) — best-effort
+#    install_kubectl / install_k3d (PATH-through-sudo #718) / install_helm
+#
+#  It deliberately does NOT start the Docker daemon or create a k3d cluster —
+#  that needs a real kernel + systemd (covered by the e2e job on the Ubuntu
+#  runners and by the local Lima/VM matrix). This proves each distro's BRANCH
+#  does the right thing, which is where every installer bug we have shipped lived.
+#
+#  Usage (inside a container, as root):
+#    bash scripts/tests/distro-prereqs.sh
+#  Typically driven by CI:
+#    docker run --rm -v "$PWD:/src:ro" -w /src <distro-image> bash scripts/tests/distro-prereqs.sh
+# =============================================================================
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$HERE/../lib"
+
+# ── Make the container resemble a real host ──────────────────────────────────
+# Anyone running the real installer reached it via `curl | bash`, so curl always
+# exists and the box has sudo. Minimal base images ship neither — install them
+# up front (we are root here) so the rest of the run mirrors a real machine.
+_pm_install_one() { # install a single package with whatever PM exists
+  if   command -v apt-get >/dev/null 2>&1; then apt-get update -qq && apt-get install -y -qq "$1"
+  elif command -v dnf     >/dev/null 2>&1; then dnf install -y -q "$1"
+  elif command -v yum     >/dev/null 2>&1; then yum install -y -q "$1"
+  elif command -v zypper  >/dev/null 2>&1; then zypper --non-interactive install "$1"
+  elif command -v pacman  >/dev/null 2>&1; then pacman -Sy --noconfirm "$1"
+  fi
+}
+_bootstrap_host() {
+  command -v curl >/dev/null 2>&1 && command -v sudo >/dev/null 2>&1 && return 0
+  echo "── bootstrapping curl + sudo ──"
+  # Install sudo and curl independently. The installer calls `sudo` for every
+  # privileged step (a real host has it); minimal images may not. Only add curl
+  # if the binary is truly absent — RHEL 9 ships curl-minimal, which provides
+  # curl, and `dnf install curl` would hit the curl/curl-minimal conflict.
+  command -v sudo >/dev/null 2>&1 || _pm_install_one sudo
+  command -v curl >/dev/null 2>&1 || _pm_install_one curl
+}
+_bootstrap_host
+
+# shellcheck source=/dev/null
+source "$LIB/common.sh"
+# shellcheck source=/dev/null
+source "$LIB/setup-linux.sh"
+
+# The real entrypoint runs validate_config first, which guarantees $USER is set
+# (usermod -aG docker "$USER" runs under `set -u`). Containers often don't export
+# USER — mirror that precondition so we test the install path, not a missing env.
+export USER="${USER:-$(id -un)}"
+
+# ── Context banner ───────────────────────────────────────────────────────────
+PRETTY="$( . /etc/os-release 2>/dev/null && echo "${PRETTY_NAME:-unknown}" )"
+echo ""
+echo "═══════════════════════════════════════════════════════════════════════"
+echo "  distro : ${PRETTY}"
+echo "  arch   : $(uname -m)  (ARCH_DL=${ARCH_DL})"
+echo "  kernel : $(uname -r)"
+echo "═══════════════════════════════════════════════════════════════════════"
+
+# umask 077 (set by common.sh) would make /usr/local/bin tools root-exec-only;
+# install_linux relaxes to 022 around the tool installs — mirror that here.
+umask 022
+
+# ── Run the real prereq path ─────────────────────────────────────────────────
+setup_pm
+echo "→ PM_INSTALL = ${PM_INSTALL}"
+
+install_system_deps
+
+# install_docker_engine installs the Docker package via the distro-specific
+# branch, then gates on a *running* daemon — which cannot come up without
+# systemd/a real kernel in a bare container. Tolerate that final gate; we only
+# assert the binary was installed. (Daemon start-up is covered by the e2e job.)
+echo "→ installing Docker (daemon start-up gate is expected to be skipped here)…"
+( install_docker_engine ) || echo "  (docker daemon gate skipped — expected in a container)"
+
+install_kubectl
+install_k3d
+install_helm
+
+# ── Assertions ───────────────────────────────────────────────────────────────
+echo ""
+echo "── prerequisite check ─────────────────────────────────────────────────"
+fail=0
+for tool in docker kubectl k3d helm conntrack; do
+  if path="$(command -v "$tool" 2>/dev/null)"; then
+    ver="$("$tool" --version 2>/dev/null | head -1 || true)"
+    printf '  ✔ %-9s %s  %s\n' "$tool" "$path" "${ver:-}"
+  else
+    printf '  ✖ %-9s MISSING\n' "$tool"
+    fail=1
+  fi
+done
+echo "───────────────────────────────────────────────────────────────────────"
+
+if [[ $fail -ne 0 ]]; then
+  echo "RESULT: FAIL — a prerequisite did not install on ${PRETTY}"
+  exit 1
+fi
+echo "RESULT: PASS — all prerequisites installed on ${PRETTY}"

--- a/scripts/tests/e2e-cluster.sh
+++ b/scripts/tests/e2e-cluster.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  e2e-cluster.sh — real end-to-end cluster smoke test
+# -----------------------------------------------------------------------------
+#  Brings up an ACTUAL k3d cluster on a real kernel using the installer's own
+#  create_cluster() path (the same function main() calls), proves the cluster can
+#  schedule and run a public workload, then tears it down. This is the highest-
+#  fidelity check CI can run: it exercises k3d cluster create, the proxy/NO_PROXY
+#  config, kubeconfig merge, and the API-readiness wait against a live daemon —
+#  none of which the mocked unit tests or the prereq-install matrix can.
+#
+#  It deliberately STOPS before the tracebloc helm install / backend
+#  registration: those pull private images and need real credentials + a
+#  reachable platform. So this needs no secrets and runs on stock GitHub runners
+#  (Docker is preinstalled) and locally (Lima/any Docker host).
+#
+#  Usage:  bash scripts/tests/e2e-cluster.sh
+# =============================================================================
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$HERE/../lib"
+
+# Isolated cluster name so we never touch a real 'tracebloc' cluster; opt out of
+# autostart so we don't reconfigure docker.service / restart policies on the host.
+export USER="${USER:-$(id -un)}"
+export CLUSTER_NAME="${CLUSTER_NAME:-tbe2e}"
+export TRACEBLOC_NO_AUTOSTART=1
+
+# shellcheck source=/dev/null
+source "$LIB/common.sh"
+# shellcheck source=/dev/null
+source "$LIB/setup-linux.sh"
+# shellcheck source=/dev/null
+source "$LIB/cluster.sh"
+
+cleanup() { k3d cluster delete "$CLUSTER_NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "═══════════════════════════════════════════════════════════════════════"
+echo "  E2E cluster smoke   arch: $(uname -m)   kernel: $(uname -r)"
+echo "═══════════════════════════════════════════════════════════════════════"
+
+# Docker is preinstalled + running on the runner; we only need the CLI tools the
+# cluster step uses. (We do NOT run install_docker_engine — no daemon gymnastics.)
+has docker || error "Docker is not available on this host."
+umask 022
+install_kubectl
+install_k3d
+install_helm
+
+echo "── create_cluster() — the installer's real cluster-bring-up path ──"
+create_cluster
+
+echo "── assert: all nodes reach Ready ──"
+kubectl wait --for=condition=Ready nodes --all --timeout=180s
+kubectl get nodes -o wide
+
+echo "── wait for the default ServiceAccount (created async after node Ready) ──"
+# kubectl run binds the pod to default/default; on fast runners that can race the
+# service-account controller ("serviceaccount default not found"). Wait for it.
+for _ in $(seq 1 30); do
+  kubectl get serviceaccount default -n default >/dev/null 2>&1 && break
+  sleep 2
+done
+
+echo "── assert: the cluster can pull, schedule, and run a public workload ──"
+kubectl run e2e-probe --image=nginx:alpine --restart=Never
+kubectl wait --for=condition=Ready pod/e2e-probe --timeout=180s
+kubectl get pods -o wide
+
+echo ""
+echo "E2E PASS: k3d cluster came up via the installer's create_cluster() and ran a workload."

--- a/scripts/tests/e2e-proxy.sh
+++ b/scripts/tests/e2e-proxy.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  e2e-proxy.sh — authenticated corporate-proxy end-to-end test
+# -----------------------------------------------------------------------------
+#  Stands up a real squid proxy that REQUIRES basic auth, then brings up a k3d
+#  cluster via the installer's create_cluster() with HTTP(S)_PROXY pointed at it
+#  as http://user:pass@host — and proves the cluster's nodes pull a workload
+#  image THROUGH the authenticated proxy.
+#
+#  This exercises the corporate-proxy hardening end-to-end (the Charité/hospital
+#  archetype): _write_k3d_proxy_config (passes proxy env via a k3d CONFIG FILE so
+#  the '@' in user:pass@host survives — k3d splits --env on '@') + _augment_no_proxy
+#  (so in-cluster traffic bypasses the proxy and `--wait` doesn't hang).
+#
+#  If the credentials get mangled, squid answers 407, the image pull hangs, and
+#  the pod never goes Ready — so this test fails loudly on a proxy-auth regression.
+#  It stops before the tracebloc helm install / backend registration (no secrets).
+#
+#  Usage:  bash scripts/tests/e2e-proxy.sh
+# =============================================================================
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$HERE/../lib"
+
+export USER="${USER:-$(id -un)}"
+export CLUSTER_NAME="${CLUSTER_NAME:-tbproxy}"
+export TRACEBLOC_NO_AUTOSTART=1
+
+PROXY_USER="tbuser"
+PROXY_PASS="tb-Pass.123"          # contains no '@', but the URL form does: user:pass@host
+PROXY_PORT="3128"
+SQUID_NAME="tb-squid"
+WORK="$(mktemp -d)"
+
+# shellcheck source=/dev/null
+source "$LIB/common.sh"
+# shellcheck source=/dev/null
+source "$LIB/setup-linux.sh"
+# shellcheck source=/dev/null
+source "$LIB/cluster.sh"
+
+cleanup() {
+  k3d cluster delete "$CLUSTER_NAME" >/dev/null 2>&1 || true
+  docker rm -f "$SQUID_NAME" >/dev/null 2>&1 || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "═══════════════════════════════════════════════════════════════════════"
+echo "  Authenticated-proxy E2E   arch: $(uname -m)"
+echo "═══════════════════════════════════════════════════════════════════════"
+
+has docker || error "Docker is not available on this host."
+
+# Install the CLI tools directly (the proxy below is exercised by the cluster
+# NODES, which is where the auth-proxy hardening lives).
+umask 022
+install_kubectl
+install_k3d
+install_helm
+
+# ── 1. squid that REQUIRES basic auth ───────────────────────────────────────
+echo "── starting an authenticated squid proxy ──"
+printf '%s:%s\n' "$PROXY_USER" "$(openssl passwd -apr1 "$PROXY_PASS")" > "$WORK/passwords"
+cat > "$WORK/squid.conf" <<'EOF'
+auth_param basic program /usr/lib/squid/basic_ncsa_auth /etc/squid/passwords
+auth_param basic realm tracebloc-test-proxy
+acl authed proxy_auth REQUIRED
+acl SSL_ports port 443
+acl CONNECT method CONNECT
+http_access deny CONNECT !SSL_ports
+http_access allow authed
+http_access deny all
+http_port 3128
+EOF
+docker rm -f "$SQUID_NAME" >/dev/null 2>&1 || true
+docker run -d --name "$SQUID_NAME" -p "${PROXY_PORT}:3128" \
+  -v "$WORK/squid.conf:/etc/squid/squid.conf:ro" \
+  -v "$WORK/passwords:/etc/squid/passwords:ro" \
+  ubuntu/squid:latest >/dev/null
+
+echo "── waiting for squid + verifying auth is enforced ──"
+ready=""
+for _ in $(seq 1 30); do
+  # A correctly-authenticated CONNECT to a registry should tunnel (curl exit 0);
+  # squid returns 407 (curl exit 56/22) if auth is wrong or not yet up.
+  # No -f: the registry answers 401 (needs a token) even on a healthy tunnel; we
+  # only care that the proxy TUNNELED the request (curl exit 0) vs refused with
+  # 407 (curl non-zero). -o /dev/null discards the body.
+  if curl -sS -m 8 -x "http://${PROXY_USER}:${PROXY_PASS}@127.0.0.1:${PROXY_PORT}" \
+        https://registry-1.docker.io/v2/ -o /dev/null 2>/dev/null; then
+    ready=1; break
+  fi
+  sleep 2
+done
+[[ -n "$ready" ]] || error "squid did not become ready / auth check failed."
+# Prove auth is actually ENFORCED: a request with NO credentials must be refused.
+if curl -sS -m 8 -x "http://127.0.0.1:${PROXY_PORT}" https://registry-1.docker.io/v2/ -o /dev/null 2>/dev/null; then
+  error "Proxy allowed an unauthenticated request — auth not enforced; test is invalid."
+fi
+success "Authenticated squid proxy up (anonymous requests refused)."
+
+# ── 2. bring up the cluster with the nodes pointed at the AUTHED proxy ───────
+# Nodes reach the host's published squid via host.k3d.internal (k3d injects it).
+# The user:pass@host form is the exact shape the #174 fix protects.
+export HTTP_PROXY="http://${PROXY_USER}:${PROXY_PASS}@host.k3d.internal:${PROXY_PORT}"
+export HTTPS_PROXY="$HTTP_PROXY"
+echo "── create_cluster() with HTTP(S)_PROXY=http://${PROXY_USER}:***@host.k3d.internal:${PROXY_PORT} ──"
+create_cluster
+kubectl wait --for=condition=Ready nodes --all --timeout=180s
+
+echo "── wait for the default ServiceAccount (created async after node Ready) ──"
+for _ in $(seq 1 30); do
+  kubectl get serviceaccount default -n default >/dev/null 2>&1 && break
+  sleep 2
+done
+
+echo "── pull + run a public workload — the node must fetch it THROUGH the proxy ──"
+kubectl run e2e-probe --image=nginx:alpine --restart=Never
+kubectl wait --for=condition=Ready pod/e2e-probe --timeout=180s
+kubectl get pods -o wide
+
+# ── 3. prove the node's image pull actually traversed the AUTHED proxy ───────
+echo "── squid access log: the node's authenticated image-pull traffic ──"
+plog="$(docker exec "$SQUID_NAME" cat /var/log/squid/access.log 2>/dev/null || true)"
+echo "$plog" | grep -E 'CONNECT' | grep "$PROXY_USER" | grep -E 'docker' | tail -8 | sed 's/^/    /'
+# auth.docker.io is fetched only by a real image pull (the node getting a pull
+# token) — never by the readiness probe to /v2/, which stops at the 401. So an
+# authenticated CONNECT to it proves the NODE pulled through the proxy (not just
+# the host's readiness check), closing the "proxy silently ignored" false-positive.
+if ! echo "$plog" | grep -E 'CONNECT .*auth\.docker\.io' | grep -q "$PROXY_USER"; then
+  error "No authenticated auth.docker.io CONNECT in the proxy log — the node's image pull did not traverse the proxy."
+fi
+
+echo ""
+echo "E2E PASS: cluster came up via an AUTHENTICATED proxy and pulled a workload through it."

--- a/scripts/tests/install-client-helm.bats
+++ b/scripts/tests/install-client-helm.bats
@@ -1,0 +1,224 @@
+#!/usr/bin/env bats
+# Tests for scripts/lib/install-client-helm.sh — credential verification (#717)
+# + the install_client_helm flow.
+load test_helper
+
+setup() {
+  load_lib install-client-helm.sh
+  MOCK_CALLS="$(mktemp)"
+  GPU_VENDOR=none
+  CLIENT_ENV=""
+}
+
+# ── _backend_url ───────────────────────────────────────────────────────────
+@test "_backend_url: default (unset) -> prod" {
+  unset CLIENT_ENV
+  run _backend_url
+  [ "$output" = "https://api.tracebloc.io/" ]
+}
+
+@test "_backend_url: dev" {
+  CLIENT_ENV=dev
+  run _backend_url
+  [ "$output" = "https://dev-api.tracebloc.io/" ]
+}
+
+@test "_backend_url: stg" {
+  CLIENT_ENV=stg
+  run _backend_url
+  [ "$output" = "https://stg-api.tracebloc.io/" ]
+}
+
+@test "_backend_url: unknown -> prod" {
+  CLIENT_ENV=whatever
+  run _backend_url
+  [ "$output" = "https://api.tracebloc.io/" ]
+}
+
+# ── verify_credentials (mock curl's http_code on stdout) ───────────────────
+@test "verify_credentials: HTTP 200 -> valid" {
+  curl() { echo 200; }
+  run verify_credentials id pw
+  [ "$output" = valid ]
+}
+
+@test "verify_credentials: HTTP 400 -> invalid" {
+  curl() { echo 400; }
+  run verify_credentials id pw
+  [ "$output" = invalid ]
+}
+
+@test "verify_credentials: HTTP 401 -> inactive" {
+  curl() { echo 401; }
+  run verify_credentials id pw
+  [ "$output" = inactive ]
+}
+
+@test "verify_credentials: HTTP 429 -> unverified" {
+  curl() { echo 429; }
+  run verify_credentials id pw
+  [ "$output" = unverified ]
+}
+
+@test "verify_credentials: connection failure -> unverified" {
+  curl() { return 7; }
+  run verify_credentials id pw
+  [ "$output" = unverified ]
+}
+
+# ── sanitizers ─────────────────────────────────────────────────────────────
+@test "_strip_paste_garbage: unwraps bracketed-paste ESC markers" {
+  run _strip_paste_garbage "$(printf '\e[200~secret\e[201~')"
+  [ "$output" = "secret" ]
+}
+
+@test "_strip_paste_garbage: strips C0 control chars, keeps text" {
+  run _strip_paste_garbage "$(printf 'ab\001cd')"
+  [ "$output" = "abcd" ]
+}
+
+@test "_sanitize_workspace_name: lowercases + dashes" {
+  run _sanitize_workspace_name "My Team_1"
+  [ "$output" = "my-team-1" ]
+}
+
+@test "_sanitize_workspace_name: all-invalid -> default" {
+  run _sanitize_workspace_name "@@@"
+  [ "$output" = "default" ]
+}
+
+@test "_sanitize_workspace_name: collapses + trims dashes" {
+  run _sanitize_workspace_name "a--b-"
+  [ "$output" = "a-b" ]
+}
+
+# ── _extract_yaml_value ────────────────────────────────────────────────────
+@test "_extract_yaml_value: double-quoted" {
+  f="$BATS_TEST_TMPDIR/v"; printf 'clientId: "abc-123"\n' >"$f"
+  run _extract_yaml_value "$f" clientId
+  [ "$output" = "abc-123" ]
+}
+
+@test "_extract_yaml_value: single-quoted with '' escape" {
+  f="$BATS_TEST_TMPDIR/v"; printf "clientPassword: 'a''b'\n" >"$f"
+  run _extract_yaml_value "$f" clientPassword
+  [ "$output" = "a'b" ]
+}
+
+@test "_extract_yaml_value: missing key -> empty" {
+  f="$BATS_TEST_TMPDIR/v"; printf 'other: x\n' >"$f"
+  run _extract_yaml_value "$f" clientId
+  [ "$output" = "" ]
+}
+
+# ── _ensure_helm_runnable (happy path) ─────────────────────────────────────
+@test "_ensure_helm_runnable: helm runs -> ok" {
+  helm() { return 0; }
+  run _ensure_helm_runnable
+  [ "$status" -eq 0 ]
+}
+
+# ── install_client_helm: full flow with mocks ──────────────────────────────
+@test "install_client_helm: valid creds -> writes values.yaml + runs helm" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  verify_credentials() { printf valid; }
+  run install_client_helm <<< $'myws\nmyid\nmypw'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Credentials verified"* ]]
+  [[ "$output" == *"Connected to tracebloc"* ]]
+  grep -q 'clientId: "myid"' "$HOST_DATA_DIR/values.yaml"
+  grep -q "clientPassword: 'mypw'" "$HOST_DATA_DIR/values.yaml"
+  mock_calls | grep -q "helm upgrade --install myws"
+}
+
+@test "install_client_helm: re-prompts on invalid, then accepts valid" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  verify_credentials() {
+    local n; n=$(cat "$BATS_TEST_TMPDIR/n" 2>/dev/null || echo 0); n=$((n+1)); echo "$n" >"$BATS_TEST_TMPDIR/n"
+    if [ "$n" -ge 2 ]; then printf valid; else printf invalid; fi
+  }
+  run install_client_helm <<< $'myws\nbadid\nbadpw\ngoodid\ngoodpw'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rejected"* ]]
+  [[ "$output" == *"Credentials verified"* ]]
+  grep -q 'clientId: "goodid"' "$HOST_DATA_DIR/values.yaml"
+}
+
+@test "install_client_helm: inactive account -> errors, no helm install" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  verify_credentials() { printf inactive; }
+  run install_client_helm <<< $'myws\nmyid\nmypw'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not active"* ]]
+  run mock_calls
+  [[ "$output" != *"helm upgrade"* ]]
+}
+
+@test "install_client_helm: unverified backend -> proceeds with install" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  verify_credentials() { printf unverified; }
+  run install_client_helm <<< $'myws\nmyid\nmypw'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Couldn't reach tracebloc"* ]]
+  run mock_calls
+  [[ "$output" == *"helm upgrade --install"* ]]
+}
+
+@test "install_client_helm: dev-mode uses caller values file, skips prompts" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  vf="$BATS_TEST_TMPDIR/v.yaml"; printf 'clientId: "x"\n' >"$vf"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  TRACEBLOC_VALUES_FILE="$vf"; TB_NAMESPACE=devns
+  run install_client_helm
+  [ "$status" -eq 0 ]
+  run mock_calls
+  [[ "$output" == *"helm upgrade --install devns"* ]]
+}
+
+@test "install_client_helm: reuses previous clientId/password defaults" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  printf 'clientId: "previd"\nclientPassword: '"'"'prevpw'"'"'\n' >"$HOST_DATA_DIR/values.yaml"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  verify_credentials() { printf valid; }
+  # use-previous=y, workspace=myws, ClientID=Enter(keep previd), password=Enter(keep prevpw)
+  run install_client_helm <<< $'y\nmyws\n\n\n'
+  [ "$status" -eq 0 ]
+  grep -q 'clientId: "previd"' "$HOST_DATA_DIR/values.yaml"
+  grep -q "clientPassword: 'prevpw'" "$HOST_DATA_DIR/values.yaml"
+}
+
+@test "install_client_helm: gives up after max failed attempts" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  verify_credentials() { printf invalid; }
+  run install_client_helm <<< $'myws\ni1\np1\ni2\np2\ni3\np3\ni4\np4\ni5\np5'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Too many failed attempts"* ]]
+  run mock_calls
+  [[ "$output" != *"helm upgrade"* ]]
+}

--- a/scripts/tests/install-k8s.Tests.ps1
+++ b/scripts/tests/install-k8s.Tests.ps1
@@ -7,6 +7,7 @@ BeforeAll {
   . "$PSScriptRoot/../install-k8s.ps1"
   # Stubs so Pester can mock external commands that the functions invoke.
   function kubectl { }
+  function docker { }
 }
 
 Describe "Get-BackendUrl" {
@@ -357,5 +358,23 @@ Describe "Test-Preflight" {
     Mock Get-WindowsArch { "arm64" }
     Mock Test-PfUrl { "ok" }
     { Test-Preflight } | Should -Not -Throw
+  }
+}
+
+# --- reboot persistence (Set-ClusterAutostart) -------------------------------
+Describe "Set-ClusterAutostart" {
+  AfterEach { $env:TRACEBLOC_NO_AUTOSTART = $null }
+  It "sets unless-stopped on each k3d node" {
+    Mock docker {
+      if (($args -join ' ') -match 'ps -a') { return @("k3d-tracebloc-server-0", "k3d-tracebloc-serverlb") }
+    }
+    Set-ClusterAutostart
+    Should -Invoke docker -ParameterFilter { ($args -join ' ') -match 'update --restart unless-stopped' } -Times 2
+  }
+  It "TRACEBLOC_NO_AUTOSTART -> no docker calls" {
+    $env:TRACEBLOC_NO_AUTOSTART = "1"
+    Mock docker { }
+    Set-ClusterAutostart
+    Should -Invoke docker -Times 0 -Exactly
   }
 }

--- a/scripts/tests/install-k8s.Tests.ps1
+++ b/scripts/tests/install-k8s.Tests.ps1
@@ -230,3 +230,60 @@ Describe "Confirm-Cluster" {
     { Confirm-Cluster } | Should -Not -Throw
   }
 }
+
+# --- Corporate-proxy hardening (Windows parity with scripts/lib/cluster.sh) ---
+Describe "Get-EffectiveNoProxy" {
+  AfterEach { $env:NO_PROXY = $null; $env:no_proxy = $null }
+  It "empty host NO_PROXY -> cluster-internal defaults" {
+    $env:NO_PROXY = $null; $env:no_proxy = $null
+    $r = Get-EffectiveNoProxy
+    $r | Should -Match '127\.0\.0\.1'
+    $r | Should -Match '10\.0\.0\.0/8'
+    $r | Should -Match '\.svc'
+    $r | Should -Match 'host\.k3d\.internal'
+  }
+  It "host entries kept first and de-duplicated" {
+    $env:NO_PROXY = "foo.com,127.0.0.1"
+    $r = Get-EffectiveNoProxy
+    $r | Should -BeLike "foo.com,127.0.0.1,*"
+    ([regex]::Matches($r, '127\.0\.0\.1')).Count | Should -Be 1
+  }
+  It "lowercase no_proxy is honoured" {
+    $env:NO_PROXY = $null; $env:no_proxy = "bar.internal"
+    Get-EffectiveNoProxy | Should -BeLike "bar.internal,*"
+  }
+}
+
+Describe "Write-K3dProxyConfig" {
+  AfterEach {
+    $env:HTTP_PROXY = $null; $env:HTTPS_PROXY = $null
+    $env:http_proxy = $null; $env:https_proxy = $null
+    $env:NO_PROXY = $null;   $env:no_proxy = $null
+  }
+  It "no proxy set -> returns null" {
+    Write-K3dProxyConfig | Should -BeNullOrEmpty
+  }
+  It "auth creds preserved (Gap A) + augmented NO_PROXY (Gap B), written without a BOM" {
+    $env:HTTP_PROXY = "http://user:pass@proxy.example.com:8080"
+    $env:NO_PROXY   = "corp.internal"
+    $cfg = Write-K3dProxyConfig
+    $cfg | Should -Not -BeNullOrEmpty
+    Test-Path $cfg | Should -BeTrue
+    $content = Get-Content $cfg -Raw
+    $content | Should -Match 'apiVersion: k3d.io/v1alpha5'
+    $content | Should -Match 'HTTP_PROXY=http://user:pass@proxy.example.com:8080'
+    $content | Should -Match 'NO_PROXY=corp.internal,'
+    $content | Should -Match 'NO_PROXY=[^"]*127\.0\.0\.1'
+    # UTF-8 without BOM — Windows PowerShell 5.1 would otherwise prepend EF BB BF
+    # and break the YAML parser.
+    $bytes = [System.IO.File]::ReadAllBytes($cfg)
+    ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) | Should -BeFalse
+    Remove-Item (Split-Path $cfg -Parent) -Recurse -Force
+  }
+  It "HTTP_PROXY only still emits augmented NO_PROXY" {
+    $env:HTTP_PROXY = "http://proxy:8080"
+    $cfg = Write-K3dProxyConfig
+    (Get-Content $cfg -Raw) | Should -Match 'NO_PROXY=[^"]*127\.0\.0\.1'
+    Remove-Item (Split-Path $cfg -Parent) -Recurse -Force
+  }
+}

--- a/scripts/tests/install-k8s.Tests.ps1
+++ b/scripts/tests/install-k8s.Tests.ps1
@@ -287,3 +287,75 @@ Describe "Write-K3dProxyConfig" {
     Remove-Item (Split-Path $cfg -Parent) -Recurse -Force
   }
 }
+
+# --- Preflight checks (mirrors scripts/lib/preflight.sh) ---------------------
+Describe "Test-PfUrl" {
+  It "HTTP 200 -> ok" {
+    Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 200 } }
+    Test-PfUrl "https://x" | Should -Be "ok"
+  }
+  It "HTTP error response (server reached) -> ok" {
+    Mock Invoke-WebRequest {
+      $ex = [System.Exception]::new("HTTP 401")
+      Add-Member -InputObject $ex -NotePropertyName Response -NotePropertyValue ([pscustomobject]@{ StatusCode = 401 }) -Force
+      throw $ex
+    }
+    Test-PfUrl "https://x" | Should -Be "ok"
+  }
+  It "TLS / certificate error -> tls" {
+    Mock Invoke-WebRequest { throw [System.Exception]::new("The SSL certificate could not be validated - trust failure") }
+    Test-PfUrl "https://x" | Should -Be "tls"
+  }
+  It "connection failure -> blocked" {
+    Mock Invoke-WebRequest { throw [System.Exception]::new("Unable to connect to the remote server") }
+    Test-PfUrl "https://x" | Should -Be "blocked"
+  }
+}
+
+# Get-CimInstance is a Windows-only cmdlet (CimCmdlets module) — it can't be
+# mocked on Linux/macOS pwsh, so these run only on Windows (a Windows reviewer /
+# Windows CI). Off-Windows the readers safely return $null (the catch), which
+# Test-Preflight handles as "couldn't determine (skipping)".
+Describe "Get-Pf* resource readers" -Skip:(-not $IsWindows) {
+  It "Get-PfCpu reads logical processors" {
+    Mock Get-CimInstance { [pscustomobject]@{ NumberOfLogicalProcessors = 4 } }
+    Get-PfCpu | Should -Be 4
+  }
+  It "Get-PfMemGb reads total RAM in GB" {
+    Mock Get-CimInstance { [pscustomobject]@{ TotalPhysicalMemory = 8GB } }
+    Get-PfMemGb | Should -Be 8
+  }
+  It "Get-PfFreeGb reads free disk in GB" {
+    Mock Get-CimInstance { [pscustomobject]@{ FreeSpace = 50GB } }
+    Get-PfFreeGb | Should -Be 50
+  }
+}
+
+Describe "Test-Preflight" {
+  BeforeEach {
+    Mock Err { throw "preflight-failed" }      # Err exits; make it throwable to assert
+    Mock Get-PfCpu { 4 }; Mock Get-PfMemGb { 8 }; Mock Get-PfFreeGb { 50 }
+    Mock Get-WindowsArch { "amd64" }
+  }
+  AfterEach { $env:TRACEBLOC_SKIP_PREFLIGHT = $null; $env:TRACEBLOC_ALLOW_ARM64 = $null }
+
+  It "healthy environment -> does not throw" {
+    Mock Test-PfUrl { "ok" }
+    { Test-Preflight } | Should -Not -Throw
+  }
+  It "a critical host blocked -> fails (Err throws)" {
+    Mock Test-PfUrl { "blocked" }
+    { Test-Preflight } | Should -Throw
+  }
+  It "TRACEBLOC_SKIP_PREFLIGHT -> skipped, no probing" {
+    $env:TRACEBLOC_SKIP_PREFLIGHT = "1"
+    Mock Test-PfUrl { "blocked" }
+    { Test-Preflight } | Should -Not -Throw
+    Should -Invoke Test-PfUrl -Exactly -Times 0
+  }
+  It "arm64 -> info, not a hard fail (Docker Desktop emulates)" {
+    Mock Get-WindowsArch { "arm64" }
+    Mock Test-PfUrl { "ok" }
+    { Test-Preflight } | Should -Not -Throw
+  }
+}

--- a/scripts/tests/install-k8s.Tests.ps1
+++ b/scripts/tests/install-k8s.Tests.ps1
@@ -1,0 +1,232 @@
+# Pester tests for scripts/install-k8s.ps1 (Windows installer).
+# Dot-sources the script with $env:TB_PESTER set so the admin gate + main() are
+# skipped and only the functions load. Run: Invoke-Pester scripts/tests/
+
+BeforeAll {
+  $env:TB_PESTER = "1"
+  . "$PSScriptRoot/../install-k8s.ps1"
+  # Stubs so Pester can mock external commands that the functions invoke.
+  function kubectl { }
+}
+
+Describe "Get-BackendUrl" {
+  AfterEach { $env:CLIENT_ENV = $null }
+  It "defaults to prod when CLIENT_ENV is unset" {
+    $env:CLIENT_ENV = $null
+    Get-BackendUrl | Should -Be "https://api.tracebloc.io/"
+  }
+  It "dev" { $env:CLIENT_ENV = "dev"; Get-BackendUrl | Should -Be "https://dev-api.tracebloc.io/" }
+  It "stg" { $env:CLIENT_ENV = "stg"; Get-BackendUrl | Should -Be "https://stg-api.tracebloc.io/" }
+  It "unknown -> prod" { $env:CLIENT_ENV = "whatever"; Get-BackendUrl | Should -Be "https://api.tracebloc.io/" }
+}
+
+Describe "Test-Credentials" {
+  It "HTTP 200 -> valid" {
+    Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 200 } }
+    Test-Credentials -ClientId x -ClientPassword y | Should -Be "valid"
+  }
+  It "HTTP 400 -> invalid" {
+    Mock Invoke-WebRequest {
+      $resp = [pscustomobject]@{ StatusCode = 400 }
+      $ex = [System.Exception]::new("400"); $ex | Add-Member -NotePropertyName Response -NotePropertyValue $resp
+      throw $ex
+    }
+    Test-Credentials -ClientId x -ClientPassword y | Should -Be "invalid"
+  }
+  It "HTTP 401 -> inactive" {
+    Mock Invoke-WebRequest {
+      $resp = [pscustomobject]@{ StatusCode = 401 }
+      $ex = [System.Exception]::new("401"); $ex | Add-Member -NotePropertyName Response -NotePropertyValue $resp
+      throw $ex
+    }
+    Test-Credentials -ClientId x -ClientPassword y | Should -Be "inactive"
+  }
+  It "connection failure -> unverified" {
+    Mock Invoke-WebRequest { throw [System.Exception]::new("connection refused") }
+    Test-Credentials -ClientId x -ClientPassword y | Should -Be "unverified"
+  }
+  It "non-200 success -> unverified" {
+    Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 204 } }
+    Test-Credentials -ClientId x -ClientPassword y | Should -Be "unverified"
+  }
+}
+
+Describe "Get-NotReadyState" {
+  It "jobs-manager auth error -> bad_creds" {
+    Mock kubectl { if ($args -match 'logs') { "Authentication failed: Unable to log in" } else { "" } }
+    Get-NotReadyState -Namespace ns | Should -Be "bad_creds"
+  }
+  It "ImagePullBackOff -> image_pull" {
+    Mock kubectl { if ($args -match 'logs') { "booting" } else { "x 0/1 ImagePullBackOff" } }
+    Get-NotReadyState -Namespace ns | Should -Be "image_pull"
+  }
+  It "CrashLoopBackOff -> crash" {
+    Mock kubectl { if ($args -match 'logs') { "booting" } else { "x 0/1 CrashLoopBackOff" } }
+    Get-NotReadyState -Namespace ns | Should -Be "crash"
+  }
+  It "still creating -> starting" {
+    Mock kubectl { if ($args -match 'logs') { "booting" } else { "x 0/1 ContainerCreating" } }
+    Get-NotReadyState -Namespace ns | Should -Be "starting"
+  }
+}
+
+Describe "Print-Summary" {
+  BeforeEach { $script:TB_NAMESPACE = "ns"; $GPU_VENDOR = "none"; $NVIDIA_DRIVER_OK = $false }
+  It "connected: Connected + trust claim" {
+    $script:ClientState = "connected"
+    $out = Print-Summary 6>&1 | Out-String
+    $out | Should -Match "Connected to tracebloc"
+    $out | Should -Match "data never leaves"
+  }
+  It "starting: still starting, no trust claim" {
+    $script:ClientState = "starting"
+    $out = Print-Summary 6>&1 | Out-String
+    $out | Should -Match "still starting"
+    $out | Should -Not -Match "data never leaves"
+  }
+  It "bad_creds: rejected, no trust claim" {
+    $script:ClientState = "bad_creds"
+    $out = Print-Summary 6>&1 | Out-String
+    $out | Should -Match "rejected"
+    $out | Should -Not -Match "data never leaves"
+  }
+  It "crash: crash-loop message" {
+    $script:ClientState = "crash"
+    $out = Print-Summary 6>&1 | Out-String
+    $out | Should -Match "crash loop"
+  }
+}
+
+Describe "ConvertTo-WorkspaceName" {
+  It "lowercases + dashes spaces/underscores" { ConvertTo-WorkspaceName -Input_ "My Team_1" | Should -Be "my-team-1" }
+  It "all-invalid -> default" { ConvertTo-WorkspaceName -Input_ "@@@" | Should -Be "default" }
+}
+
+Describe "Get-WindowsArch" {
+  AfterEach { $env:PROCESSOR_ARCHITECTURE = "AMD64" }
+  It "AMD64 -> amd64" { $env:PROCESSOR_ARCHITECTURE = "AMD64"; Get-WindowsArch | Should -Be "amd64" }
+  It "ARM64 -> arm64" { $env:PROCESSOR_ARCHITECTURE = "ARM64"; Get-WindowsArch | Should -Be "arm64" }
+  It "unknown -> Err" {
+    Mock Err { throw "err" }
+    $env:PROCESSOR_ARCHITECTURE = "sparc"
+    { Get-WindowsArch } | Should -Throw
+  }
+}
+
+Describe "Confirm-Config" {
+  It "valid config passes + sets HOST_DATA_DIR" {
+    $env:USERPROFILE = $env:HOME
+    $CLUSTER_NAME = "tracebloc"; $SERVERS = "1"; $AGENTS = "1"; $HOST_DATA_DIR = "$env:HOME/.tracebloc"
+    { Confirm-Config } | Should -Not -Throw
+  }
+  It "invalid CLUSTER_NAME -> Err" {
+    Mock Err { throw "err" }
+    $env:USERPROFILE = $env:HOME
+    $CLUSTER_NAME = "1bad"; $SERVERS = "1"; $AGENTS = "1"; $HOST_DATA_DIR = "$env:HOME/x"
+    { Confirm-Config } | Should -Throw
+  }
+}
+
+Describe "Wait-ForClientReady" {
+  BeforeEach { $script:TB_NAMESPACE = "ns"; $ReadyTimeout = "20" }
+  It "all rollouts ready -> connected" {
+    Mock kubectl { $global:LASTEXITCODE = 0 }
+    Mock Confirm-Cluster { }
+    Wait-ForClientReady
+    $script:ClientState | Should -Be "connected"
+  }
+  It "a rollout fails -> diagnosed (bad_creds)" {
+    Mock kubectl {
+      if ($args -match 'rollout') { $global:LASTEXITCODE = 1; return }
+      $global:LASTEXITCODE = 0
+      if ($args -match 'logs') { return "Authentication failed: Unable to log in" }
+      return "x 0/1 CrashLoopBackOff"
+    }
+    Mock Confirm-Cluster { }
+    Wait-ForClientReady
+    $script:ClientState | Should -Be "bad_creds"
+  }
+}
+
+Describe "Install-ClientHelm" {
+  BeforeEach {
+    $GPU_VENDOR = "none"; $NVIDIA_DRIVER_OK = $false; $env:CLIENT_ENV = $null
+    Mock helm { $global:LASTEXITCODE = 0 }
+  }
+  It "valid creds: writes values.yaml + runs helm" {
+    $HOST_DATA_DIR = "$TestDrive/d1"
+    Mock Read-Host {
+      param([string]$Prompt, [switch]$AsSecureString)
+      if ($Prompt -match 'password') { return (ConvertTo-SecureString "mypw" -AsPlainText -Force) }
+      if ($Prompt -match 'Workspace') { return "myws" }
+      if ($Prompt -match 'Client ID') { return "myid" }
+      return ""
+    }
+    Mock Test-Credentials { "valid" }
+    Install-ClientHelm
+    (Get-Content "$HOST_DATA_DIR/values.yaml" -Raw) | Should -Match 'clientId: "myid"'
+    # NB: the SecureString->plaintext path runs, but PtrToStringAuto only decodes
+    # correctly on Windows; assert the key is written, not the macOS-decoded value.
+    (Get-Content "$HOST_DATA_DIR/values.yaml" -Raw) | Should -Match "clientPassword:"
+    Should -Invoke helm -ParameterFilter { $args -contains "upgrade" }
+  }
+  It "CLIENT_ENV=dev is written into the values" {
+    $HOST_DATA_DIR = "$TestDrive/d1b"; $CLIENT_ENV = "dev"
+    Mock Read-Host {
+      param([string]$Prompt, [switch]$AsSecureString)
+      if ($Prompt -match 'password') { return (ConvertTo-SecureString "pw" -AsPlainText -Force) }
+      if ($Prompt -match 'Workspace') { return "ws" }
+      return "id"
+    }
+    Mock Test-Credentials { "valid" }
+    Install-ClientHelm
+    (Get-Content "$HOST_DATA_DIR/values.yaml" -Raw) | Should -Match 'CLIENT_ENV: dev'
+  }
+  It "re-prompts on invalid, then accepts valid" {
+    $HOST_DATA_DIR = "$TestDrive/d2"; $script:vc = 0
+    Mock Read-Host {
+      param([string]$Prompt, [switch]$AsSecureString)
+      if ($Prompt -match 'password') { return (ConvertTo-SecureString "pw" -AsPlainText -Force) }
+      if ($Prompt -match 'Workspace') { return "ws" }
+      return "id"
+    }
+    Mock Test-Credentials { $script:vc++; if ($script:vc -ge 2) { "valid" } else { "invalid" } }
+    Install-ClientHelm
+    Should -Invoke Test-Credentials -Times 2
+    Should -Invoke helm -ParameterFilter { $args -contains "upgrade" }
+  }
+  It "unverified backend -> proceeds with install" {
+    $HOST_DATA_DIR = "$TestDrive/d3"
+    Mock Read-Host {
+      param([string]$Prompt, [switch]$AsSecureString)
+      if ($Prompt -match 'password') { return (ConvertTo-SecureString "pw" -AsPlainText -Force) }
+      if ($Prompt -match 'Workspace') { return "ws" }
+      return "id"
+    }
+    Mock Test-Credentials { "unverified" }
+    Install-ClientHelm
+    Should -Invoke helm -ParameterFilter { $args -contains "upgrade" }
+  }
+  It "reuses previous clientId/password defaults" {
+    $HOST_DATA_DIR = "$TestDrive/d4"; New-Item -ItemType Directory -Path $HOST_DATA_DIR -Force | Out-Null
+    Set-Content "$HOST_DATA_DIR/values.yaml" "clientId: `"previd`"`nclientPassword: 'prevpw'"
+    Mock Read-Host {
+      param([string]$Prompt, [switch]$AsSecureString)
+      if ($Prompt -match 'previous') { return "y" }
+      if ($Prompt -match 'password') { return (ConvertTo-SecureString "newpw" -AsPlainText -Force) }
+      if ($Prompt -match 'Workspace') { return "ws" }
+      return ""   # Client ID -> Enter keeps the previous default (previd)
+    }
+    Mock Test-Credentials { "valid" }
+    Install-ClientHelm
+    (Get-Content "$HOST_DATA_DIR/values.yaml" -Raw) | Should -Match 'clientId: "previd"'
+  }
+}
+
+Describe "Confirm-Cluster" {
+  It "dumps cluster status without error" {
+    $script:TB_NAMESPACE = "ns"; $script:LOG_FILE = "$TestDrive/log.txt"
+    Mock kubectl { "info" }
+    { Confirm-Cluster } | Should -Not -Throw
+  }
+}

--- a/scripts/tests/install-k8s.Tests.ps1
+++ b/scripts/tests/install-k8s.Tests.ps1
@@ -8,6 +8,8 @@ BeforeAll {
   # Stubs so Pester can mock external commands that the functions invoke.
   function kubectl { }
   function docker { }
+  function helm { }
+  function k3d { }
 }
 
 Describe "Get-BackendUrl" {
@@ -116,14 +118,18 @@ Describe "Get-WindowsArch" {
 
 Describe "Confirm-Config" {
   It "valid config passes + sets HOST_DATA_DIR" {
-    $env:USERPROFILE = $env:HOME
-    $CLUSTER_NAME = "tracebloc"; $SERVERS = "1"; $AGENTS = "1"; $HOST_DATA_DIR = "$env:HOME/.tracebloc"
+    # $env:HOME is empty on Windows (it uses USERPROFILE) — derive a profile dir
+    # valid on both OSes, else GetFullPath in Confirm-Config throws "path is empty".
+    $prof = if ($env:USERPROFILE) { $env:USERPROFILE } elseif ($env:HOME) { $env:HOME } else { [System.IO.Path]::GetTempPath() }
+    $env:USERPROFILE = $prof
+    $CLUSTER_NAME = "tracebloc"; $SERVERS = "1"; $AGENTS = "1"; $HOST_DATA_DIR = Join-Path $prof ".tracebloc"
     { Confirm-Config } | Should -Not -Throw
   }
   It "invalid CLUSTER_NAME -> Err" {
     Mock Err { throw "err" }
-    $env:USERPROFILE = $env:HOME
-    $CLUSTER_NAME = "1bad"; $SERVERS = "1"; $AGENTS = "1"; $HOST_DATA_DIR = "$env:HOME/x"
+    $prof = if ($env:USERPROFILE) { $env:USERPROFILE } elseif ($env:HOME) { $env:HOME } else { [System.IO.Path]::GetTempPath() }
+    $env:USERPROFILE = $prof
+    $CLUSTER_NAME = "1bad"; $SERVERS = "1"; $AGENTS = "1"; $HOST_DATA_DIR = Join-Path $prof "x"
     { Confirm-Config } | Should -Throw
   }
 }
@@ -376,5 +382,58 @@ Describe "Set-ClusterAutostart" {
     Mock docker { }
     Set-ClusterAutostart
     Should -Invoke docker -Times 0 -Exactly
+  }
+}
+
+# --- diagnose support bundle (mirrors scripts/lib/diagnose.sh) ---------------
+Describe "Edit-Redaction" {
+  It "redacts clientPassword / proxy creds / token; keeps clientId + NO_PROXY" {
+    $f = Join-Path $TestDrive "v.txt"
+    @"
+clientId: "abc-123"
+clientPassword: 'S3cr3tP@ss'
+HTTP_PROXY=http://user:s3cr3t@proxy:8080
+token: ghp_SECRET
+NO_PROXY=localhost,127.0.0.1
+"@ | Set-Content $f
+    Edit-Redaction $f
+    $c = Get-Content $f -Raw
+    $c | Should -Not -Match 'S3cr3tP@ss'
+    $c | Should -Not -Match 's3cr3t'
+    $c | Should -Not -Match 'ghp_SECRET'
+    $c | Should -Match 'abc-123'
+    $c | Should -Match '127\.0\.0\.1'
+  }
+  It "redacts any *password key (dockerRegistry password, HTTP_PROXY_PASSWORD)" {
+    $f = Join-Path $TestDrive "g.txt"
+    @"
+dockerRegistry:
+  password: dckr_REGTOKEN
+HTTP_PROXY_PASSWORD: PROXYPW123
+"@ | Set-Content $f
+    Edit-Redaction $f
+    $c = Get-Content $f -Raw
+    $c | Should -Not -Match 'dckr_REGTOKEN'
+    $c | Should -Not -Match 'PROXYPW123'
+  }
+  It "missing file -> no throw" {
+    { Edit-Redaction (Join-Path $TestDrive "nope.txt") } | Should -Not -Throw
+  }
+}
+
+Describe "Invoke-DiagnoseBundle" {
+  It "produces a bundle and a seeded secret does NOT survive in it" {
+    $HOST_DATA_DIR = Join-Path $TestDrive "tb"
+    New-Item -ItemType Directory -Path $HOST_DATA_DIR -Force | Out-Null
+    "clientPassword: 'LEAKME123'" | Set-Content (Join-Path $HOST_DATA_DIR "values.yaml")
+    Mock kubectl { "" }; Mock docker { "" }; Mock helm { "" }; Mock k3d { "" }
+    Mock Get-WindowsArch { "amd64" }   # avoid the PROCESSOR_ARCHITECTURE Err off-Windows
+    { Invoke-DiagnoseBundle } | Should -Not -Throw
+    $zip = Get-ChildItem $HOST_DATA_DIR -Filter 'tracebloc-diagnose-*.zip' | Select-Object -First 1
+    $zip | Should -Not -BeNullOrEmpty
+    $ex = Join-Path $TestDrive "ex"
+    Expand-Archive -Path $zip.FullName -DestinationPath $ex -Force
+    $all = (Get-ChildItem $ex -Recurse -File | ForEach-Object { Get-Content $_.FullName -Raw }) -join "`n"
+    $all | Should -Not -Match 'LEAKME123'
   }
 }

--- a/scripts/tests/preflight.bats
+++ b/scripts/tests/preflight.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+# Tests for scripts/lib/preflight.sh — fail-fast environment checks
+# (arch / connectivity / disk / RAM / CPU). The checks delegate to small
+# injectable readers, which we override here so nothing touches the real
+# network, df, or /proc. Counter assertions call the function directly (bats
+# `run` executes in a subshell, so PF_HARD_FAIL wouldn't propagate back).
+load test_helper
+
+setup() {
+  load_lib preflight.sh
+  PF_HARD_FAIL=0
+  # Default-safe stubs (a healthy amd64 box); individual tests override.
+  _pf_probe_url() { echo ok; }
+  _pf_free_kb() { echo $((50 * 1024 * 1024)); }       # 50 GB
+  _pf_total_mem_kb() { echo $((8 * 1024 * 1024)); }   # 8 GB
+  _pf_ncpu() { echo 4; }
+  _pf_amd64_emulation_available() { return 0; }
+  docker() { return 1; }   # keep _pf_docker_root off the real daemon
+  has() { return 0; }      # pretend tools present (conds empty) unless overridden
+  OS="Linux"; ARCH="x86_64"
+}
+
+# ── _pf_arch ─────────────────────────────────────────────────────────────────
+@test "_pf_arch: amd64 -> success, no hard fail" {
+  ARCH=x86_64
+  run _pf_arch
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"amd64"* ]]
+}
+
+@test "_pf_arch: arm64 Linux without emulation -> hard fail + binfmt remedy" {
+  ARCH=aarch64; OS=Linux
+  _pf_amd64_emulation_available() { return 1; }
+  run _pf_arch
+  [[ "$output" == *"amd64-only"* ]]
+  [[ "$output" == *"tonistiigi/binfmt"* ]]
+  PF_HARD_FAIL=0; _pf_arch >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 1 ]
+}
+
+@test "_pf_arch: arm64 Linux WITH emulation -> info, no hard fail" {
+  ARCH=aarch64; OS=Linux
+  _pf_amd64_emulation_available() { return 0; }
+  PF_HARD_FAIL=0; _pf_arch >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_arch: arm64 macOS -> info (Desktop emulation), no hard fail" {
+  ARCH=arm64; OS=Darwin
+  PF_HARD_FAIL=0; _pf_arch >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_arch: arm64 + TRACEBLOC_ALLOW_ARM64 -> warn, no hard fail" {
+  ARCH=aarch64; OS=Linux; export TRACEBLOC_ALLOW_ARM64=1
+  _pf_amd64_emulation_available() { return 1; }
+  run _pf_arch
+  [[ "$output" == *"proceeding"* ]]
+  PF_HARD_FAIL=0; _pf_arch >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+  unset TRACEBLOC_ALLOW_ARM64
+}
+
+# ── _pf_connectivity ─────────────────────────────────────────────────────────
+@test "_pf_connectivity: all reachable -> no hard fail" {
+  _pf_probe_url() { echo ok; }
+  PF_HARD_FAIL=0; _pf_connectivity >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_connectivity: a critical host blocked -> hard fail + allowlist hint" {
+  _pf_probe_url() { case "$1" in *ghcr*) echo blocked ;; *) echo ok ;; esac; }
+  run _pf_connectivity
+  [[ "$output" == *"ghcr.io) unreachable"* ]]
+  [[ "$output" == *"Allow HTTPS"* ]]
+  PF_HARD_FAIL=0; _pf_connectivity >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 1 ]
+}
+
+@test "_pf_connectivity: TLS error -> break-and-inspect (Gap D) hint" {
+  _pf_probe_url() { case "$1" in *registry-1.docker*) echo tls ;; *) echo ok ;; esac; }
+  run _pf_connectivity
+  [[ "$output" == *"break-and-inspect"* ]]
+}
+
+@test "_pf_connectivity: tool host skipped when the tool is present" {
+  _pf_probe_url() { echo ok; }
+  has() { return 0; }
+  run _pf_connectivity
+  [[ "$output" != *"get.docker.com"* ]]
+}
+
+@test "_pf_connectivity: tool host probed (warn-only) when the tool is missing" {
+  _pf_probe_url() { case "$1" in *get.docker.com*) echo blocked ;; *) echo ok ;; esac; }
+  has() { return 1; }
+  OS=Linux
+  run _pf_connectivity
+  [[ "$output" == *"get.docker.com"* ]]
+  # a missing tool host is warn-only, never a hard fail
+  PF_HARD_FAIL=0; _pf_connectivity >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+# ── _pf_disk / _pf_memory / _pf_cpu ──────────────────────────────────────────
+@test "_pf_disk: ample free space -> success" {
+  OS=Linux; _pf_free_kb() { echo $((50 * 1024 * 1024)); }
+  run _pf_disk; [[ "$output" == *"50 GB free"* ]]
+  PF_HARD_FAIL=0; _pf_disk >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_disk: low (<20 GB) -> warn, no hard fail" {
+  OS=Linux; _pf_free_kb() { echo $((10 * 1024 * 1024)); }
+  run _pf_disk; [[ "$output" == *"recommended"* ]]
+  PF_HARD_FAIL=0; _pf_disk >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_disk: critically low (<5 GB) -> hard fail" {
+  OS=Linux; _pf_free_kb() { echo $((2 * 1024 * 1024)); }
+  run _pf_disk; [[ "$output" == *"need"* ]]
+  PF_HARD_FAIL=0; _pf_disk >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 1 ]
+}
+
+@test "_pf_disk: macOS -> info only (Desktop VM disk is opaque)" {
+  OS=Darwin; _pf_free_kb() { echo $((2 * 1024 * 1024)); }   # even 'low' must not fail
+  PF_HARD_FAIL=0; _pf_disk >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_memory: low RAM -> warn" {
+  _pf_total_mem_kb() { echo $((2 * 1024 * 1024)); }
+  run _pf_memory; [[ "$output" == *"recommended"* ]]
+}
+
+@test "_pf_memory: ample RAM -> success" {
+  _pf_total_mem_kb() { echo $((8 * 1024 * 1024)); }
+  run _pf_memory; [[ "$output" == *"8 GB"* ]]
+}
+
+@test "_pf_cpu: too few cores -> warn" {
+  _pf_ncpu() { echo 1; }
+  run _pf_cpu; [[ "$output" == *"recommended"* ]]
+}
+
+@test "_pf_cpu: enough cores -> success" {
+  _pf_ncpu() { echo 4; }
+  run _pf_cpu; [[ "$output" == *"4 cores"* ]]
+}
+
+# ── run_preflight orchestration ──────────────────────────────────────────────
+@test "run_preflight: TRACEBLOC_SKIP_PREFLIGHT -> skipped, exit 0" {
+  export TRACEBLOC_SKIP_PREFLIGHT=1
+  run run_preflight
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipped"* ]]
+  unset TRACEBLOC_SKIP_PREFLIGHT
+}
+
+@test "run_preflight: a hard failure -> non-zero exit + aggregated summary" {
+  ARCH=x86_64; OS=Linux
+  _pf_probe_url() { case "$1" in *registry-1.docker*) echo blocked ;; *) echo ok ;; esac; }
+  run run_preflight
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Preflight failed"* ]]
+}
+
+@test "run_preflight: healthy environment -> exit 0" {
+  ARCH=x86_64; OS=Linux
+  _pf_probe_url() { echo ok; }
+  run run_preflight
+  [ "$status" -eq 0 ]
+}

--- a/scripts/tests/preflight.bats
+++ b/scripts/tests/preflight.bats
@@ -86,7 +86,7 @@ setup() {
 
 @test "_pf_connectivity: tool host probed (warn-only) when the tool is missing" {
   _pf_probe_url() { case "$1" in *get.docker.com*) echo blocked ;; *) echo ok ;; esac; }
-  has() { return 1; }
+  has() { [[ "$1" == "curl" ]]; }   # curl present (probing possible), other tools missing
   OS=Linux
   run _pf_connectivity
   [[ "$output" == *"get.docker.com"* ]]
@@ -160,4 +160,39 @@ setup() {
   _pf_probe_url() { echo ok; }
   run run_preflight
   [ "$status" -eq 0 ]
+}
+
+# ── real _pf_probe_url + readers (setup() stubs them; re-source for the real ones) ──
+@test "_pf_probe_url: maps curl outcomes to tokens" {
+  source "${BATS_TEST_DIRNAME}/../lib/preflight.sh"   # restore the real function
+  has() { return 0; }                                  # 'has curl' true
+  curl() { return 6; };             run _pf_probe_url https://x; [ "$output" = "dns" ]
+  curl() { return 7; };             run _pf_probe_url https://x; [ "$output" = "refused" ]
+  curl() { return 28; };            run _pf_probe_url https://x; [ "$output" = "timeout" ]
+  curl() { return 60; };            run _pf_probe_url https://x; [ "$output" = "tls" ]
+  curl() { printf '200'; return 0;};run _pf_probe_url https://x; [ "$output" = "ok" ]
+}
+
+@test "_pf_probe_url: missing curl -> nocurl" {
+  source "${BATS_TEST_DIRNAME}/../lib/preflight.sh"
+  has() { return 1; }
+  run _pf_probe_url https://x
+  [ "$output" = "nocurl" ]
+}
+
+@test "_pf readers return a number on this host" {
+  source "${BATS_TEST_DIRNAME}/../lib/preflight.sh"
+  OS="$(uname -s)"
+  run _pf_ncpu;         [[ "$output" =~ ^[0-9]+$ ]]
+  run _pf_total_mem_kb; [[ "$output" =~ ^[0-9]+$ ]]
+  run _pf_free_kb /;    [[ "$output" =~ ^[0-9]+$ ]]
+}
+
+# Code review: curl absent must SKIP connectivity (curl is installed downstream),
+# not hard-fail with a misleading "egress blocked".
+@test "_pf_connectivity: no curl -> warn + skip, not a hard fail" {
+  has() { return 1; }
+  run _pf_connectivity
+  [[ "$output" == *"Skipping connectivity"* ]]
+  PF_HARD_FAIL=0; _pf_connectivity >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
 }

--- a/scripts/tests/setup-linux.bats
+++ b/scripts/tests/setup-linux.bats
@@ -71,6 +71,22 @@ setup() {
   run mock_calls
   [[ "$output" != *"Installing conntrack"* ]]
 }
+# Caught by the cross-distro CI matrix on Amazon Linux 2023: helm's get-helm-3
+# needs openssl (checksum) + tar (unpack), absent on minimal cloud images.
+@test "install_system_deps: ensures openssl + tar (helm needs them on minimal images)" {
+  PRESENT_CMDS="dnf curl conntrack"   # openssl + tar absent
+  run install_system_deps
+  run mock_calls
+  [[ "$output" == *"Installing openssl"* ]]
+  [[ "$output" == *"Installing tar"* ]]
+}
+@test "install_system_deps: openssl + tar already present -> not reinstalled" {
+  PRESENT_CMDS="apt-get curl conntrack openssl tar"
+  run install_system_deps
+  run mock_calls
+  [[ "$output" != *"Installing openssl"* ]]
+  [[ "$output" != *"Installing tar"* ]]
+}
 
 # ── install_docker_engine: branch selection ────────────────────────────────
 @test "install_docker_engine: Amazon Linux -> dnf docker" {
@@ -134,4 +150,31 @@ setup() {
   [ "$status" -eq 0 ]
   run mock_calls
   [ -z "$output" ]
+}
+
+# ── install_docker_engine: dead daemon vs group-not-active (Asad's Alma9 case) ──
+@test "install_docker_engine: daemon won't start -> Docker's error, not the group hint" {
+  PRESENT_CMDS="docker"          # docker present -> skip install
+  docker() { return 1; }         # docker info fails
+  id() { echo "testuser"; }      # NOT in docker group -> no sg re-exec
+  sudo() {
+    case "$*" in *"is-active"*) return 1 ;; esac   # daemon not active
+    record "sudo $*"; return 0
+  }
+  run install_docker_engine
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"daemon won't start"* ]]
+  [[ "$output" != *"logging out"* ]]               # the misleading group hint is NOT used
+}
+
+# Asad's root cause: minimal AlmaLinux lacks xt_addrtype -> dockerd bridge init fails.
+@test "_ensure_kernel_modules: modprobes modules + installs kernel-modules on a load failure" {
+  has() { [[ "$1" == "dnf" ]]; }
+  sudo() { record "sudo $*"; case "$*" in *modprobe*) return 1 ;; esac; return 0; }
+  spin_cmd() { record "$*"; return 0; }
+  run _ensure_kernel_modules
+  run mock_calls
+  [[ "$output" == *"modprobe overlay"* ]]
+  [[ "$output" == *"modprobe xt_addrtype"* ]]
+  [[ "$output" == *"kernel-modules-"* ]]           # RHEL fallback install fired
 }

--- a/scripts/tests/setup-linux.bats
+++ b/scripts/tests/setup-linux.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# Tests for scripts/lib/setup-linux.sh — RHEL Docker (#719), k3d secure_path
+# (#718), conntrack package name (#720), package-manager detection.
+load test_helper
+
+setup() {
+  load_lib setup-linux.sh
+  MOCK_CALLS="$(mktemp)"
+  PRESENT_CMDS="curl conntrack"
+  TEST_DISTRO=ubuntu
+  USER=testuser
+  PM_UPDATE="pmupdate"; PM_INSTALL="pminstall"
+
+  has()       { case " $PRESENT_CMDS " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+  spin_cmd()  { record "$*"; return 0; }
+  sudo()      { record "sudo $*"; return 0; }
+  systemctl() { return 0; }
+  usermod()   { return 0; }
+  docker()    { return 0; }   # `docker info` succeeds → skip the sg-docker re-exec
+  id()        { echo "testuser docker"; }
+  curl()      { record "curl $*"; return 0; }
+  # Simulate /etc/os-release matching per TEST_DISTRO; delegate other greps.
+  grep() {
+    if [[ "$*" == *"/etc/os-release"* ]]; then
+      case "$TEST_DISTRO" in
+        amzn) [[ "$*" == *amzn* ]] ;;
+        alma) [[ "$*" == *almalinux* ]] ;;
+        *)    return 1 ;;
+      esac
+      return
+    fi
+    command grep "$@"
+  }
+}
+
+# ── setup_pm ───────────────────────────────────────────────────────────────
+@test "setup_pm: apt-get detected" {
+  PRESENT_CMDS="apt-get"
+  setup_pm
+  [[ "$PM_INSTALL" == *"apt-get install"* ]]
+}
+@test "setup_pm: dnf detected" {
+  PRESENT_CMDS="dnf"
+  setup_pm
+  [[ "$PM_INSTALL" == *"dnf install"* ]]
+}
+@test "setup_pm: none -> error" {
+  PRESENT_CMDS=""
+  run setup_pm
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"No supported package manager"* ]]
+}
+
+# ── install_system_deps: conntrack package name (#720) ─────────────────────
+@test "install_system_deps: apt uses 'conntrack'" {
+  PRESENT_CMDS="apt-get curl"      # apt present, conntrack binary absent
+  run install_system_deps
+  run mock_calls
+  [[ "$output" == *"conntrack"* ]]
+  [[ "$output" != *"conntrack-tools"* ]]
+}
+@test "install_system_deps: dnf uses 'conntrack-tools'" {
+  PRESENT_CMDS="dnf curl"          # no apt-get, conntrack binary absent
+  run install_system_deps
+  run mock_calls
+  [[ "$output" == *"conntrack-tools"* ]]
+}
+@test "install_system_deps: conntrack present -> not installed" {
+  PRESENT_CMDS="apt-get curl conntrack"
+  run install_system_deps
+  run mock_calls
+  [[ "$output" != *"Installing conntrack"* ]]
+}
+
+# ── install_docker_engine: branch selection ────────────────────────────────
+@test "install_docker_engine: Amazon Linux -> dnf docker" {
+  PRESENT_CMDS="dnf"; TEST_DISTRO=amzn
+  run install_docker_engine
+  run mock_calls
+  [[ "$output" == *"dnf install -y docker"* ]]
+}
+@test "install_docker_engine: Arch -> pacman docker" {
+  PRESENT_CMDS="pacman"; TEST_DISTRO=ubuntu
+  run install_docker_engine
+  run mock_calls
+  [[ "$output" == *"pacman -S --noconfirm docker"* ]]
+}
+@test "install_docker_engine: SUSE -> zypper docker" {
+  PRESENT_CMDS="zypper"; TEST_DISTRO=ubuntu
+  run install_docker_engine
+  run mock_calls
+  [[ "$output" == *"zypper install -y docker"* ]]
+}
+@test "install_docker_engine: RHEL clone (#719) -> docker-ce dnf repo" {
+  PRESENT_CMDS=""; TEST_DISTRO=alma
+  run install_docker_engine
+  run mock_calls
+  [[ "$output" == *"docker-ce.repo"* ]]
+  [[ "$output" == *"docker-ce docker-ce-cli containerd.io"* ]]
+}
+@test "install_docker_engine: Debian/Ubuntu -> get.docker.com" {
+  PRESENT_CMDS="curl"; TEST_DISTRO=ubuntu
+  run install_docker_engine
+  run mock_calls
+  [[ "$output" == *"get.docker.com"* ]]
+}
+@test "install_docker_engine: docker already present -> no install" {
+  PRESENT_CMDS="docker"; TEST_DISTRO=ubuntu
+  run install_docker_engine
+  run mock_calls
+  [[ "$output" != *"get.docker.com"* ]]
+  [[ "$output" != *"docker-ce.repo"* ]]
+}
+
+# ── install_k3d: PATH preserved through sudo (#718) ────────────────────────
+@test "install_k3d: installs via 'sudo env PATH=' (#718)" {
+  PRESENT_CMDS="curl"
+  has() {
+    if [ "$1" = k3d ]; then [ -f "$BATS_TEST_TMPDIR/k3di" ]
+    else case " $PRESENT_CMDS " in *" $1 "*) return 0 ;; *) return 1 ;; esac; fi
+  }
+  spin_cmd() { record "$*"; touch "$BATS_TEST_TMPDIR/k3di"; return 0; }
+  run install_k3d
+  [ "$status" -eq 0 ]
+  run mock_calls
+  [[ "$output" == *"sudo env"* ]]
+  [[ "$output" == *"PATH="* ]]
+  [[ "$output" == *"bash"* ]]
+}
+@test "install_k3d: already present -> skip" {
+  has() { [ "$1" = k3d ]; }
+  spin_cmd() { record "$*"; return 0; }
+  run install_k3d
+  [ "$status" -eq 0 ]
+  run mock_calls
+  [ -z "$output" ]
+}

--- a/scripts/tests/summary.bats
+++ b/scripts/tests/summary.bats
@@ -91,3 +91,24 @@ setup() {
   [[ "$output" == *"crash loop"* ]]
   [[ "$output" != *"data never leaves"* ]]
 }
+
+# ── _reboot_note (reboot persistence) ───────────────────────────────────────
+@test "_reboot_note: Linux -> survives-reboot line" {
+  OS=Linux
+  run _reboot_note
+  [[ "$output" == *"Survives reboot"* ]]
+  [[ "$output" != *"Docker Desktop"* ]]
+}
+
+@test "_reboot_note: macOS -> Docker Desktop start-on-login instruction" {
+  OS=Darwin
+  run _reboot_note
+  [[ "$output" == *"Docker Desktop"* ]]
+  [[ "$output" == *"sign in"* ]]
+}
+
+@test "print_summary connected: includes the reboot note" {
+  CLIENT_STATE=connected; OS=Linux
+  run print_summary
+  [[ "$output" == *"Survives reboot"* ]]
+}

--- a/scripts/tests/summary.bats
+++ b/scripts/tests/summary.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# Tests for scripts/lib/summary.sh — readiness gate + state-branched summary (#716)
+load test_helper
+
+setup() {
+  load_lib summary.sh
+  TB_NAMESPACE=testns
+  GPU_VENDOR=none
+}
+
+# ── _diagnose_not_ready ────────────────────────────────────────────────────
+@test "_diagnose_not_ready: jobs-manager auth error -> bad_creds" {
+  kubectl() { case "$*" in *logs*) echo "Exception: Authentication failed: Unable to log in with provided credentials";; *) echo "x 0/2 CrashLoopBackOff";; esac; }
+  run _diagnose_not_ready testns
+  [ "$output" = "bad_creds" ]
+}
+
+@test "_diagnose_not_ready: ImagePullBackOff -> image_pull" {
+  kubectl() { case "$*" in *logs*) echo "booting";; *) echo "x 0/1 ImagePullBackOff";; esac; }
+  run _diagnose_not_ready testns
+  [ "$output" = "image_pull" ]
+}
+
+@test "_diagnose_not_ready: CrashLoopBackOff (no auth err) -> crash" {
+  kubectl() { case "$*" in *logs*) echo "booting";; *) echo "x 0/1 CrashLoopBackOff";; esac; }
+  run _diagnose_not_ready testns
+  [ "$output" = "crash" ]
+}
+
+@test "_diagnose_not_ready: still creating -> starting" {
+  kubectl() { case "$*" in *logs*) echo "booting";; *) echo "x 0/1 ContainerCreating";; esac; }
+  run _diagnose_not_ready testns
+  [ "$output" = "starting" ]
+}
+
+# ── wait_for_client_ready ──────────────────────────────────────────────────
+@test "wait_for_client_ready: all rollouts succeed -> connected" {
+  kubectl() { case "$*" in *"rollout status"*) return 0;; *) echo "";; esac; }
+  READY_TIMEOUT=20
+  CLIENT_STATE=""
+  wait_for_client_ready
+  [ "$CLIENT_STATE" = "connected" ]
+}
+
+@test "wait_for_client_ready: a rollout fails -> diagnosed (bad_creds)" {
+  kubectl() {
+    case "$*" in
+      *"rollout status"*) return 1 ;;
+      *logs*) echo "Authentication failed: Unable to log in" ;;
+      *) echo "x 0/2 CrashLoopBackOff" ;;
+    esac
+  }
+  READY_TIMEOUT=20
+  CLIENT_STATE=""
+  wait_for_client_ready
+  [ "$CLIENT_STATE" = "bad_creds" ]
+}
+
+# ── print_summary: the trust claim must appear ONLY when connected ─────────
+@test "print_summary connected: Connected + trust claim" {
+  CLIENT_STATE=connected
+  run print_summary
+  [[ "$output" == *"Connected to tracebloc"* ]]
+  [[ "$output" == *"data never leaves"* ]]
+}
+
+@test "print_summary starting: 'still starting', no trust claim" {
+  CLIENT_STATE=starting
+  run print_summary
+  [[ "$output" == *"still starting"* ]]
+  [[ "$output" != *"data never leaves"* ]]
+}
+
+@test "print_summary bad_creds: 'rejected', no trust claim" {
+  CLIENT_STATE=bad_creds
+  run print_summary
+  [[ "$output" == *"rejected"* ]]
+  [[ "$output" != *"data never leaves"* ]]
+}
+
+@test "print_summary image_pull: image message, no trust claim" {
+  CLIENT_STATE=image_pull
+  run print_summary
+  [[ "$output" == *"image couldn't be pulled"* ]]
+  [[ "$output" != *"data never leaves"* ]]
+}
+
+@test "print_summary crash: crash-loop message" {
+  CLIENT_STATE=crash
+  run print_summary
+  [[ "$output" == *"crash loop"* ]]
+  [[ "$output" != *"data never leaves"* ]]
+}

--- a/scripts/tests/test_helper.bash
+++ b/scripts/tests/test_helper.bash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Shared helpers + mock scaffolding for the installer bats suite.
+# The installer libs are side-effect-safe to `source` (no top-level install
+# logic); only install-k8s.sh runs main(), which the tests never source.
+
+LIB_DIR="${BATS_TEST_DIRNAME}/../lib"
+SCRIPTS_DIR="${BATS_TEST_DIRNAME}/.."
+
+# Source common.sh (logging helpers, colours, has/retry) + an optional target lib.
+load_lib() {
+  # shellcheck source=/dev/null
+  source "${LIB_DIR}/common.sh"
+  if [ -n "${1:-}" ]; then
+    # shellcheck source=/dev/null
+    source "${LIB_DIR}/$1"
+  fi
+  LOG_FILE=/dev/null   # make log() a silent sink during tests
+}
+
+# Record a mock invocation (one line per call) for later assertions.
+record()     { printf '%s\n' "$*" >>"${MOCK_CALLS:-/dev/null}"; }
+mock_calls() { cat "${MOCK_CALLS:-/dev/null}" 2>/dev/null; }


### PR DESCRIPTION
## Summary
Promotes the installer-hardening series to production by syncing develop → main and releasing chart **v1.4.3**.

Includes (#171–#175):
- RHEL-family Linux support (AlmaLinux/Rocky/Oracle/Amazon Linux) + kernel-modules-extra self-heal with reboot-required UX
- Credential + readiness verification before reporting success (Linux + Windows parity)
- Preflight gate (arch, egress, disk, RAM, CPU)
- Reboot persistence (auto-restart on boot)
- `--diagnose` redacted support bundle
- Hardened corporate-proxy support (auth proxy, NO_PROXY, 0.0.0.0 detection)
- bats/Pester/E2E CI suites

## Notes
- **Installer-only release** — `client/` (chart templates/values) is unchanged from 1.4.2; published chart artifacts are byte-identical. The public installer one-liner runs from `main`, so this sync is what delivers the hardening to users.
- Validated end-to-end: live AlmaLinux self-heal + real-creds "Connected" run.

## Release steps after merge
- [ ] Publish GitHub Release **v1.4.3** (tag on main tip) → triggers `release-helm-chart.yaml` chart packaging to gh-pages
- [ ] Back-merge: Sync main → develop after v1.4.3 release

Tracking: #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide changes to production install paths (proxy, credentials, Docker/k3s on RHEL) affect every customer bootstrap; risk is mitigated by extensive bats/Pester and distro/E2E CI, while the published chart content is unchanged aside from the version label.
> 
> **Overview**
> Releases chart **v1.4.3** (version bump only; templates unchanged from 1.4.2) and ships a large **installer hardening** pass on Linux/bash and Windows/PowerShell, plus dedicated CI.
> 
> **Installer behavior:** Adds **preflight** (arch, egress, disk/RAM/CPU) and **`--diagnose`** redacted support bundles. **Corporate proxy** support now uses a k3d **config file** so `user:pass@host` URLs work, with auto-augmented **NO_PROXY** and warnings for existing clusters on **0.0.0.0** API binds. **Credentials** are checked against `api-token-auth/` before Helm; install waits for deployments and reports **connected / starting / bad_creds / image_pull / crash** with matching exit codes. **Linux** gains RHEL-family Docker (`docker-ce`), kernel-modules-extra handling, distro-correct **conntrack**, **openssl/tar** for Helm, **k3d** install with `sudo env PATH=…`, and reboot **autostart** for k3d nodes and `docker.service`. **Windows** mirrors proxy, preflight, diagnose, credential verify, and readiness. **INSTALL.md** documents egress allowlists and proxy/TLS notes.
> 
> **CI:** New **`installer-tests.yaml`** (shellcheck, bats, Pester on Ubuntu + Windows, real prereq installs in nine distro containers, k3d E2E on multiple runners, authenticated squid proxy E2E). Helm CI notes installer tests moved out of that workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a78e0c8469a7dcec26e7cc6336e56d168313a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->