### PR TITLE
test(drift): CI guard for source-of-truth drift (backend hosts + workload names)

### DIFF
--- a/.github/workflows/drift-checks.yaml
+++ b/.github/workflows/drift-checks.yaml
@@ -1,0 +1,37 @@
+name: Drift checks
+
+# Source-of-truth drift: values duplicated across files (the backend API hosts)
+# or coupled across artifacts (the chart's workload names <-> the names the
+# readiness-wait and --diagnose bundle grep for). Mocked unit tests can't see
+# these — a rename ships green and breaks in the field. This guards both sides.
+# Triggers on scripts/ OR client/ because either side moving is the drift.
+on:
+  push:
+    branches: [main, develop, openshift]
+    paths:
+      - 'scripts/**'
+      - 'client/**'
+      - '.github/workflows/drift-checks.yaml'
+  pull_request:
+    branches: [main, develop, openshift]
+    paths:
+      - 'scripts/**'
+      - 'client/**'
+      - '.github/workflows/drift-checks.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: Source-of-truth drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.15.4
+      - name: check-drift
+        run: bash scripts/tests/check-drift.sh

--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -55,11 +55,11 @@ jobs:
           # below for visibility but don't fail the gate.
           shellcheck --severity=error --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/lib/*.sh \
-            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh
+            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh scripts/tests/check-drift.sh
           echo "── shellcheck warnings (advisory, non-blocking) ──"
           shellcheck --severity=warning --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/lib/*.sh \
-            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh || true
+            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh scripts/tests/check-drift.sh || true
 
       - name: PSScriptAnalyzer (PowerShell installer)
         shell: pwsh

--- a/scripts/tests/check-drift.bats
+++ b/scripts/tests/check-drift.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# Tests for scripts/tests/check-drift.sh — the source-of-truth drift checker.
+# We build a tiny fixture repo under $BATS_TEST_TMPDIR, point DRIFT_ROOT at it,
+# source the script (its `set` + main() only run when executed directly), and
+# call the check helpers. helm is stubbed so Check 2b is deterministic offline.
+
+setup() {
+  ROOT="$BATS_TEST_TMPDIR/root"
+  mkdir -p "$ROOT/scripts/lib" "$ROOT/scripts" "$ROOT/client/ci"
+  # Check 1 fixtures — all three carry the same dev/stg/prod hosts.
+  printf '_pf_backend_host(){ echo dev-api.tracebloc.io; echo stg-api.tracebloc.io; echo api.tracebloc.io; }\n' > "$ROOT/scripts/lib/preflight.sh"
+  printf '_backend_url(){ printf https://dev-api.tracebloc.io/; printf https://stg-api.tracebloc.io/; printf https://api.tracebloc.io/; }\n' > "$ROOT/scripts/lib/install-client-helm.sh"
+  printf 'function Get-BackendUrl { "dev-api.tracebloc.io"; "stg-api.tracebloc.io"; "api.tracebloc.io" }\n' > "$ROOT/scripts/install-k8s.ps1"
+  # Check 2a fixtures — scripts reference all contract workloads.
+  printf 'deploys=("mysql-client" "${ns}-jobs-manager" "${ns}-requests-proxy")\n' > "$ROOT/scripts/lib/summary.sh"
+  printf 'for w in mysql-client "${ns}-jobs-manager" "${ns}-requests-proxy"; do :; done\nkubectl logs daemonset/tracebloc-resource-monitor\n' > "$ROOT/scripts/lib/diagnose.sh"
+  printf 'clientId: x\nclientPassword: y\n' > "$ROOT/client/ci/bm-values.yaml"
+
+  export DRIFT_ROOT="$ROOT" TB_RELEASE=tracebloc TB_NAMESPACE=tracebloc
+  source "${BATS_TEST_DIRNAME}/check-drift.sh"
+
+  # helm stub rendering all four contract workloads (override per-test as needed).
+  helm() { cat <<'YAML'
+kind: Deployment
+metadata:
+  name: mysql-client
+kind: Deployment
+metadata:
+  name: tracebloc-jobs-manager
+kind: Deployment
+metadata:
+  name: tracebloc-requests-proxy
+kind: DaemonSet
+metadata:
+  name: tracebloc-resource-monitor
+YAML
+}
+}
+
+# ── Check 1: backend host parity ─────────────────────────────────────────────
+@test "backend hosts: all three files agree -> no drift" {
+  _drift=0; _drift_backend_hosts >/dev/null; [ "$_drift" -eq 0 ]
+}
+
+@test "backend hosts: one file diverges (missing stg) -> drift" {
+  printf '_backend_url(){ printf https://dev-api.tracebloc.io/; printf https://api.tracebloc.io/; }\n' > "$DRIFT_ROOT/scripts/lib/install-client-helm.sh"
+  _drift=0; _drift_backend_hosts >/dev/null; [ "$_drift" -ge 1 ]
+}
+
+@test "backend hosts: prod host renamed in one file -> drift" {
+  printf 'function Get-BackendUrl { "dev-api.tracebloc.io"; "stg-api.tracebloc.io"; "prod.tracebloc.io" }\n' > "$DRIFT_ROOT/scripts/install-k8s.ps1"
+  _drift=0; _drift_backend_hosts >/dev/null; [ "$_drift" -ge 1 ]
+}
+
+@test "backend hosts: function removed (no hosts) -> drift" {
+  echo '# backend function gone' > "$DRIFT_ROOT/scripts/lib/preflight.sh"
+  _drift=0; _drift_backend_hosts >/dev/null; [ "$_drift" -ge 1 ]
+}
+
+# ── Check 2: workload-name contract ──────────────────────────────────────────
+@test "workloads: scripts + chart both carry all names -> no drift" {
+  _drift=0; _drift_workload_names >/dev/null 2>&1; [ "$_drift" -eq 0 ]
+}
+
+@test "workloads: a contract name dropped from the scripts -> drift (2a)" {
+  printf 'deploys=("mysql-client")\n' > "$DRIFT_ROOT/scripts/lib/summary.sh"
+  printf 'echo no-workloads-here\n' > "$DRIFT_ROOT/scripts/lib/diagnose.sh"
+  _drift=0; _drift_workload_names >/dev/null 2>&1; [ "$_drift" -ge 1 ]
+}
+
+@test "workloads: chart render missing a name -> drift (2b)" {
+  helm() { cat <<'YAML'
+kind: Deployment
+metadata:
+  name: mysql-client
+kind: Deployment
+metadata:
+  name: tracebloc-jobs-manager
+kind: DaemonSet
+metadata:
+  name: tracebloc-resource-monitor
+YAML
+}   # tracebloc-requests-proxy is absent
+  _drift=0; _drift_workload_names >/dev/null 2>&1; [ "$_drift" -ge 1 ]
+}
+
+@test "workloads: helm unavailable -> 2b skipped, no drift from the render half" {
+  command() { if [[ "${2:-}" == helm ]]; then return 1; fi; builtin command "$@"; }
+  _drift=0; _drift_workload_names >/dev/null 2>&1; [ "$_drift" -eq 0 ]
+}

--- a/scripts/tests/check-drift.sh
+++ b/scripts/tests/check-drift.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  check-drift.sh — fail when two sources of truth that MUST agree have drifted.
+#
+#  Mocked unit tests can't catch "the chart renamed a Deployment that the
+#  diagnostics script greps for by name" or "the prod API host changed in one of
+#  the three files that hardcode it". Those ship green and break in the field.
+#  This runs in CI on any scripts/ or client/ change and fails with a precise
+#  diff. (Same idea as cli/scripts/sync-schema.sh, which pins the ingest schema.)
+#
+#  Checks:
+#    1. Backend API host map identical across preflight.sh / install-client-helm.sh
+#       / install-k8s.ps1 — the dev/stg/prod hosts are hardcoded in all three.
+#    2. The workload objects summary.sh (readiness wait) and diagnose.sh (support
+#       bundle) reference BY NAME are actually rendered by the chart. A chart
+#       rename would silently break readiness detection and the --diagnose bundle.
+#
+#  Exit 0 = no drift; non-zero = drift (every divergence is printed).
+#  Overrides: DRIFT_ROOT (repo root), TB_RELEASE, TB_NAMESPACE.
+# =============================================================================
+# (set -uo pipefail lives inside main() so this file is side-effect-safe to
+#  source — the bats suite sources it to exercise the helpers in isolation.)
+
+DRIFT_ROOT="${DRIFT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+TB_RELEASE="${TB_RELEASE:-tracebloc}"
+TB_NAMESPACE="${TB_NAMESPACE:-tracebloc}"
+
+_drift=0
+_note() { printf '  \033[31m✖\033[0m %s\n' "$*"; _drift=$(( _drift + 1 )); }
+_ok()   { printf '  \033[32m✔\033[0m %s\n' "$*"; }
+
+# ── Check 1: backend API host map parity ─────────────────────────────────────
+# preflight.sh::_pf_backend_host, install-client-helm.sh::_backend_url, and
+# install-k8s.ps1::Get-BackendUrl each hardcode the dev/stg/prod hosts. They must
+# carry the identical set; a domain change in one file that misses the others is
+# the drift we're guarding.
+_drift_backend_hosts() {
+  echo "▸ Backend API host map (preflight.sh · install-client-helm.sh · install-k8s.ps1)"
+  local files=( scripts/lib/preflight.sh scripts/lib/install-client-helm.sh scripts/install-k8s.ps1 )
+  local ref="" reff="" f hset
+  for f in "${files[@]}"; do
+    if [[ ! -f "$DRIFT_ROOT/$f" ]]; then _note "$f is missing"; continue; fi
+    hset="$(grep -oE '(dev-api|stg-api|api)\.tracebloc\.io' "$DRIFT_ROOT/$f" | sort -u | paste -sd, -)"
+    if [[ -z "$hset" ]]; then _note "$f: no *.tracebloc.io API hosts found (function renamed/removed?)"; continue; fi
+    if [[ -z "$ref" ]]; then ref="$hset"; reff="$f"; _ok "$f → $hset"
+    elif [[ "$hset" != "$ref" ]]; then _note "$f → [$hset]  differs from  $reff → [$ref]"
+    else _ok "$f → $hset"; fi
+  done
+}
+
+# ── Check 2: script-referenced workloads exist in the rendered chart ─────────
+# summary.sh waits on `deployment/<name>` and diagnose.sh logs `deploy/<name>` +
+# `daemonset/<name>`. If the chart renames any, readiness + diagnostics break
+# silently. The names below are the contract (release-prefixed where the scripts
+# use ${ns}-); they're asserted against `helm template` AND against the scripts
+# (so the contract here can't go stale on either side).
+_drift_workload_names() {
+  echo "▸ Workload objects referenced by summary.sh / diagnose.sh vs the chart render"
+  local deployments=( "mysql-client" "${TB_RELEASE}-jobs-manager" "${TB_RELEASE}-requests-proxy" )
+  local daemonsets=( "tracebloc-resource-monitor" )
+  local n
+
+  # 2a. each contract name must still be referenced by the scripts.
+  local blob; blob="$(cat "$DRIFT_ROOT"/scripts/lib/summary.sh "$DRIFT_ROOT"/scripts/lib/diagnose.sh 2>/dev/null)"
+  for n in "mysql-client" '${ns}-jobs-manager' '${ns}-requests-proxy' "tracebloc-resource-monitor"; do
+    grep -qF -- "$n" <<<"$blob" || _note "contract lists '$n' but summary.sh/diagnose.sh no longer reference it — update check-drift.sh"
+  done
+
+  # 2b. each contract name must be rendered by the chart.
+  if ! command -v helm >/dev/null 2>&1; then
+    echo "  (helm not installed — skipping chart render; CI runs this half)"; return 0
+  fi
+  local vals; vals="$(ls "$DRIFT_ROOT"/client/ci/bm-values.yaml "$DRIFT_ROOT"/client/ci/*-values.yaml 2>/dev/null | head -1)"
+  local rendered
+  if ! rendered="$(helm template "$TB_RELEASE" "$DRIFT_ROOT/client" -n "$TB_NAMESPACE" ${vals:+-f "$vals"} 2>/dev/null)"; then
+    _note "helm template failed — the chart does not render (values: ${vals:-none})"; return 0
+  fi
+  for n in "${deployments[@]}"; do
+    if grep -qE "^[[:space:]]*name:[[:space:]]+${n}([[:space:]]|$)" <<<"$rendered"; then _ok "Deployment/$n rendered"
+    else _note "summary.sh/diagnose.sh expect Deployment/$n — the chart does not render that name"; fi
+  done
+  for n in "${daemonsets[@]}"; do
+    if grep -qE "^[[:space:]]*name:[[:space:]]+${n}([[:space:]]|$)" <<<"$rendered"; then _ok "DaemonSet/$n rendered"
+    else _note "diagnose.sh expects DaemonSet/$n — the chart does not render that name"; fi
+  done
+}
+
+main() {
+  set -uo pipefail
+  echo "── source-of-truth drift checks ─────────────────────────────"
+  _drift_backend_hosts
+  _drift_workload_names
+  echo "─────────────────────────────────────────────────────────────"
+  if [[ "$_drift" -gt 0 ]]; then
+    echo "DRIFT: $_drift divergence(s) above. Update both sides (or the contract in check-drift.sh) and re-run." >&2
+    return 1
+  fi
+  echo "no drift."
+  return 0
+}
+
+# Run only when executed directly (bats sources this file to test the helpers).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then main "$@"; fi


### PR DESCRIPTION
## What

Net-new CI **drift check** — fails when two sources of truth that must agree have silently diverged. From the test-hardening analysis; the only roadmap item with no existing PR. Tracks backend#746.

Two checks (`scripts/tests/check-drift.sh`):

**1. Backend API host parity** — the dev/stg/prod hosts are hardcoded in three files (`preflight.sh::_pf_backend_host`, `install-client-helm.sh::_backend_url`, `install-k8s.ps1::Get-BackendUrl`). Asserts all three carry the identical `*.tracebloc.io` host set.

**2. Workload-name contract** — `summary.sh` (readiness wait, `rollout status deployment/<name>`) and `diagnose.sh` (`--diagnose` bundle, `logs deploy/<name>` + `daemonset/<name>`) reference `mysql-client`, `<release>-jobs-manager`, `<release>-requests-proxy`, `tracebloc-resource-monitor` by name. A chart rename breaks readiness + diagnostics **silently** — same class as the `app=manager` selector bug. Renders the chart (`helm template`) and asserts each name exists, and that the scripts still reference each (so the contract can't go stale on either side).

## How
- `.github/workflows/drift-checks.yaml` runs on `scripts/**` OR `client/**` (either side moving is the drift), sets up helm, runs the check.
- `scripts/tests/check-drift.bats` — 8 cases (parity match / mismatch / removed; contract drop; render-missing; helm-absent skip).
- `check-drift.sh` added to the static job's shellcheck list.

## Testing
- `bash scripts/tests/check-drift.sh` → green on develop (both checks pass; the chart render confirms the four workload names).
- `bats scripts/tests/check-drift.bats` → 8/8.
- Full suite: no new failures (same 4 pre-existing macOS-env failures).
- shellcheck (error severity) clean on the new script.

## Follow-ups (separate)
- Cross-repo selector drift: Mintlify `docs` `-l app=…` selectors ↔ chart labels (the original `app=manager` surface) — needs a cross-repo guard.
- Preflight thresholds ↔ docs sizing numbers (cross-repo).
- Promote the `Source-of-truth drift` job to a required status check once proven stable.

Refs tracebloc/backend#746

🤖 Generated with [Claude Code](https://claude.com/claude-code)
