### PR TITLE
Promote develop → main: POD_TOKEN_SIGNING_SECRET wiring, chart 1.5.0 (client-runtime#79)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.4.5
-appVersion: "1.4.5"
+version: 1.5.0
+appVersion: "1.5.0"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -76,6 +76,17 @@ spec:
             secretKeyRef:
               name: {{ include "tracebloc.secretName" . }}
               key: CLIENT_PASSWORD
+        # client-runtime#79: shared HMAC secret used to MINT the per-pod
+        # REQUESTS_PROXY_TOKEN. Same Secret key the requests-proxy reads to
+        # verify. When present, spin_job mints stateless signed tokens (no
+        # pod_tokens table). Never injected into training pods.
+        - name: POD_TOKEN_SIGNING_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "tracebloc.secretName" . }}
+              key: POD_TOKEN_SIGNING_SECRET
+        - name: POD_TOKEN_TTL_SECONDS
+          value: {{ .Values.podTokenTtlSeconds | default 604800 | quote }}
         - name: CLIENT_PVC
           value: {{ include "tracebloc.clientDataPvc" . | quote }}
         - name: CLIENT_LOGS_PVC

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -77,6 +77,15 @@ spec:
               value: "experiments"
             - name: FLOPS_QUEUE_NAME
               value: "flops"
+            # client-runtime#79: shared HMAC secret used to VERIFY the per-pod
+            # bearer token statelessly (signature + expiry), the same key the
+            # jobs-manager uses to mint it. When present, the proxy skips the
+            # pod_tokens table entirely.
+            - name: POD_TOKEN_SIGNING_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tracebloc.secretName" . }}
+                  key: POD_TOKEN_SIGNING_SECRET
       {{- if include "tracebloc.useImagePullSecrets" . }}
       imagePullSecrets:
         - name: {{ include "tracebloc.registrySecretName" . }}

--- a/client/templates/secrets.yaml
+++ b/client/templates/secrets.yaml
@@ -2,6 +2,27 @@
 {{- $clientPassword := required "clientPassword is required (set via --set clientPassword=... or values file)" .Values.clientPassword -}}
 {{- if regexMatch "^<.*>$" $clientId -}}{{- fail "clientId looks like a placeholder (e.g. \"<CLIENT_ID>\"); set a real value" -}}{{- end -}}
 {{- if regexMatch "^<.*>$" $clientPassword -}}{{- fail "clientPassword looks like a placeholder (e.g. \"<CLIENT_PASSWORD>\"); set a real value" -}}{{- end -}}
+{{- /*
+  Pod-proxy token signing secret (client-runtime#79). Stability is critical:
+  a token minted before an upgrade must still verify after, so we must NOT
+  regenerate the secret on every `helm upgrade`. Resolution order:
+    1. explicit .Values.podTokenSigningSecret (operator pin / rotation), else
+    2. the value already stored in the live Secret (preserve across upgrades), else
+    3. a freshly generated random secret (first install).
+  `lookup` returns an empty dict during `helm template`/dry-run; that's fine —
+  it falls through to generate, and the rendered value is only consumed at a
+  real install/upgrade.
+*/ -}}
+{{- $secretName := include "tracebloc.secretName" . -}}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
+{{- $podTokenSecret := "" -}}
+{{- if .Values.podTokenSigningSecret -}}
+{{-   $podTokenSecret = .Values.podTokenSigningSecret -}}
+{{- else if and $existingSecret $existingSecret.data (hasKey $existingSecret.data "POD_TOKEN_SIGNING_SECRET") -}}
+{{-   $podTokenSecret = (index $existingSecret.data "POD_TOKEN_SIGNING_SECRET" | b64dec) -}}
+{{- else -}}
+{{-   $podTokenSecret = randAlphaNum 48 -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,6 +34,7 @@ type: Opaque
 data:
   CLIENT_ID: {{ $clientId | b64enc | quote }}
   CLIENT_PASSWORD: {{ $clientPassword | b64enc | quote }}
+  POD_TOKEN_SIGNING_SECRET: {{ $podTokenSecret | b64enc | quote }}
 {{- if and (ne .Values.resourceMonitor false) (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
 ---
 # Mirrored into the node-agents namespace so the resource-monitor DaemonSet

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -349,6 +349,26 @@ podDisruptionBudget:
 clientId: ""
 clientPassword: ""
 
+# -- Pod-proxy token signing (client-runtime#79)
+# Shared HMAC secret used by the jobs-manager to MINT and the requests-proxy to
+# VERIFY the per-pod REQUESTS_PROXY_TOKEN. When set (non-empty), the proxy
+# validates tokens statelessly (signature + expiry) and the legacy pod_tokens
+# table is not used — eliminating the token-revoke-while-live race class.
+#
+# Leave empty to AUTO-GENERATE a stable secret: the chart generates one on
+# first install and reuses it on every subsequent upgrade (via `lookup`), so
+# tokens minted before an upgrade still verify after. Set explicitly only to
+# pin a known value or to rotate (rotating invalidates all live tokens at once,
+# forcing pods to be respawned). Never injected into training pods.
+podTokenSigningSecret: ""
+
+# -- Backstop lifetime (seconds) for a signed pod-proxy token. The real bound
+# on a token's usefulness is the pod lifecycle (the pod is deleted on stop);
+# this just caps a leaked token. Set to comfortably exceed the longest expected
+# training-job duration, or a long-running job will 401 mid-run when its token
+# expires. Default 7 days.
+podTokenTtlSeconds: 604800
+
 # -- Docker registry credentials (optional; only used when dockerRegistry is set and create is true)
 # Omit dockerRegistry entirely, or set create: false, for public images (no imagePullSecrets).
 # When create is true, secret name is {{ .Release.Name }}-regcred.


### PR DESCRIPTION
Promotes the stateless-token chart wiring (#205) from `develop` to `main`, so it can be released to the Pages channel.

## Included (1 commit)
- **#205** — `POD_TOKEN_SIGNING_SECRET` in `secrets.yaml` (stable via `lookup`), env wiring into jobs-manager + requests-proxy, `podTokenSigningSecret`/`podTokenTtlSeconds` values, version **1.4.5 → 1.5.0**.

## Rollout ordering (important)
The chart secret only *activates* stateless mode when the running images carry the mint/verify code (**client-runtime#89**). Recommended order:
1. Land **client-runtime** `develop → staging → master` (#90 then staging→master) so `:prod` images have #79.
2. Merge this PR + cut **GitHub Release v1.5.0** to publish the chart.
3. Fleet auto-upgrades to 1.5.0 → secret lands → stateless mode activates on the next pod spawn.

Safe either way: if 1.5.0 reaches a fleet whose images predate #79, the secret is simply ignored and the deployment stays in legacy `pod_tokens` mode (no breakage) until the image catches up.

## Validation
Stateless mode validated live on the `tracebloc-amazon` canary — 10 experiments through stop-storm churn, every proxy post `200`, zero `401`. See client-runtime#88.

Refs client-runtime#79, client-runtime#89, #205, #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication-related secrets and deployment env across jobs-manager and requests-proxy; misconfigured TTL or secret rotation could invalidate live training tokens, though legacy behavior remains if images predate the runtime support.
> 
> **Overview**
> **Chart release 1.5.0** promotes Helm wiring for **client-runtime#79**: a shared HMAC secret so jobs-manager can mint and requests-proxy can verify per-pod `REQUESTS_PROXY_TOKEN` without the legacy `pod_tokens` table.
> 
> The chart adds **`POD_TOKEN_SIGNING_SECRET`** to the main client Secret with **upgrade-stable** resolution (explicit `podTokenSigningSecret`, else preserve via `lookup`, else generate on first install). **jobs-manager** gets `POD_TOKEN_SIGNING_SECRET` plus **`POD_TOKEN_TTL_SECONDS`** (default 7 days); **requests-proxy** gets the same signing secret for stateless verification. New values **`podTokenSigningSecret`** and **`podTokenTtlSeconds`** document operator pin/rotation and TTL backstop behavior.
> 
> Stateless mode only takes effect when running images include the mint/verify logic; older images ignore the new env vars and stay on legacy mode until upgraded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 013a88b02238c2a80cc85636595454c0154920a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->