### PR TITLE
Sync develop → main for v1.4.4 chart release

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.4.3
-appVersion: "1.4.3"
+version: 1.4.4
+appVersion: "1.4.4"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -213,13 +213,14 @@ images:
   # Customers can also override per-install via the ingestor subchart's
   # `image.digest` for one-off testing, independent of this value.
   ingestor:
-    # Current baseline digest: v0.3.1 (2026-05-25, from #161). Patch on
-    # top of v0.3.0 carrying customer-impacting fixes —
-    # tracebloc/data-ingestors#108 (tokenizer.json copy for MLM
-    # datasets) and #119 (per-category metadata parity for tabular +
-    # keypoint). Bump only when greenfield installs should start on a
+    # Current baseline digest: v0.3.2 (2026-06-03, from #184). Patch on
+    # top of v0.3.1 carrying customer-impacting fixes —
+    # tracebloc/data-ingestors#139 (MLM tokenizer fix, relaxed PascalVOC
+    # `difficult` flag, reserved-id guard; closes #137 / #135) — plus the
+    # first multi-arch image (amd64 + arm64, #24) so arm64 nodes can run
+    # the ingestor. Bump only when greenfield installs should start on a
     # different version; ongoing rollouts are managed by image-refresh.
-    digest: "sha256:a0861ea9fbf4653279351ee30af9ebe2b75fcacd391923b681631312f4a85ee4"
+    digest: "sha256:d361fa778554ab171adcc2671eaf109c32f3d2af339c7920a2d38d102ce53678"
     # Floating tag polled by image-refresh. The team's ghcr.io
     # publishing convention uses semver-style float tags — `0` tracks
     # the latest 0.x, `0.3` tracks the latest 0.3.x patch. Default is


### PR DESCRIPTION
Promotes \`develop\` to \`main\` for the **v1.4.4** chart release.

The only change ahead of \`main\` is #185 — the greenfield ingestor baseline bump to **v0.3.2** (`images.ingestor.digest` → `sha256:d361fa77…`, chart `1.4.3 → 1.4.4`). See #184.

## What this releases
- Greenfield `helm install tracebloc/client` / `tracebloc/ingestor` now land on ingestor **v0.3.2** ([data-ingestors release](https://github.com/tracebloc/data-ingestors/releases/tag/v0.3.2): MLM tokenizer fix + relaxed PascalVOC `difficult` + reserved-id guard, first multi-arch image).
- Existing clusters are unaffected — image-refresh already rolled them to v0.3.2.

## Release steps after merge
1. Publish GitHub Release **v1.4.4** on `main` → triggers `release-helm-chart.yaml` (packages + publishes both charts to gh-pages).
2. Back-merge `main` → `develop`.
3. Close #184.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart-only default digest and version bump for greenfield installs; no runtime logic changes and existing rollouts are unchanged.
> 
> **Overview**
> **Release v1.4.4** promotes the develop→main sync so the published Helm chart matches the ingestor baseline already rolled out via image-refresh.
> 
> The chart **`version` / `appVersion`** move from **1.4.3** to **1.4.4**. **`images.ingestor.digest`** is updated to the **v0.3.2** SHA (`sha256:d361fa77…`), replacing the v0.3.1 pin, with comments refreshed to note data-ingestors fixes (MLM tokenizer, PascalVOC `difficult`, reserved-id guard) and the first **multi-arch** ingestor image. The floating **`tag: "0.3"`** is unchanged.
> 
> **Greenfield** `helm install` / upgrades that re-sync the pinned digest will seed **`INGESTOR_IMAGE_DIGEST`** to v0.3.2; **existing** clusters are expected to already be on that digest from image-refresh unless they opted out of auto-refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b652b509ad812a10095b3363ac274c0895c1a6e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->