### PR TITLE
fix(rbac): grant `get` on configmaps/secrets to jobs-manager SA

### DIFF
--- a/client/templates/rbac.yaml
+++ b/client/templates/rbac.yaml
@@ -44,7 +44,12 @@ rules:
     verbs: ["create"]
   - apiGroups: [""]
     resources: ["configmaps", "secrets"]
-    verbs: ["create"]
+    # `get` is required by jobs-manager's orphan-resource verify path
+    # (client-runtime#52) and the missing-row self-heal (client-runtime#54):
+    # on a create-409 it reads the existing ConfigMap/Secret to confirm the
+    # content matches before reusing it. Without `get`, those reads return
+    # Forbidden and the endpoint 500s instead of the intended 409/replay.
+    verbs: ["create", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -95,7 +100,12 @@ rules:
   # to authenticate ingestion calls — see the ClusterRole branch above.
   - apiGroups: [""]
     resources: ["configmaps", "secrets"]
-    verbs: ["create"]
+    # `get` is required by jobs-manager's orphan-resource verify path
+    # (client-runtime#52) and the missing-row self-heal (client-runtime#54):
+    # on a create-409 it reads the existing ConfigMap/Secret to confirm the
+    # content matches before reusing it. Without `get`, those reads return
+    # Forbidden and the endpoint 500s instead of the intended 409/replay.
+    verbs: ["create", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary

The ingestion endpoint (`POST /internal/submit-ingestion-run`) on jobs-manager reads the existing ConfigMap/Secret on a create-409 to verify content before reuse:
- **orphan-resource verify** ([client-runtime#52](https://github.com/tracebloc/client-runtime/pull/52)) — `_verify_existing_configmap_matches` / `_verify_existing_secret_matches`
- **missing-row self-heal** ([client-runtime#54](https://github.com/tracebloc/client-runtime/pull/54)) — `_self_heal_or_concurrent_conflict`

Both call `read_namespaced_config_map` / `read_namespaced_secret`, which require the `get` verb. The Role/ClusterRole only granted `create`, so on the real cluster those reads return **Forbidden** and the endpoint returns **500** instead of the intended **409 / 200-replay**.

## Fix

Add `get` alongside `create` on `["configmaps", "secrets"]` in **both** the ClusterRole (`clusterScope: true`) and namespace Role (`clusterScope: false`) branches of `client/templates/rbac.yaml`.

## Verification (dev cluster `tb-client-dev-templates`)

Reproduced live: with only `create`, planting an orphan ConfigMap + re-POSTing returned:
```
HTTP 500 {"error":"failed to read existing ConfigMap '…' after 409: Forbidden"}
```
After temporarily granting `get`, the same requests returned the intended results — orphan-content mismatch → **409**, matching content → **201/200 replay**, and #54's self-heal → **200 replay**. This PR makes that grant permanent.

- `helm template` renders cleanly in both `clusterScope` branches with `verbs: ["create", "get"]`.

Unblocks the orphan-recovery / self-heal paths shipped in client-runtime #52 and #54, which are non-functional in dev/prod until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped RBAC verb addition on resources the SA already creates; fixes broken 409/replay paths without changing auth or ingestion logic.
> 
> **Overview**
> Grants the jobs-manager service account **`get`** on **`configmaps`** and **`secrets`** (in addition to **`create`**) in **`client/templates/rbac.yaml`**, for both **`clusterScope: true`** (ClusterRole) and **`clusterScope: false`** (namespace Role).
> 
> That permission is needed when ingestion creates a ConfigMap/Secret and Kubernetes returns **409**: jobs-manager must read the existing object to verify content (orphan recovery) or self-heal/replay. Without **`get`**, those reads fail with **Forbidden** and **`POST /internal/submit-ingestion-run`** returns **500** instead of the intended **409** or replay behavior from client-runtime **#52** / **#54**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1070ca1464e13befc51e3a82e1b127ab1109f578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->