### PR TITLE
fix(installer): bound the apt dpkg-lock wait so a held lock can't hang the install (#210)

### DIFF
--- a/scripts/lib/setup-linux.sh
+++ b/scripts/lib/setup-linux.sh
@@ -13,12 +13,38 @@ setup_pm() {
   # forever ("still pulling conntrack"). DEBIAN_FRONTEND=noninteractive +
   # NEEDRESTART_MODE=a make apt fully non-interactive; they are passed *through*
   # `sudo env` because sudo resets the environment by default.
-  if   has apt-get; then PM_UPDATE="sudo apt-get update -qq";           PM_INSTALL="sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -q -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
+  #
+  # apt also waits *indefinitely* on the dpkg lock while apt-daily / unattended-
+  # upgrades hold it on a freshly-booted host (#210); -o DPkg::Lock::Timeout=600
+  # bounds that wait so the install fails with a clear error rather than hanging
+  # silently behind the spinner.
+  if   has apt-get; then PM_UPDATE="sudo apt-get update -qq -o DPkg::Lock::Timeout=600"; PM_INSTALL="sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -q -o DPkg::Lock::Timeout=600 -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
   elif has dnf;     then PM_UPDATE="sudo dnf makecache -q";             PM_INSTALL="sudo dnf install -y -q"
   elif has yum;     then PM_UPDATE="sudo yum makecache -q";             PM_INSTALL="sudo yum install -y -q"
   elif has zypper;  then PM_UPDATE="sudo zypper refresh";               PM_INSTALL="sudo zypper install -y"
   elif has pacman;  then PM_UPDATE="sudo pacman -Sy --noconfirm";       PM_INSTALL="sudo pacman -S --noconfirm"
   else error "No supported package manager found."; fi
+}
+
+# ── Wait out apt/dpkg lock holders before our apt calls ──────────────────────
+# On a freshly-installed/booted Debian/Ubuntu host, the apt-daily and
+# unattended-upgrades systemd units grab the dpkg lock at boot and can hold it
+# for several minutes (longer when a kernel/security batch is pending). apt-get
+# then blocks on the lock, and because we run it behind spin_cmd the
+# "Waiting for cache lock…" line is hidden in the log — the installer looks
+# frozen (#210). Surface the wait with a visible spinner and bound it; the
+# per-command DPkg::Lock::Timeout (setup_pm) is the backstop if a holder appears
+# mid-run. No-op when apt or fuser is absent, or when the lock is already free.
+apt_wait_for_lock() {
+  has apt-get && has fuser || return 0
+  local locks="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock"
+  sudo fuser $locks >/dev/null 2>&1 || return 0   # free already → silent fast path
+  spin_cmd "Waiting for background system updates to finish…" bash -c '
+    waited=0
+    while sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock >/dev/null 2>&1; do
+      [ "$waited" -ge 600 ] && exit 0
+      sleep 5; waited=$((waited + 5))
+    done' || true
 }
 
 # ── Kernel modules Docker + k3s need ─────────────────────────────────────────
@@ -272,6 +298,7 @@ install_linux() {
 
   preflight_sudo
   setup_pm
+  apt_wait_for_lock          # don't fight apt-daily/unattended-upgrades for the lock
   install_docker_engine
   install_system_deps
 

--- a/scripts/tests/setup-linux.bats
+++ b/scripts/tests/setup-linux.bats
@@ -49,6 +49,14 @@ setup() {
   [[ "$PM_INSTALL" == *"NEEDRESTART_MODE=a"* ]]
   [[ "$PM_INSTALL" == *"sudo env"* ]]
 }
+# apt must WAIT (bounded) for the dpkg lock instead of hanging forever behind
+# apt-daily/unattended-upgrades on a freshly-booted host (#210).
+@test "setup_pm: apt waits for the dpkg lock with a bounded timeout (#210)" {
+  PRESENT_CMDS="apt-get"
+  setup_pm
+  [[ "$PM_INSTALL" == *"DPkg::Lock::Timeout="* ]]
+  [[ "$PM_UPDATE"  == *"DPkg::Lock::Timeout="* ]]
+}
 @test "setup_pm: dnf detected" {
   PRESENT_CMDS="dnf"
   setup_pm


### PR DESCRIPTION
Fixes #210. Complementary to #212 (now merged) — that PR fixed the **needrestart hidden-prompt** hang; this one fixes the **dpkg-lock** hang. Same symptom (`Installing conntrack…` freezes on a fresh Ubuntu host), different root cause.

Rebased onto `develop` after #212 merged, so the diff is the lock dimension only.

## Root cause

On a freshly-booted host, `apt-daily` / `unattended-upgrades` hold the dpkg lock. The installer's `apt-get install` had **no lock timeout**, so it waited indefinitely — and `spin_cmd` redirects apt's `Waiting for cache lock…` line into a log file, so it looked frozen with no error.

## What this adds (on top of #212)

- `setup_pm`: add `-o DPkg::Lock::Timeout=600` to the apt `update`/`install` commands → bounded wait, then a clear failure (which `spin_cmd` surfaces) instead of an infinite silent hang. Appends to #212's non-interactive `sudo env` command, leaving its env exactly as-is.
- New `apt_wait_for_lock`: a **visible**, bounded `Waiting for background system updates to finish…` spinner before the docker / system-deps installs (no-op when apt or `fuser` is absent, or the lock is free). Placed before `install_docker_engine` so the `get.docker.com` apt path benefits too.
- `setup-linux.bats`: assert both apt commands carry the lock timeout (regression guard).

## Testing

- `bash -n scripts/lib/setup-linux.sh` — clean.
- Sourced the real `setup_pm` / `apt_wait_for_lock` with the bats mocks and asserted #212's guarantees (`sudo env`, `DEBIAN_FRONTEND=noninteractive`, `NEEDRESTART_MODE=a`) **and** this PR's (`DPkg::Lock::Timeout=` in both apt commands) hold together; `dnf` branch free of the apt option; `apt_wait_for_lock` no-ops on the no-`fuser` / lock-free paths. All pass.
- `bats` isn't installed locally — the cross-distro installer CI exercises the real path.

## Compatibility

`DPkg::Lock::Timeout` is a config key (`-o`), unknown to pre-2.0 apt (e.g. 18.04) where it's silently ignored — no breakage on older distros. `dnf`/`yum`/`zypper`/`pacman` branches unchanged.

## Immediate client workaround (no merge needed)

```bash
while sudo fuser /var/lib/dpkg/lock-frontend /var/lib/apt/lists/lock >/dev/null 2>&1; do
  echo "waiting for apt lock…"; sleep 5; done
# then re-run the installer
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Linux installer script and test-only changes; no auth, data, or runtime service logic affected.
> 
> **Overview**
> Fixes **#210**: on fresh Debian/Ubuntu boots, **apt-daily** / **unattended-upgrades** can hold the dpkg lock while the Linux installer runs **apt** behind **`spin_cmd`**, so the install looks frozen (e.g. at “Installing conntrack…”) with no visible “Waiting for cache lock…” message.
> 
> **`setup_pm`** now passes **`-o DPkg::Lock::Timeout=600`** on apt **update** and **install** so lock waits are bounded and failures surface instead of hanging silently. A new **`apt_wait_for_lock`** runs early in **`install_linux`** (before Docker/system deps): if **`fuser`** sees holders on the standard lock paths, it shows a **“Waiting for background system updates to finish…”** spinner for up to 600s; otherwise it no-ops. Non-apt package managers are unchanged. **`setup-linux.bats`** asserts both apt commands include the lock timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2481d4128060c6168608aa66aa59570af42b46ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->