### PR TITLE
test(charts): add helm-unittest suite for jobs-manager-service template

### DIFF
--- a/client/tests/jobs_manager_service_test.yaml
+++ b/client/tests/jobs_manager_service_test.yaml
@@ -1,0 +1,76 @@
+suite: jobs-manager Service
+templates:
+  - templates/jobs-manager-service.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: should render a single Service document
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+
+  - it: should name the Service jobs-manager (stable in-cluster name contract)
+    asserts:
+      - equal:
+          path: metadata.name
+          value: jobs-manager
+
+  - it: should be ClusterIP only (no external exposure)
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should not be a NodePort or LoadBalancer
+    asserts:
+      - notEqual:
+          path: spec.type
+          value: NodePort
+      - notEqual:
+          path: spec.type
+          value: LoadBalancer
+
+  - it: should select the jobs-manager pods via app=manager
+    asserts:
+      - equal:
+          path: spec.selector.app
+          value: manager
+
+  - it: should expose the ingestion HTTP port 8080 over TCP
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8080
+      - equal:
+          path: spec.ports[0].protocol
+          value: TCP
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+
+  - it: should carry the app=manager label and standard chart labels
+    asserts:
+      - equal:
+          path: metadata.labels.app
+          value: manager
+      - isNotNullOrEmpty:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+      - isNotNullOrEmpty:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: should live in the release namespace
+    release:
+      namespace: my-custom-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-custom-ns


### PR DESCRIPTION
## What

Adds a helm-unittest suite for the previously-untested `templates/jobs-manager-service.yaml`.

Tracking epic: tracebloc/client#193

## Why

`jobs-manager-service.yaml` exposes jobs-manager's internal HTTP ingestion endpoint at a stable in-cluster name (`jobs-manager`) so the ingestor subchart's post-install hook can POST without discovering Pod IPs. It had no test suite, so its ClusterIP-only boundary and name/port contract were unverified.

## Coverage delta

- +1 template suite (`jobs-manager-service`); 8 tests / ~14 assertions
- Chart suites 15 → 16 (167 tests total, all green via `helm unittest ./client`)

## Assertions

- Renders a single `Service`
- Named `jobs-manager` (stable in-cluster name contract)
- `type: ClusterIP` and **not** `NodePort`/`LoadBalancer` (no external exposure)
- Selects `app=manager`
- Exposes HTTP port `8080`/TCP only (single port)
- Carries `app=manager` + standard chart labels, in the release namespace

tests-only; security invariants unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no changes to Helm templates or deployed manifests.
> 
> **Overview**
> Adds **helm-unittest** coverage for `templates/jobs-manager-service.yaml`, which previously had no suite.
> 
> The new `client/tests/jobs_manager_service_test.yaml` suite (8 tests) locks in the rendered **Service** contract: fixed name **`jobs-manager`**, **`ClusterIP`** only (explicitly not NodePort/LoadBalancer), selector **`app=manager`**, a single **TCP 8080** HTTP port, standard chart labels plus **`app=manager`**, and placement in the release namespace. Tests-only; no chart template or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af855aaf694ff91e3bc4feb399bb16a3446833b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->