### PR TITLE
fix(installer): point kubeconfig at the client namespace after deploy

### DIFF
--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -1214,6 +1214,10 @@ $envBlock
   Log "Helm Output: $helmOutput"
   if ($LASTEXITCODE -ne 0) { Err "Client installation failed. Helm output:`n$helmOutput`nCheck the log for details: $LOG_FILE" }
 
+  # Point kubeconfig's current context at the client namespace so kubectl + the
+  # tracebloc CLI default to it (no -n / --namespace needed). Best-effort.
+  kubectl config set-context --current --namespace $TB_NAMESPACE 2>$null | Out-Null
+
   Ok "Connected to tracebloc"
   Log "Values file: $valuesFile"
 }

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -383,6 +383,11 @@ EOF
   cat "$helm_log" >> "${LOG_FILE:-/dev/null}" 2>/dev/null
   rm -f "$helm_log"
 
+  # Point the kubeconfig's current context at the client namespace, so kubectl and
+  # the tracebloc CLI default to it with no -n / --namespace flag. Best-effort:
+  # a failure here must not abort an otherwise-successful install.
+  kubectl config set-context --current --namespace "$TB_NAMESPACE" >/dev/null 2>&1 || true
+
   success "Connected to tracebloc"
   log "Values file: $values_file"
 }

--- a/scripts/tests/install-client-helm.bats
+++ b/scripts/tests/install-client-helm.bats
@@ -135,6 +135,19 @@ setup() {
   mock_calls | grep -q "helm upgrade --install tracebloc"
 }
 
+@test "install_client_helm: points kubeconfig at the client namespace (so the CLI needs no -n)" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { return 0; }
+  kubectl() { record "kubectl $*"; return 0; }
+  verify_credentials() { printf valid; }
+  run install_client_helm <<< $'myid\nmypw'
+  [ "$status" -eq 0 ]
+  mock_calls | grep -q "kubectl config set-context --current --namespace tracebloc"
+}
+
 @test "install_client_helm: re-prompts on invalid, then accepts valid" {
   HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
   _ensure_tracebloc_dirs() { :; }


### PR DESCRIPTION
## Bug
Right after a **successful** install, the first CLI command errors:
```
$ tracebloc cluster info
Error: no tracebloc parent client release found in namespace "default" ...
```
The installer deploys the client into the **`tracebloc`** namespace, but the k3d kubeconfig context stays on **`default`** — so the CLI (and plain `kubectl`) look in the wrong namespace. The documented next step, `tracebloc dataset push ./data`, hits the same error.

## Fix
After `helm upgrade --install`, set the current context's namespace to `$TB_NAMESPACE` (best-effort, honors `TB_NAMESPACE` overrides). Now `kubectl` and the tracebloc CLI default to the client's namespace — **no `-n` / `--namespace` needed**. Mirrored in `install-k8s.ps1`; new bats test asserts the `set-context` call.

## Follow-up (separate PR, `cli` repo)
Make the CLI **auto-discover** the client's namespace (scan for `*-jobs-manager`) so it's robust when the context isn't set or the client lives in a custom namespace.

---
Targets `develop`. Local bats: the new test passes; the one unrelated failure (`_extract_yaml_value` single-quote) is the known macOS bash-3.2 quirk that also fails on pristine develop — CI (bash 5) passes it. PowerShell mirror per the usual Windows-reviewer check.
