### PR TITLE
chore: bump chart 1.4.4 → 1.4.5 (ships #197 training-egress proxy fix)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.4.4
-appVersion: "1.4.4"
+version: 1.4.5
+appVersion: "1.4.5"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
## Why

`1.4.4` is already published on the `tracebloc.github.io/client` Pages channel and is what clusters run. The training-egress NetworkPolicy fix (#197 — allow training pods → `requests-proxy:8888`) merged to `develop` **without a version bump**, so it's currently undeliverable:

- chart-releaser won't overwrite the existing `1.4.4` release, and
- clusters already on `1.4.4` see no version change → auto-upgrade pulls nothing.

## What

Bump `Chart.yaml` `1.4.4 → 1.4.5` (lockstep `version`/`appVersion`, matching the 1.4.3/1.4.4 history). Chart-only change; no image change.

## After this merges

Cut a **`v1.4.5` GitHub Release** → the `release-helm-chart` workflow packages + publishes it → every client's auto-upgrade pulls it at `:23` and self-heals onto the chart-managed NetworkPolicy rule. (Fleet-wide — release-owner's call.) Then re-enable the interim-patched cluster's suspended `auto-upgrade` CronJob.

Ref #196 / #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata bump in Chart.yaml with no runtime or template changes in this PR.
> 
> **Overview**
> **Version-only release** so the already-merged training-egress NetworkPolicy fix (#197) can ship via Helm: `Chart.yaml` **`version`** and **`appVersion`** move in lockstep from **1.4.4** to **1.4.5**. No template or image changes in this diff.
> 
> Because **1.4.4** is already on the chart repo, chart-releaser cannot republish that tag and clusters on 1.4.4 see no upgrade path for the proxy egress rule. A new chart version is required for auto-upgrade to pick up the chart-managed allow for training pods → **`requests-proxy:8888`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7bbff1f809c432cb9dc4aeaa65588a70f7c8327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->