### PR TITLE
fix(#196): allow training-pod egress to the requests-proxy (8888)

### DIFF
--- a/client/templates/network-policy-training.yaml
+++ b/client/templates/network-policy-training.yaml
@@ -85,4 +85,19 @@ spec:
       ports:
         - port: 3306
           protocol: TCP
+    # 4. requests-proxy — training pods POST epoch results / FLOPs to the
+    #    in-namespace requests-proxy on 8888 (so they never hold Service Bus
+    #    credentials). Rule 2 blocks this ClusterIP egress, so re-permit it
+    #    explicitly, exactly like MySQL above. Without this rule every
+    #    experiment CrashLoopBackOffs at the first epoch finalize with
+    #    "requests-proxy-service:8888 ... Connection refused" (client#196).
+    #    Service selector + port: templates/requests-proxy-service.yaml
+    #    (app=requests-proxy, 8888).
+    - to:
+        - podSelector:
+            matchLabels:
+              app: requests-proxy
+      ports:
+        - port: 8888
+          protocol: TCP
 {{- end }}


### PR DESCRIPTION
## Summary

The `training-egress` NetworkPolicy blocks training pods from reaching `requests-proxy-service:8888`, so every experiment fails: pods can't POST epoch results → `Connection refused` → `CrashLoopBackOff`. Adds the missing egress rule.

## Root cause

`templates/network-policy-training.yaml` denies all pod-to-pod / ClusterIP egress (rule 2 `except`s the cluster CIDRs) and re-permits **only MySQL** (rule 3). The requests-proxy architecture — pods POST to the proxy on 8888 instead of holding Service Bus creds — shipped without a matching egress allow-rule here. The proxy, the entire intended egress path, was blocked.

## Fix

Rule 4, mirroring the MySQL rule: TCP/8888 → `podSelector app=requests-proxy` (same namespace). Matches `templates/requests-proxy-service.yaml` (selector `app=requests-proxy`, port 8888).

## Verification
- `helm template -f ci/bm-values.yaml --show-only templates/network-policy-training.yaml` renders the rule as valid YAML.
- Found live on a fresh client (`tracebloc-amazon`, k3d): jobs-manager reached the proxy (HTTP 401) while training pods got connection-refused — the only differentiator was this egress policy. Live-patched + verified the affected cluster (training-labeled probe connects; pods now progress past epoch 0; jobs completing).

## Deployment note
The affected cluster's `auto-upgrade` CronJob is **suspended** so its `helm upgrade --reuse-values` doesn't revert the interim live patch. Once this is released, re-enable it and the cluster self-heals onto the chart-managed rule.

Closes #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-port, in-namespace egress exception matching the existing MySQL pattern; no broadening of external or cross-namespace access.
> 
> **Overview**
> Adds **egress rule 4** to the training `NetworkPolicy` so pods labeled `tracebloc.io/workload=training` can reach the in-namespace **requests-proxy** on **TCP 8888**, using the same `podSelector` pattern as the existing MySQL allow.
> 
> Rule 2 only permits HTTPS to addresses outside the cluster CIDRs, which blocks ClusterIP traffic to `requests-proxy-service`. Training jobs POST epoch results through that proxy instead of holding Service Bus credentials; without this exception they fail at epoch finalize with connection refused and **CrashLoopBackOff** (#196).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8d4f2b0443c34bdad1f7e66d9a552d12e2f29e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->