### PR TITLE
Prod: Set kubeconfig context namespace after Helm install for tracebloc 

### DIFF
--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -1214,6 +1214,10 @@ $envBlock
   Log "Helm Output: $helmOutput"
   if ($LASTEXITCODE -ne 0) { Err "Client installation failed. Helm output:`n$helmOutput`nCheck the log for details: $LOG_FILE" }
 
+  # Point kubeconfig's current context at the client namespace so kubectl + the
+  # tracebloc CLI default to it (no -n / --namespace needed). Best-effort.
+  kubectl config set-context --current --namespace $TB_NAMESPACE 2>$null | Out-Null
+
   Ok "Connected to tracebloc"
   Log "Values file: $valuesFile"
 }

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -383,6 +383,11 @@ EOF
   cat "$helm_log" >> "${LOG_FILE:-/dev/null}" 2>/dev/null
   rm -f "$helm_log"
 
+  # Point the kubeconfig's current context at the client namespace, so kubectl and
+  # the tracebloc CLI default to it with no -n / --namespace flag. Best-effort:
+  # a failure here must not abort an otherwise-successful install.
+  kubectl config set-context --current --namespace "$TB_NAMESPACE" >/dev/null 2>&1 || true
+
   success "Connected to tracebloc"
   log "Values file: $values_file"
 }

--- a/scripts/tests/install-client-helm.bats
+++ b/scripts/tests/install-client-helm.bats
@@ -135,6 +135,19 @@ setup() {
   mock_calls | grep -q "helm upgrade --install tracebloc"
 }
 
+@test "install_client_helm: points kubeconfig at the client namespace (so the CLI needs no -n)" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { return 0; }
+  kubectl() { record "kubectl $*"; return 0; }
+  verify_credentials() { printf valid; }
+  run install_client_helm <<< $'myid\nmypw'
+  [ "$status" -eq 0 ]
+  mock_calls | grep -q "kubectl config set-context --current --namespace tracebloc"
+}
+
 @test "install_client_helm: re-prompts on invalid, then accepts valid" {
   HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
   _ensure_tracebloc_dirs() { :; }


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Installer-only, best-effort kubeconfig tweak with tests; no runtime auth or cluster logic changes.
> 
> **Overview**
> After a successful Helm client install, both installers now run **`kubectl config set-context --current --namespace`** for the client namespace (default **`tracebloc`**, or **`TB_NAMESPACE`**). **kubectl** and the **tracebloc CLI** can use that namespace without **`-n` / `--namespace`**.
> 
> The step is **best-effort**: on bash it uses **`|| true`**; on Windows stderr is suppressed so a failed context update does not undo a successful install.
> 
> A new **BATS** test asserts the bash path invokes **`kubectl config set-context --current --namespace tracebloc`** during **`install_client_helm`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4215616ab122170360b7eee2cbd38be97b48d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->