### PR TITLE
test(requests-proxy): add helm-unittest coverage for requests-proxy Deployment

### DIFF
--- a/client/tests/requests_proxy_test.yaml
+++ b/client/tests/requests_proxy_test.yaml
@@ -1,0 +1,120 @@
+suite: Requests Proxy Deployment
+# requests-proxy-deployment.yaml had no unit test. It is a workload pod that
+# runs in the data plane, so the security-context invariants (see
+# docs/SECURITY.md) and the single-worker constraint (the proxy keeps the pod
+# token registry in process-local memory — more than one worker silently
+# breaks token lookups) need a regression guard. The resources block is also
+# nil-guarded against `helm upgrade --reuse-values` from pre-1.3.6 releases;
+# pinning the rendered defaults catches a guard that eats the preceding
+# newline (the historic `readOnlyRootFilesystem: trueresources:` bug).
+templates:
+  - templates/requests-proxy-deployment.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+  dockerRegistry:
+    server: https://index.docker.io/v1/
+    username: test
+    password: test
+    email: test@test.com
+tests:
+  - it: should create the requests-proxy Deployment
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-requests-proxy
+
+  - it: should carry standard chart labels
+    asserts:
+      - exists:
+          path: metadata.labels["app.kubernetes.io/name"]
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: should run exactly one replica
+    # Token registry is process-local; replicas>1 would shard token lookups.
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should not automount the service account token
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should enforce a hardened pod security context
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: should enforce a hardened container security context
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: "ALL"
+
+  - it: should pull the jobs-manager image from docker.io
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^docker\\.io/tracebloc/jobs-manager[:@]"
+
+  - it: should expose the proxy on container port 8888
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8888
+
+  - it: should run gunicorn with a single worker
+    # Mirrors the replica constraint at the process level — the token registry
+    # lives in one worker's memory.
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--workers=1"
+
+  - it: should render the default resource requests and limits
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 256Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 1000m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+
+  - it: should honor a resource override through the nil-guard
+    set:
+      resources:
+        requestsProxy:
+          limits:
+            memory: 1Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1Gi


### PR DESCRIPTION
## What

Adds a helm-unittest suite for `templates/requests-proxy-deployment.yaml`, the only data-plane workload template with no unit test. Part of #193.

## Why

The requests-proxy Deployment carries the chart's security-context invariants and a single-worker constraint that are costly to regress silently. This suite pins them:

- **Security context** (see `docs/SECURITY.md`): no SA-token automount, `runAsNonRoot`, seccomp `RuntimeDefault`, `runAsUser: 1001`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `readOnlyRootFilesystem: true`.
- **Single replica + single gunicorn worker** — the pod token registry is process-local; >1 worker silently shards token lookups.
- **Image source** `docker.io/tracebloc/jobs-manager` and container port 8888.
- **Nil-guarded resources** — the default requests/limits render, plus an override case that exercises the default-through-dict fallthrough (guards the historic `readOnlyRootFilesystem: trueresources:` newline-eating regression).

## Coverage delta

`templates/requests-proxy-deployment.yaml`: **no suite → 11 assertions / 11 cases.** Untested chart templates: **7 → 6**.

## Verification

```
$ helm unittest ./client
Test Suites: 15 passed, 15 total
Tests:       153 passed, 153 total
```
(14 suites / 142 tests before this change — no existing suites touched.)

---
This is the first PR from a **test-coverage dry-run** (the scheduled "daily coverage PR" routine couldn't be registered — claude.ai scheduler was unreachable). It previews what that automation will produce per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production template or application code modifications.
> 
> **Overview**
> Adds a new **helm-unittest** suite (`client/tests/requests_proxy_test.yaml`) for `templates/requests-proxy-deployment.yaml`, which previously had no unit tests.
> 
> The suite **locks in rendered behavior** with 11 test cases: Deployment identity/labels, **exactly one replica**, **no service account token automount**, pod and container **security hardening** (non-root, seccomp, capabilities drop, read-only root FS), **jobs-manager image** on `docker.io`, port **8888**, **gunicorn `--workers=1`**, default **CPU/memory** requests and limits, and a **values override** path through the nil-guarded `resources.requestsProxy` block (regression guard for the historic YAML newline bug).
> 
> No Helm template or runtime code is modified—test-only coverage for a data-plane workload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50417a7431f1fc916b0abf4c1706453595be99a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->