### PR TITLE
chore(#184): pin greenfield ingestor baseline to v0.3.2

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.4.3
-appVersion: "1.4.3"
+version: 1.4.4
+appVersion: "1.4.4"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -213,13 +213,14 @@ images:
   # Customers can also override per-install via the ingestor subchart's
   # `image.digest` for one-off testing, independent of this value.
   ingestor:
-    # Current baseline digest: v0.3.1 (2026-05-25, from #161). Patch on
-    # top of v0.3.0 carrying customer-impacting fixes —
-    # tracebloc/data-ingestors#108 (tokenizer.json copy for MLM
-    # datasets) and #119 (per-category metadata parity for tabular +
-    # keypoint). Bump only when greenfield installs should start on a
+    # Current baseline digest: v0.3.2 (2026-06-03, from #184). Patch on
+    # top of v0.3.1 carrying customer-impacting fixes —
+    # tracebloc/data-ingestors#139 (MLM tokenizer fix, relaxed PascalVOC
+    # `difficult` flag, reserved-id guard; closes #137 / #135) — plus the
+    # first multi-arch image (amd64 + arm64, #24) so arm64 nodes can run
+    # the ingestor. Bump only when greenfield installs should start on a
     # different version; ongoing rollouts are managed by image-refresh.
-    digest: "sha256:a0861ea9fbf4653279351ee30af9ebe2b75fcacd391923b681631312f4a85ee4"
+    digest: "sha256:d361fa778554ab171adcc2671eaf109c32f3d2af339c7920a2d38d102ce53678"
     # Floating tag polled by image-refresh. The team's ghcr.io
     # publishing convention uses semver-style float tags — `0` tracks
     # the latest 0.x, `0.3` tracks the latest 0.3.x patch. Default is


### PR DESCRIPTION
## Summary
Bumps the **greenfield-install baseline** for the ingestor image to v0.3.2 so brand-new installs start on it immediately, and bumps the client chart version in lockstep. Live clusters already converge to v0.3.2 on their own via image-refresh (float tag `0.3`, `autoRefresh: true`) — this is the explicit-baseline path only. Mirrors #161 (the v0.3.1 baseline bump).

- `client/values.yaml` `images.ingestor.digest`: `sha256:a0861ea9…` (v0.3.1) → `sha256:d361fa77…` (v0.3.2)
- `client/Chart.yaml` `version` + `appVersion`: `1.4.3` → `1.4.4`

The digest is the cosign-signed image from [data-ingestors release v0.3.2](https://github.com/tracebloc/data-ingestors/releases/tag/v0.3.2).

## Related
Closes #184

## Type of change
- [x] Tech-debt / refactor (release packaging)

## What v0.3.2 carries over v0.3.1
- [tracebloc/data-ingestors#139](https://github.com/tracebloc/data-ingestors/pull/139) — MLM tokenizer fix, relaxed PascalVOC `difficult` flag, reserved-id guard (closes #137 / #135)
- First **multi-arch** ingestor image (amd64 + arm64, #24) — arm64 nodes can now run the ingestor

## Test plan
- `git diff` confirms only the two intended lines (digest + chart version/appVersion) changed.
- Digest matches the canonical sha256 in the v0.3.2 GitHub Release notes.
- No template reads a new key, so no nil-guard / `--reuse-values` risk.

## Deployment notes
No rollout action needed for existing clusters — image-refresh already moves them to v0.3.2 within ~15 min of the image push. This only changes what greenfield installs land on.

## Checklist
- [x] No secrets / credentials in the diff
- [x] Docs updated if behavior or config changed (the values.yaml comment block)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only digest and chart version bump with no template or auth changes; operational impact is limited to greenfield installs and clusters that run `helm upgrade` with a changed pinned digest.
> 
> **Overview**
> **Release packaging only:** client chart **1.4.3 → 1.4.4** and the greenfield baseline **`images.ingestor.digest`** from v0.3.1 to **v0.3.2** (cosign-signed sha256). The **`values.yaml`** comment block is updated to document what v0.3.2 includes (data-ingestors fixes and multi-arch amd64/arm64).
> 
> This follows the same explicit-baseline pattern as #161: **new installs** get `INGESTOR_IMAGE_DIGEST` from the pinned value on `helm install`/`upgrade` when the chart digest changes. **Already-running clusters** are unchanged by this PR alone—they keep converging on the float tag `0.3` through the image-refresh CronJob unless an operator upgrades the chart.
> 
> No templates, schema keys, or runtime behavior changes beyond which digest greenfield installs start on after upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0500f1f38e453dded8de182f4e45dd8bb50736a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->