### PR TITLE
fix(installer): keep apt non-interactive so needrestart can't hang installs on Ubuntu 22.04+

### DIFF
--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -527,7 +527,9 @@ curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-contai
   | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
   | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list >/dev/null
 sudo apt-get update -qq
-sudo apt-get install -y -q nvidia-container-toolkit
+# needrestart on WSL Ubuntu would open a hidden prompt in this captured job and
+# stall to the 180s timeout; DEBIAN_FRONTEND/NEEDRESTART_MODE keep apt non-interactive.
+sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -q nvidia-container-toolkit
 sudo nvidia-ctk runtime configure --runtime=docker --set-as-default 2>/dev/null || true
 sudo nvidia-ctk runtime configure --runtime=containerd 2>/dev/null || true
 echo "NCT installed successfully."

--- a/scripts/lib/setup-linux.sh
+++ b/scripts/lib/setup-linux.sh
@@ -6,7 +6,14 @@
 
 # ── Package manager detection ────────────────────────────────────────────────
 setup_pm() {
-  if   has apt-get; then PM_UPDATE="sudo apt-get update -qq";           PM_INSTALL="sudo apt-get install -y -q -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
+  # apt note: Ubuntu 22.04+ ships needrestart, which hooks `apt-get install` and
+  # opens an interactive "restart services?" prompt that `-y` does NOT suppress.
+  # Run inside spin_cmd (stdout/stderr redirected, process backgrounded) that
+  # prompt is invisible and blocks reading the TTY → SIGTTIN → the install hangs
+  # forever ("still pulling conntrack"). DEBIAN_FRONTEND=noninteractive +
+  # NEEDRESTART_MODE=a make apt fully non-interactive; they are passed *through*
+  # `sudo env` because sudo resets the environment by default.
+  if   has apt-get; then PM_UPDATE="sudo apt-get update -qq";           PM_INSTALL="sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -q -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
   elif has dnf;     then PM_UPDATE="sudo dnf makecache -q";             PM_INSTALL="sudo dnf install -y -q"
   elif has yum;     then PM_UPDATE="sudo yum makecache -q";             PM_INSTALL="sudo yum install -y -q"
   elif has zypper;  then PM_UPDATE="sudo zypper refresh";               PM_INSTALL="sudo zypper install -y"
@@ -77,7 +84,9 @@ install_docker_engine() {
       docker_script="$(mktemp)"
       retry 3 5 curl -fsSL $CURL_SECURE https://get.docker.com -o "$docker_script"
       chmod +x "$docker_script"
-      spin_cmd "Installing Docker…" sudo bash "$docker_script"
+      # Same needrestart guard as setup_pm: get.docker.com runs `apt-get install`
+      # internally, so under spin_cmd it can hit the same hidden prompt and hang.
+      spin_cmd "Installing Docker…" sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a bash "$docker_script"
       rm -f "$docker_script"
     fi
     # Enable for boot only (no --now): starting is handled below, where a start

--- a/scripts/tests/setup-linux.bats
+++ b/scripts/tests/setup-linux.bats
@@ -39,6 +39,16 @@ setup() {
   setup_pm
   [[ "$PM_INSTALL" == *"apt-get install"* ]]
 }
+# Ubuntu 22.04+ needrestart opens a hidden "restart services?" prompt under
+# spin_cmd that `-y` doesn't suppress → the install hangs. apt must be fully
+# non-interactive, with the env passed through `sudo env` (sudo resets env).
+@test "setup_pm: apt is non-interactive (needrestart/debconf guard)" {
+  PRESENT_CMDS="apt-get"
+  setup_pm
+  [[ "$PM_INSTALL" == *"DEBIAN_FRONTEND=noninteractive"* ]]
+  [[ "$PM_INSTALL" == *"NEEDRESTART_MODE=a"* ]]
+  [[ "$PM_INSTALL" == *"sudo env"* ]]
+}
 @test "setup_pm: dnf detected" {
   PRESENT_CMDS="dnf"
   setup_pm
@@ -119,6 +129,9 @@ setup() {
   run install_docker_engine
   run mock_calls
   [[ "$output" == *"get.docker.com"* ]]
+  # the convenience script runs apt-get internally → must be non-interactive too
+  [[ "$output" == *"DEBIAN_FRONTEND=noninteractive"* ]]
+  [[ "$output" == *"NEEDRESTART_MODE=a"* ]]
 }
 @test "install_docker_engine: docker already present -> no install" {
   PRESENT_CMDS="docker"; TEST_DISTRO=ubuntu


### PR DESCRIPTION
## Summary

On Ubuntu 22.04+ (incl. 24.04) the **needrestart** package hooks `apt-get install` and opens an interactive *"Which services should be restarted?"* prompt. `-y` does **not** suppress it.

The installer runs apt inside `spin_cmd`, which redirects stdout/stderr to a log and **backgrounds** the process. So the prompt is **invisible** (only the spinner shows) and, being backgrounded, blocks the moment it reads the TTY (`SIGTTIN`) — the install **hangs forever**. The reported symptom was the spinner stuck "still pulling conntrack" on a fresh Ubuntu 24.04 host: the package was downloading fine; it was waiting on a hidden prompt.

(The authors already knew "spinners hide prompts" — `preflight_sudo` warms the sudo cache for exactly this reason — but `needrestart`/`debconf` were missed.)

## Fix

Pass `DEBIAN_FRONTEND=noninteractive` + `NEEDRESTART_MODE=a` through `sudo env` (sudo resets the environment, so the vars must be set *through* it) on every apt path the installer drives:

| Path | File |
|---|---|
| `PM_INSTALL` — conntrack / openssl / curl / tar (and `nvidia-container-toolkit`, which calls `$PM_INSTALL`) | `scripts/lib/setup-linux.sh` |
| `get.docker.com` convenience script (runs `apt-get` internally) | `scripts/lib/setup-linux.sh` |
| WSL2 NVIDIA Container Toolkit heredoc — same hidden-prompt class; bounded by the 180 s job timeout but still fails the toolkit install | `scripts/install-k8s.ps1` |

Reuses the established `sudo env VAR=val` pattern already used for `install_k3d` (#718).

## Tests

`scripts/tests/setup-linux.bats`:
- **new:** `setup_pm: apt is non-interactive (needrestart/debconf guard)` — asserts `DEBIAN_FRONTEND=noninteractive`, `NEEDRESTART_MODE=a`, and `sudo env` in `PM_INSTALL`.
- **strengthened:** the Debian/Ubuntu `get.docker.com` test now also asserts the non-interactive env.

`bats scripts/tests/setup-linux.bats` is green for every touched test. Two unrelated tests (*Amazon Linux → dnf docker*, *RHEL clone → docker-ce*) fail **only on macOS dev machines** because of BSD-vs-GNU `grep` in the `/etc/os-release` mock; they pass in CI on Linux and are untouched here.

## Out of scope / follow-up

- `scripts/lib/gpu-amd.sh:53` (`sudo apt-get install … amdgpu-install.deb`) is a **direct, visible** apt-get (not wrapped in `spin_cmd`), so a needrestart prompt there is annoying but not a silent hang. The same env could be added for consistency in a later pass.
- `scripts/tests/distro-prereqs.sh` is a CI-only helper that runs as root in minimal containers (no needrestart) — no exposure.