### PR TITLE
release: promote develop → main (installer hardening — OOM gate, apt/needrestart fixes, drift CI)

### DIFF
--- a/.github/workflows/drift-checks.yaml
+++ b/.github/workflows/drift-checks.yaml
@@ -1,0 +1,37 @@
+name: Drift checks
+
+# Source-of-truth drift: values duplicated across files (the backend API hosts)
+# or coupled across artifacts (the chart's workload names <-> the names the
+# readiness-wait and --diagnose bundle grep for). Mocked unit tests can't see
+# these — a rename ships green and breaks in the field. This guards both sides.
+# Triggers on scripts/ OR client/ because either side moving is the drift.
+on:
+  push:
+    branches: [main, develop, openshift]
+    paths:
+      - 'scripts/**'
+      - 'client/**'
+      - '.github/workflows/drift-checks.yaml'
+  pull_request:
+    branches: [main, develop, openshift]
+    paths:
+      - 'scripts/**'
+      - 'client/**'
+      - '.github/workflows/drift-checks.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: Source-of-truth drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.15.4
+      - name: check-drift
+        run: bash scripts/tests/check-drift.sh

--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -55,11 +55,11 @@ jobs:
           # below for visibility but don't fail the gate.
           shellcheck --severity=error --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/lib/*.sh \
-            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh
+            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh scripts/tests/check-drift.sh
           echo "── shellcheck warnings (advisory, non-blocking) ──"
           shellcheck --severity=warning --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/lib/*.sh \
-            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh || true
+            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh scripts/tests/check-drift.sh || true
 
       - name: PSScriptAnalyzer (PowerShell installer)
         shell: pwsh

--- a/client/tests/ingestion_authz_configmap_test.yaml
+++ b/client/tests/ingestion_authz_configmap_test.yaml
@@ -1,0 +1,125 @@
+suite: Ingestion Authz ConfigMap
+# Covers templates/ingestion-authz-configmap.yaml — the authorization policy
+# that decides which ServiceAccount(s) may call
+# POST /internal/submit-ingestion-run on jobs-manager, scoped to table-name
+# prefixes (client-runtime#21). This is a security-relevant template: the
+# rendered policy is the single source of truth jobs-manager loads at startup,
+# so the fail-safe deny-all behaviour and the SA-name / namespace fallbacks
+# must hold.
+templates:
+  - templates/ingestion-authz-configmap.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: renders a ConfigMap with the release-scoped name and namespace
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ingestion-authz
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: stamps the standard tracebloc labels
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: client
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+
+  - it: renders the default policy entry with the default SA, release namespace and wildcard prefix
+    # values.yaml ships a single default entry `- table_prefixes: ["*"]`,
+    # which the template fills in with the default SA name and the release
+    # namespace.
+    asserts:
+      - matchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: 'service_account: "ingestor"'
+      - matchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: 'namespace: "NAMESPACE"'
+      - matchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: '- "\*"'
+
+  - it: renders an explicit entry verbatim with multiple table prefixes
+    set:
+      ingestionAuthz:
+        allowed:
+          - service_account: my-dataset-ingestor
+            namespace: tracebloc
+            table_prefixes: ["chest_xrays_", "tumors_"]
+    asserts:
+      - matchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: 'service_account: "my-dataset-ingestor"'
+      - matchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: 'namespace: "tracebloc"'
+      - matchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: '- "chest_xrays_"'
+      - matchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: '- "tumors_"'
+
+  - it: falls back to ingestionAuthz.serviceAccountName when an entry omits service_account
+    # Per-entry service_account is nil-guarded (#129) to the shared SA name so
+    # the operator changes it in one place. Here the custom SA name must flow
+    # into the policy even though the entry itself doesn't repeat it.
+    set:
+      ingestionAuthz:
+        serviceAccountName: custom-ingestor
+        allowed:
+          - table_prefixes: ["x_"]
+    asserts:
+      - matchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: 'service_account: "custom-ingestor"'
+
+  - it: defaults a per-entry omitted namespace to the release namespace
+    set:
+      ingestionAuthz:
+        allowed:
+          - service_account: scoped-sa
+            table_prefixes: ["y_"]
+    asserts:
+      - matchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: 'service_account: "scoped-sa"'
+      - matchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: 'namespace: "NAMESPACE"'
+
+  - it: fail-safe deny-all when ingestionAuthz is absent from a --reuse-values upgrade
+    # Simulates a pre-#123 stored values dict (no .Values.ingestionAuthz). The
+    # nil-guarded chain must collapse to an empty `allowed:` list rather than
+    # panicking — and an empty policy denies every caller, which is the correct
+    # fail-safe default.
+    set:
+      ingestionAuthz: null
+    asserts:
+      - matchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: 'allowed:'
+      - notMatchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: 'service_account'
+
+  - it: fail-safe deny-all when ingestionAuthz.allowed is empty
+    set:
+      ingestionAuthz:
+        serviceAccountName: ingestor
+        allowed: []
+    asserts:
+      - matchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: 'allowed:'
+      - notMatchRegex:
+          path: data["ingestion-authz.yaml"]
+          pattern: 'service_account'

--- a/client/tests/jobs_manager_service_test.yaml
+++ b/client/tests/jobs_manager_service_test.yaml
@@ -1,0 +1,76 @@
+suite: jobs-manager Service
+templates:
+  - templates/jobs-manager-service.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: should render a single Service document
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+
+  - it: should name the Service jobs-manager (stable in-cluster name contract)
+    asserts:
+      - equal:
+          path: metadata.name
+          value: jobs-manager
+
+  - it: should be ClusterIP only (no external exposure)
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should not be a NodePort or LoadBalancer
+    asserts:
+      - notEqual:
+          path: spec.type
+          value: NodePort
+      - notEqual:
+          path: spec.type
+          value: LoadBalancer
+
+  - it: should select the jobs-manager pods via app=manager
+    asserts:
+      - equal:
+          path: spec.selector.app
+          value: manager
+
+  - it: should expose the ingestion HTTP port 8080 over TCP
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8080
+      - equal:
+          path: spec.ports[0].protocol
+          value: TCP
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+
+  - it: should carry the app=manager label and standard chart labels
+    asserts:
+      - equal:
+          path: metadata.labels.app
+          value: manager
+      - isNotNullOrEmpty:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+      - isNotNullOrEmpty:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: should live in the release namespace
+    release:
+      namespace: my-custom-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-custom-ns

--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -769,6 +769,9 @@ function Set-ClusterAutostart {
 function New-K3dCluster {
   Log "Creating k3d cluster: '$CLUSTER_NAME'"
 
+  # Docker is up now (unlike at preflight); re-check the runtime's real memory budget.
+  Test-PreflightRuntimeMem
+
   $clusterExists = $false
   $clusterObj = $null
   try {
@@ -1406,12 +1409,33 @@ function Get-PfFreeGb {
   } catch { return $null }
 }
 
+# Memory/CPU as the container runtime sees it (the Docker Desktop / WSL2 VM budget,
+# which is what the pods actually get — smaller than the host). $null if the daemon
+# is down or the value is junk, so callers fall back to the host (CIM) reader.
+function Get-PfRuntimeMemGb {
+  try {
+    $v = ((docker info --format '{{.MemTotal}}' 2>$null) | Out-String).Trim()
+    if ($v -match '^\d+$' -and [int64]$v -gt 0) { return [math]::Floor([int64]$v / 1GB) }
+  } catch {}
+  return $null
+}
+function Get-PfRuntimeCpu {
+  try {
+    $v = ((docker info --format '{{.NCPU}}' 2>$null) | Out-String).Trim()
+    if ($v -match '^\d+$' -and [int]$v -gt 0) { return [int]$v }
+  } catch {}
+  return $null
+}
+
+# Prefer the runtime view, fall back to the host (CIM).
 function Get-PfMemGb {
+  $r = Get-PfRuntimeMemGb; if ($null -ne $r) { return $r }
   try { return [math]::Floor((Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).TotalPhysicalMemory / 1GB) }
   catch { return $null }
 }
 
 function Get-PfCpu {
+  $r = Get-PfRuntimeCpu; if ($null -ne $r) { return $r }
   try { return [int](Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).NumberOfLogicalProcessors }
   catch { if ($env:NUMBER_OF_PROCESSORS) { return [int]$env:NUMBER_OF_PROCESSORS } else { return $null } }
 }
@@ -1419,10 +1443,13 @@ function Get-PfCpu {
 function Test-Preflight {
   if ($env:TRACEBLOC_SKIP_PREFLIGHT) { Info "Preflight checks skipped (TRACEBLOC_SKIP_PREFLIGHT set)."; return }
 
-  $minDiskGb  = if ($env:PF_MIN_DISK_GB)  { [int]$env:PF_MIN_DISK_GB }  else { 5 }
+  $minDiskGb  = if ($env:PF_MIN_DISK_GB)  { [int]$env:PF_MIN_DISK_GB }  else { 10 }
   $warnDiskGb = if ($env:PF_WARN_DISK_GB) { [int]$env:PF_WARN_DISK_GB } else { 20 }
-  $warnMemGb  = if ($env:PF_WARN_MEM_GB)  { [int]$env:PF_WARN_MEM_GB }  else { 4 }
+  $minMemGb   = if ($env:PF_MIN_MEM_GB)   { [int]$env:PF_MIN_MEM_GB }   else { 5 }
+  $warnMemGb  = if ($env:PF_WARN_MEM_GB)  { [int]$env:PF_WARN_MEM_GB }  else { 8 }
+  $recMemGb   = if ($env:PF_REC_MEM_GB)   { [int]$env:PF_REC_MEM_GB }   else { 16 }
   $minCpu     = if ($env:PF_MIN_CPU)      { [int]$env:PF_MIN_CPU }      else { 2 }
+  $recCpu     = if ($env:PF_REC_CPU)      { [int]$env:PF_REC_CPU }      else { 4 }
   $hardFail   = 0
 
   # Architecture — the tracebloc client images (e.g. mysql-client) are amd64-only.
@@ -1437,12 +1464,22 @@ function Test-Preflight {
 
   $cpu = Get-PfCpu
   if      ($null -eq $cpu)   { Warn "CPU: couldn't determine core count (skipping)." }
-  elseif  ($cpu -lt $minCpu) { Warn "CPU: $cpu core(s) - recommended >= $minCpu." }
+  elseif  ($cpu -lt $minCpu) { Warn "CPU: $cpu core(s) - below the $minCpu-core minimum; mysql may hit lock-wait timeouts. $recCpu+ recommended to train." }
+  elseif  ($cpu -lt $recCpu) { Warn "CPU: $cpu cores - fine to run; $recCpu+ recommended to train locally." }
   else                       { Ok "CPU: $cpu cores" }
 
+  # Memory is warn-only on Windows: at preflight the Docker Desktop / WSL2 daemon may
+  # be down (so this is host RAM); the post-Docker re-check sees the real VM budget.
   $mem = Get-PfMemGb
   if      ($null -eq $mem)      { Warn "Memory: couldn't determine total RAM (skipping)." }
-  elseif  ($mem -lt $warnMemGb) { Warn "Memory: $mem GB total - recommended >= $warnMemGb GB; k3s + training may run out of memory." }
+  elseif  ($mem -lt $minMemGb)  {
+    Warn "Memory: $mem GB - below the $minMemGb GB the client needs; it will OOM."
+    Hint "Docker Desktop -> Settings -> Resources -> Memory: raise to >= $warnMemGb GB ($recMemGb GB to train), then re-run."
+  }
+  elseif  ($mem -lt $warnMemGb) {
+    Warn "Memory: $mem GB - enough to run, but training (~8 GB/job) may OOM; $recMemGb GB recommended to train locally."
+    Hint "Docker Desktop -> Settings -> Resources -> Memory >= $recMemGb GB to train."
+  }
   else                          { Ok "Memory: $mem GB" }
 
   $disk = Get-PfFreeGb
@@ -1476,6 +1513,22 @@ function Test-Preflight {
   if ($hardFail -gt 0) {
     Write-Host ""
     Err "Preflight failed - resolve the items above and re-run. (Override at your own risk with `$env:TRACEBLOC_SKIP_PREFLIGHT=1.)"
+  }
+}
+
+# Re-evaluate memory once Docker is confirmed up. Test-Preflight runs before Docker
+# Desktop starts, so its read may have been host RAM, not the (smaller) Docker VM
+# budget. Called from New-K3dCluster. WARN-only — the user has already waited for
+# Docker, so aborting here would be jarring.
+function Test-PreflightRuntimeMem {
+  if ($env:TRACEBLOC_SKIP_PREFLIGHT) { return }
+  $mem = Get-PfRuntimeMemGb
+  if ($null -eq $mem) { return }
+  $warnMemGb = if ($env:PF_WARN_MEM_GB) { [int]$env:PF_WARN_MEM_GB } else { 8 }
+  $recMemGb  = if ($env:PF_REC_MEM_GB)  { [int]$env:PF_REC_MEM_GB }  else { 16 }
+  if ($mem -lt $warnMemGb) {
+    Warn "Docker is running with $mem GB - recommended >= $warnMemGb GB ($recMemGb GB to train); the client may OOM under load."
+    Hint "Docker Desktop -> Settings -> Resources -> Memory >= $warnMemGb GB, then re-install."
   }
 }
 

--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -527,7 +527,9 @@ curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-contai
   | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
   | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list >/dev/null
 sudo apt-get update -qq
-sudo apt-get install -y -q nvidia-container-toolkit
+# needrestart on WSL Ubuntu would open a hidden prompt in this captured job and
+# stall to the 180s timeout; DEBIAN_FRONTEND/NEEDRESTART_MODE keep apt non-interactive.
+sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -q nvidia-container-toolkit
 sudo nvidia-ctk runtime configure --runtime=docker --set-as-default 2>/dev/null || true
 sudo nvidia-ctk runtime configure --runtime=containerd 2>/dev/null || true
 echo "NCT installed successfully."

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -121,7 +121,8 @@ create_cluster() {
 
   # Docker is up now (unlike at preflight time), so re-check the runtime's real
   # memory budget — a too-small Docker VM (Mac/Win) surfaces before we build out.
-  _pf_recheck_runtime_mem || true
+  # Guarded: cluster.sh can be sourced without preflight.sh (e.g. the e2e harness).
+  if declare -F _pf_recheck_runtime_mem >/dev/null 2>&1; then _pf_recheck_runtime_mem || true; fi
 
   if _cluster_exists; then
     _handle_existing_cluster

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -119,6 +119,10 @@ create_cluster() {
 
   _ensure_tracebloc_dirs
 
+  # Docker is up now (unlike at preflight time), so re-check the runtime's real
+  # memory budget — a too-small Docker VM (Mac/Win) surfaces before we build out.
+  _pf_recheck_runtime_mem || true
+
   if _cluster_exists; then
     _handle_existing_cluster
   else

--- a/scripts/lib/preflight.sh
+++ b/scripts/lib/preflight.sh
@@ -10,15 +10,23 @@
 #  Escape hatches:
 #    TRACEBLOC_SKIP_PREFLIGHT=1   skip all checks
 #    TRACEBLOC_ALLOW_ARM64=1      proceed on arm64 despite amd64-only images
+#    PF_MIN_MEM_GB / PF_MIN_CPU / PF_MIN_DISK_GB   lower the hard floors (CI / odd sites)
 #
 #  This file is side-effect-safe to source (defaults + function defs only).
 # =============================================================================
 
-# Thresholds (overridable via env — for unusual sites or tests)
-PF_MIN_DISK_GB="${PF_MIN_DISK_GB:-5}"      # hard-fail below this (Linux)
+# Thresholds (overridable via env — for unusual sites or tests).
+# RAM floors are derived from the real stack, not guessed: the always-on control
+# plane requests ~2.1 GiB, + k3s/k3d ~0.8 + OS/Docker ~0.7 ≈ ~4.4 GiB just to stay
+# Online on a single-node (k3d) install — so below 5 GiB it boots then OOMs. 8 GiB
+# is comfortable to run; 16 GiB is needed to train locally (a job's limit is ~8 GiB+).
+PF_MIN_DISK_GB="${PF_MIN_DISK_GB:-10}"     # hard-fail below this (Linux) — base images alone need >5
 PF_WARN_DISK_GB="${PF_WARN_DISK_GB:-20}"   # warn below this
-PF_WARN_MEM_GB="${PF_WARN_MEM_GB:-4}"      # warn below this
+PF_MIN_MEM_GB="${PF_MIN_MEM_GB:-5}"        # hard-fail below this (Linux; warn on Mac/Win)
+PF_WARN_MEM_GB="${PF_WARN_MEM_GB:-8}"      # warn below this (comfortable to run)
+PF_REC_MEM_GB="${PF_REC_MEM_GB:-16}"       # recommended to train locally (copy only, not a gate)
 PF_MIN_CPU="${PF_MIN_CPU:-2}"              # warn below this
+PF_REC_CPU="${PF_REC_CPU:-4}"              # recommended (warn) below this
 
 # Non-exiting failure line (common.sh's error() exits; preflight must finish all
 # checks first, so failures print here and are recorded in PF_HARD_FAIL). Writes
@@ -50,8 +58,26 @@ _pf_probe_url() {
 # Free space in KB on the filesystem holding $1.
 _pf_free_kb() { df -Pk "$1" 2>/dev/null | awk 'NR==2 {print $4}'; }
 
-# Total physical RAM in KB.
-_pf_total_mem_kb() {
+# Memory/CPU as the CONTAINER RUNTIME sees it (the budget the pods actually get).
+# On Docker Desktop / Colima / WSL2 this is the VM's allocation — smaller than the
+# host and the number that matters (a 36 GB Mac can cap its Docker VM at 4 GB). Echo
+# a single integer, or nothing if the daemon is down / the value is junk — callers
+# then fall back to the host reader. (docker info precedent: _pf_docker_root above.)
+_pf_runtime_mem_kb() {
+  has docker && docker info >/dev/null 2>&1 || return 0
+  local b; b="$(docker info --format '{{.MemTotal}}' 2>/dev/null)"
+  [[ "$b" =~ ^[0-9]+$ && "$b" -gt 0 ]] && echo $(( b / 1024 ))
+  return 0
+}
+_pf_runtime_ncpu() {
+  has docker && docker info >/dev/null 2>&1 || return 0
+  local n; n="$(docker info --format '{{.NCPU}}' 2>/dev/null)"
+  [[ "$n" =~ ^[0-9]+$ && "$n" -gt 0 ]] && echo "$n"
+  return 0
+}
+
+# Total physical RAM of the HOST in KB.
+_pf_host_mem_kb() {
   if [[ "$OS" == "Darwin" ]]; then
     local b; b=$(sysctl -n hw.memsize 2>/dev/null) || b=""
     [[ -n "$b" ]] && echo $(( b / 1024 ))
@@ -60,14 +86,22 @@ _pf_total_mem_kb() {
   fi
 }
 
-# Logical CPU count.
-_pf_ncpu() {
+# Logical CPU count of the HOST.
+_pf_host_ncpu() {
   if [[ "$OS" == "Darwin" ]]; then
     sysctl -n hw.ncpu 2>/dev/null
   else
     nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null
   fi
 }
+
+# Available (free) RAM right now, KB — Linux only (for the busy-shared-VM warn).
+_pf_avail_mem_kb() { awk '/^MemAvailable:/ {print $2}' /proc/meminfo 2>/dev/null; }
+
+# Selectors: prefer the runtime view, fall back to the host. The checks (and the
+# bats numeric test) call these names; they always emit exactly one integer.
+_pf_total_mem_kb() { local v; v="$(_pf_runtime_mem_kb)"; [[ -n "$v" ]] && { echo "$v"; return 0; }; _pf_host_mem_kb; }
+_pf_ncpu()         { local v; v="$(_pf_runtime_ncpu)";   [[ -n "$v" ]] && { echo "$v"; return 0; }; _pf_host_ncpu; }
 
 # Docker data root if the daemon is up; else where it will live / a host proxy.
 _pf_docker_root() {
@@ -124,8 +158,12 @@ _pf_arch() {
 _pf_cpu() {
   local n; n="$(_pf_ncpu)"
   if [[ -z "$n" ]]; then warn "CPU: couldn't determine core count (skipping)."; return 0; fi
+  # CPU is warn-only: starvation throttles (and can trip mysql InnoDB lock-wait
+  # timeouts) but doesn't OOM-kill, and the chart deliberately omits limits.cpu.
   if [[ "$n" -lt "$PF_MIN_CPU" ]]; then
-    warn "CPU: ${n} core(s) — recommended ≥ ${PF_MIN_CPU}."
+    warn "CPU: ${n} core(s) — below the ${PF_MIN_CPU}-core minimum; mysql may hit lock-wait timeouts. ${PF_REC_CPU}+ recommended to train."
+  elif [[ "$n" -lt "$PF_REC_CPU" ]]; then
+    warn "CPU: ${n} cores — fine to run; ${PF_REC_CPU}+ recommended to train locally."
   else
     success "CPU: ${n} cores"
   fi
@@ -133,13 +171,62 @@ _pf_cpu() {
 }
 
 _pf_memory() {
-  local kb gb; kb="$(_pf_total_mem_kb)"
+  local kb gb mib floor_mib warn_mib src
+  kb="$(_pf_total_mem_kb)"
   if [[ -z "$kb" ]]; then warn "Memory: couldn't determine total RAM (skipping)."; return 0; fi
   gb=$(( kb / 1024 / 1024 ))
-  if [[ "$gb" -lt "$PF_WARN_MEM_GB" ]]; then
-    warn "Memory: ${gb} GB total — recommended ≥ ${PF_WARN_MEM_GB} GB; k3s + training may run out of memory."
+  mib=$(( kb / 1024 ))
+  # Compare in MiB with a 64 MiB grace so a VM that reports e.g. 4 GiB a hair under
+  # 4*1024^3 (Colima / Docker Desktop) doesn't floor to 3 GB and false-trip the gate.
+  floor_mib=$(( PF_MIN_MEM_GB * 1024 - 64 ))
+  warn_mib=$(( PF_WARN_MEM_GB * 1024 ))
+  src="host"; [[ -n "$(_pf_runtime_mem_kb)" ]] && src="Docker VM"
+
+  if [[ "$mib" -lt "$floor_mib" ]]; then
+    if [[ "$OS" == "Linux" ]]; then
+      _pf_fail_line "Memory: only ${gb} GB (${src}) — need ≥ ${PF_MIN_MEM_GB} GB to run the tracebloc client."
+      PF_HARD_FAIL=$(( ${PF_HARD_FAIL:-0} + 1 ))
+      hint "Resize the VM (or free memory) to ≥ ${PF_WARN_MEM_GB} GB; ${PF_REC_MEM_GB} GB to train locally. Then re-run."
+    else
+      # Mac/Win: at preflight Docker is usually still down, so this is host RAM —
+      # warn (don't block); the create_cluster re-check sees the real VM size.
+      warn "Memory: ${gb} GB (${src}) — below the ${PF_MIN_MEM_GB} GB the client needs; it will OOM."
+      hint "Docker Desktop → Settings → Resources → Memory: raise to ≥ ${PF_WARN_MEM_GB} GB (${PF_REC_MEM_GB} GB to train), then re-run."
+    fi
+  elif [[ "$mib" -lt "$warn_mib" ]]; then
+    warn "Memory: ${gb} GB (${src}) — enough to run, but training (≈8 GB/job) may OOM; ${PF_REC_MEM_GB} GB recommended to train locally."
+    [[ "$OS" != "Linux" ]] && hint "Docker Desktop → Settings → Resources → Memory ≥ ${PF_REC_MEM_GB} GB to train."
   else
-    success "Memory: ${gb} GB"
+    success "Memory: ${gb} GB (${src})"
+  fi
+
+  # Linux: even when total is fine, a busy shared VM may have little free RAM now.
+  if [[ "$OS" == "Linux" ]]; then
+    local avail_kb avail_gb
+    avail_kb="$(_pf_avail_mem_kb)"
+    if [[ -n "$avail_kb" ]]; then
+      avail_gb=$(( avail_kb / 1024 / 1024 ))
+      if [[ "$avail_gb" -lt "$PF_MIN_MEM_GB" ]]; then
+        warn "Memory: only ${avail_gb} GB available right now (other workloads are using this machine) — the client needs ~${PF_MIN_MEM_GB} GB free to start."
+      fi
+    fi
+  fi
+  return 0
+}
+
+# Re-evaluate memory once Docker is confirmed up. Preflight runs before Docker
+# starts (install-k8s.sh), so on macOS/Windows the first read was host RAM, not the
+# Docker VM's smaller budget. Called from create_cluster (cluster.sh) — the first
+# point `docker info` is reliably up on every OS. WARN-only: the user has already
+# waited for Docker to come up, so aborting here would be jarring.
+_pf_recheck_runtime_mem() {
+  [[ -n "${TRACEBLOC_SKIP_PREFLIGHT:-}" ]] && return 0
+  local kb gb; kb="$(_pf_runtime_mem_kb)"
+  [[ -z "$kb" ]] && return 0          # daemon still not reporting — nothing to add
+  gb=$(( kb / 1024 / 1024 ))
+  if [[ $(( kb / 1024 )) -lt $(( PF_WARN_MEM_GB * 1024 )) ]]; then
+    warn "Docker is running with ${gb} GB — recommended ≥ ${PF_WARN_MEM_GB} GB (${PF_REC_MEM_GB} GB to train); the client may OOM under load."
+    [[ "$OS" != "Linux" ]] && hint "Docker Desktop → Settings → Resources → Memory ≥ ${PF_WARN_MEM_GB} GB, then re-install."
   fi
   return 0
 }

--- a/scripts/lib/setup-linux.sh
+++ b/scripts/lib/setup-linux.sh
@@ -6,7 +6,14 @@
 
 # ── Package manager detection ────────────────────────────────────────────────
 setup_pm() {
-  if   has apt-get; then PM_UPDATE="sudo apt-get update -qq";           PM_INSTALL="sudo apt-get install -y -q -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
+  # apt note: Ubuntu 22.04+ ships needrestart, which hooks `apt-get install` and
+  # opens an interactive "restart services?" prompt that `-y` does NOT suppress.
+  # Run inside spin_cmd (stdout/stderr redirected, process backgrounded) that
+  # prompt is invisible and blocks reading the TTY → SIGTTIN → the install hangs
+  # forever ("still pulling conntrack"). DEBIAN_FRONTEND=noninteractive +
+  # NEEDRESTART_MODE=a make apt fully non-interactive; they are passed *through*
+  # `sudo env` because sudo resets the environment by default.
+  if   has apt-get; then PM_UPDATE="sudo apt-get update -qq";           PM_INSTALL="sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -q -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
   elif has dnf;     then PM_UPDATE="sudo dnf makecache -q";             PM_INSTALL="sudo dnf install -y -q"
   elif has yum;     then PM_UPDATE="sudo yum makecache -q";             PM_INSTALL="sudo yum install -y -q"
   elif has zypper;  then PM_UPDATE="sudo zypper refresh";               PM_INSTALL="sudo zypper install -y"
@@ -77,7 +84,9 @@ install_docker_engine() {
       docker_script="$(mktemp)"
       retry 3 5 curl -fsSL $CURL_SECURE https://get.docker.com -o "$docker_script"
       chmod +x "$docker_script"
-      spin_cmd "Installing Docker…" sudo bash "$docker_script"
+      # Same needrestart guard as setup_pm: get.docker.com runs `apt-get install`
+      # internally, so under spin_cmd it can hit the same hidden prompt and hang.
+      spin_cmd "Installing Docker…" sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a bash "$docker_script"
       rm -f "$docker_script"
     fi
     # Enable for boot only (no --now): starting is handled below, where a start

--- a/scripts/lib/setup-linux.sh
+++ b/scripts/lib/setup-linux.sh
@@ -13,12 +13,38 @@ setup_pm() {
   # forever ("still pulling conntrack"). DEBIAN_FRONTEND=noninteractive +
   # NEEDRESTART_MODE=a make apt fully non-interactive; they are passed *through*
   # `sudo env` because sudo resets the environment by default.
-  if   has apt-get; then PM_UPDATE="sudo apt-get update -qq";           PM_INSTALL="sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -q -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
+  #
+  # apt also waits *indefinitely* on the dpkg lock while apt-daily / unattended-
+  # upgrades hold it on a freshly-booted host (#210); -o DPkg::Lock::Timeout=600
+  # bounds that wait so the install fails with a clear error rather than hanging
+  # silently behind the spinner.
+  if   has apt-get; then PM_UPDATE="sudo apt-get update -qq -o DPkg::Lock::Timeout=600"; PM_INSTALL="sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -q -o DPkg::Lock::Timeout=600 -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
   elif has dnf;     then PM_UPDATE="sudo dnf makecache -q";             PM_INSTALL="sudo dnf install -y -q"
   elif has yum;     then PM_UPDATE="sudo yum makecache -q";             PM_INSTALL="sudo yum install -y -q"
   elif has zypper;  then PM_UPDATE="sudo zypper refresh";               PM_INSTALL="sudo zypper install -y"
   elif has pacman;  then PM_UPDATE="sudo pacman -Sy --noconfirm";       PM_INSTALL="sudo pacman -S --noconfirm"
   else error "No supported package manager found."; fi
+}
+
+# ── Wait out apt/dpkg lock holders before our apt calls ──────────────────────
+# On a freshly-installed/booted Debian/Ubuntu host, the apt-daily and
+# unattended-upgrades systemd units grab the dpkg lock at boot and can hold it
+# for several minutes (longer when a kernel/security batch is pending). apt-get
+# then blocks on the lock, and because we run it behind spin_cmd the
+# "Waiting for cache lock…" line is hidden in the log — the installer looks
+# frozen (#210). Surface the wait with a visible spinner and bound it; the
+# per-command DPkg::Lock::Timeout (setup_pm) is the backstop if a holder appears
+# mid-run. No-op when apt or fuser is absent, or when the lock is already free.
+apt_wait_for_lock() {
+  has apt-get && has fuser || return 0
+  local locks="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock"
+  sudo fuser $locks >/dev/null 2>&1 || return 0   # free already → silent fast path
+  spin_cmd "Waiting for background system updates to finish…" bash -c '
+    waited=0
+    while sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock >/dev/null 2>&1; do
+      [ "$waited" -ge 600 ] && exit 0
+      sleep 5; waited=$((waited + 5))
+    done' || true
 }
 
 # ── Kernel modules Docker + k3s need ─────────────────────────────────────────
@@ -272,6 +298,7 @@ install_linux() {
 
   preflight_sudo
   setup_pm
+  apt_wait_for_lock          # don't fight apt-daily/unattended-upgrades for the lock
   install_docker_engine
   install_system_deps
 

--- a/scripts/lib/setup-macos.sh
+++ b/scripts/lib/setup-macos.sh
@@ -69,7 +69,9 @@ _install_docker_colima() {
     return
   fi
 
-  spin_cmd "Starting Docker runtime…" colima start --cpu 2 --memory 4 --disk 60
+  # Colima VM sizing must clear the preflight floor — the client needs ~5 GB just
+  # to run (control plane + k3s + OS), 16 GB to train locally. Overridable per box.
+  spin_cmd "Starting Docker runtime…" colima start --cpu "${COLIMA_CPU:-4}" --memory "${COLIMA_MEMORY:-6}" --disk "${COLIMA_DISK:-60}"
 
   if ! docker info &>/dev/null 2>&1; then
     error "Docker did not start. Try running 'colima status' to investigate."

--- a/scripts/tests/check-drift.bats
+++ b/scripts/tests/check-drift.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# Tests for scripts/tests/check-drift.sh — the source-of-truth drift checker.
+# We build a tiny fixture repo under $BATS_TEST_TMPDIR, point DRIFT_ROOT at it,
+# source the script (its `set` + main() only run when executed directly), and
+# call the check helpers. helm is stubbed so Check 2b is deterministic offline.
+
+setup() {
+  ROOT="$BATS_TEST_TMPDIR/root"
+  mkdir -p "$ROOT/scripts/lib" "$ROOT/scripts" "$ROOT/client/ci"
+  # Check 1 fixtures — all three carry the same dev/stg/prod hosts.
+  printf '_pf_backend_host(){ echo dev-api.tracebloc.io; echo stg-api.tracebloc.io; echo api.tracebloc.io; }\n' > "$ROOT/scripts/lib/preflight.sh"
+  printf '_backend_url(){ printf https://dev-api.tracebloc.io/; printf https://stg-api.tracebloc.io/; printf https://api.tracebloc.io/; }\n' > "$ROOT/scripts/lib/install-client-helm.sh"
+  printf 'function Get-BackendUrl { "dev-api.tracebloc.io"; "stg-api.tracebloc.io"; "api.tracebloc.io" }\n' > "$ROOT/scripts/install-k8s.ps1"
+  # Check 2a fixtures — scripts reference all contract workloads.
+  printf 'deploys=("mysql-client" "${ns}-jobs-manager" "${ns}-requests-proxy")\n' > "$ROOT/scripts/lib/summary.sh"
+  printf 'for w in mysql-client "${ns}-jobs-manager" "${ns}-requests-proxy"; do :; done\nkubectl logs daemonset/tracebloc-resource-monitor\n' > "$ROOT/scripts/lib/diagnose.sh"
+  printf 'clientId: x\nclientPassword: y\n' > "$ROOT/client/ci/bm-values.yaml"
+
+  export DRIFT_ROOT="$ROOT" TB_RELEASE=tracebloc TB_NAMESPACE=tracebloc
+  source "${BATS_TEST_DIRNAME}/check-drift.sh"
+
+  # helm stub rendering all four contract workloads (override per-test as needed).
+  helm() { cat <<'YAML'
+kind: Deployment
+metadata:
+  name: mysql-client
+kind: Deployment
+metadata:
+  name: tracebloc-jobs-manager
+kind: Deployment
+metadata:
+  name: tracebloc-requests-proxy
+kind: DaemonSet
+metadata:
+  name: tracebloc-resource-monitor
+YAML
+}
+}
+
+# ── Check 1: backend host parity ─────────────────────────────────────────────
+@test "backend hosts: all three files agree -> no drift" {
+  _drift=0; _drift_backend_hosts >/dev/null; [ "$_drift" -eq 0 ]
+}
+
+@test "backend hosts: one file diverges (missing stg) -> drift" {
+  printf '_backend_url(){ printf https://dev-api.tracebloc.io/; printf https://api.tracebloc.io/; }\n' > "$DRIFT_ROOT/scripts/lib/install-client-helm.sh"
+  _drift=0; _drift_backend_hosts >/dev/null; [ "$_drift" -ge 1 ]
+}
+
+@test "backend hosts: prod host renamed in one file -> drift" {
+  printf 'function Get-BackendUrl { "dev-api.tracebloc.io"; "stg-api.tracebloc.io"; "prod.tracebloc.io" }\n' > "$DRIFT_ROOT/scripts/install-k8s.ps1"
+  _drift=0; _drift_backend_hosts >/dev/null; [ "$_drift" -ge 1 ]
+}
+
+@test "backend hosts: function removed (no hosts) -> drift" {
+  echo '# backend function gone' > "$DRIFT_ROOT/scripts/lib/preflight.sh"
+  _drift=0; _drift_backend_hosts >/dev/null; [ "$_drift" -ge 1 ]
+}
+
+# ── Check 2: workload-name contract ──────────────────────────────────────────
+@test "workloads: scripts + chart both carry all names -> no drift" {
+  _drift=0; _drift_workload_names >/dev/null 2>&1; [ "$_drift" -eq 0 ]
+}
+
+@test "workloads: a contract name dropped from the scripts -> drift (2a)" {
+  printf 'deploys=("mysql-client")\n' > "$DRIFT_ROOT/scripts/lib/summary.sh"
+  printf 'echo no-workloads-here\n' > "$DRIFT_ROOT/scripts/lib/diagnose.sh"
+  _drift=0; _drift_workload_names >/dev/null 2>&1; [ "$_drift" -ge 1 ]
+}
+
+@test "workloads: chart render missing a name -> drift (2b)" {
+  helm() { cat <<'YAML'
+kind: Deployment
+metadata:
+  name: mysql-client
+kind: Deployment
+metadata:
+  name: tracebloc-jobs-manager
+kind: DaemonSet
+metadata:
+  name: tracebloc-resource-monitor
+YAML
+}   # tracebloc-requests-proxy is absent
+  _drift=0; _drift_workload_names >/dev/null 2>&1; [ "$_drift" -ge 1 ]
+}
+
+@test "workloads: helm unavailable -> 2b skipped, no drift from the render half" {
+  command() { if [[ "${2:-}" == helm ]]; then return 1; fi; builtin command "$@"; }
+  _drift=0; _drift_workload_names >/dev/null 2>&1; [ "$_drift" -eq 0 ]
+}

--- a/scripts/tests/check-drift.sh
+++ b/scripts/tests/check-drift.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  check-drift.sh — fail when two sources of truth that MUST agree have drifted.
+#
+#  Mocked unit tests can't catch "the chart renamed a Deployment that the
+#  diagnostics script greps for by name" or "the prod API host changed in one of
+#  the three files that hardcode it". Those ship green and break in the field.
+#  This runs in CI on any scripts/ or client/ change and fails with a precise
+#  diff. (Same idea as cli/scripts/sync-schema.sh, which pins the ingest schema.)
+#
+#  Checks:
+#    1. Backend API host map identical across preflight.sh / install-client-helm.sh
+#       / install-k8s.ps1 — the dev/stg/prod hosts are hardcoded in all three.
+#    2. The workload objects summary.sh (readiness wait) and diagnose.sh (support
+#       bundle) reference BY NAME are actually rendered by the chart. A chart
+#       rename would silently break readiness detection and the --diagnose bundle.
+#
+#  Exit 0 = no drift; non-zero = drift (every divergence is printed).
+#  Overrides: DRIFT_ROOT (repo root), TB_RELEASE, TB_NAMESPACE.
+# =============================================================================
+# (set -uo pipefail lives inside main() so this file is side-effect-safe to
+#  source — the bats suite sources it to exercise the helpers in isolation.)
+
+DRIFT_ROOT="${DRIFT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+TB_RELEASE="${TB_RELEASE:-tracebloc}"
+TB_NAMESPACE="${TB_NAMESPACE:-tracebloc}"
+
+_drift=0
+_note() { printf '  \033[31m✖\033[0m %s\n' "$*"; _drift=$(( _drift + 1 )); }
+_ok()   { printf '  \033[32m✔\033[0m %s\n' "$*"; }
+
+# ── Check 1: backend API host map parity ─────────────────────────────────────
+# preflight.sh::_pf_backend_host, install-client-helm.sh::_backend_url, and
+# install-k8s.ps1::Get-BackendUrl each hardcode the dev/stg/prod hosts. They must
+# carry the identical set; a domain change in one file that misses the others is
+# the drift we're guarding.
+_drift_backend_hosts() {
+  echo "▸ Backend API host map (preflight.sh · install-client-helm.sh · install-k8s.ps1)"
+  local files=( scripts/lib/preflight.sh scripts/lib/install-client-helm.sh scripts/install-k8s.ps1 )
+  local ref="" reff="" f hset
+  for f in "${files[@]}"; do
+    if [[ ! -f "$DRIFT_ROOT/$f" ]]; then _note "$f is missing"; continue; fi
+    hset="$(grep -oE '(dev-api|stg-api|api)\.tracebloc\.io' "$DRIFT_ROOT/$f" | sort -u | paste -sd, -)"
+    if [[ -z "$hset" ]]; then _note "$f: no *.tracebloc.io API hosts found (function renamed/removed?)"; continue; fi
+    if [[ -z "$ref" ]]; then ref="$hset"; reff="$f"; _ok "$f → $hset"
+    elif [[ "$hset" != "$ref" ]]; then _note "$f → [$hset]  differs from  $reff → [$ref]"
+    else _ok "$f → $hset"; fi
+  done
+}
+
+# ── Check 2: script-referenced workloads exist in the rendered chart ─────────
+# summary.sh waits on `deployment/<name>` and diagnose.sh logs `deploy/<name>` +
+# `daemonset/<name>`. If the chart renames any, readiness + diagnostics break
+# silently. The names below are the contract (release-prefixed where the scripts
+# use ${ns}-); they're asserted against `helm template` AND against the scripts
+# (so the contract here can't go stale on either side).
+_drift_workload_names() {
+  echo "▸ Workload objects referenced by summary.sh / diagnose.sh vs the chart render"
+  local deployments=( "mysql-client" "${TB_RELEASE}-jobs-manager" "${TB_RELEASE}-requests-proxy" )
+  local daemonsets=( "tracebloc-resource-monitor" )
+  local n
+
+  # 2a. each contract name must still be referenced by the scripts.
+  local blob; blob="$(cat "$DRIFT_ROOT"/scripts/lib/summary.sh "$DRIFT_ROOT"/scripts/lib/diagnose.sh 2>/dev/null)"
+  for n in "mysql-client" '${ns}-jobs-manager' '${ns}-requests-proxy' "tracebloc-resource-monitor"; do
+    grep -qF -- "$n" <<<"$blob" || _note "contract lists '$n' but summary.sh/diagnose.sh no longer reference it — update check-drift.sh"
+  done
+
+  # 2b. each contract name must be rendered by the chart.
+  if ! command -v helm >/dev/null 2>&1; then
+    echo "  (helm not installed — skipping chart render; CI runs this half)"; return 0
+  fi
+  local vals; vals="$(ls "$DRIFT_ROOT"/client/ci/bm-values.yaml "$DRIFT_ROOT"/client/ci/*-values.yaml 2>/dev/null | head -1)"
+  local rendered
+  if ! rendered="$(helm template "$TB_RELEASE" "$DRIFT_ROOT/client" -n "$TB_NAMESPACE" ${vals:+-f "$vals"} 2>/dev/null)"; then
+    _note "helm template failed — the chart does not render (values: ${vals:-none})"; return 0
+  fi
+  for n in "${deployments[@]}"; do
+    if grep -qE "^[[:space:]]*name:[[:space:]]+${n}([[:space:]]|$)" <<<"$rendered"; then _ok "Deployment/$n rendered"
+    else _note "summary.sh/diagnose.sh expect Deployment/$n — the chart does not render that name"; fi
+  done
+  for n in "${daemonsets[@]}"; do
+    if grep -qE "^[[:space:]]*name:[[:space:]]+${n}([[:space:]]|$)" <<<"$rendered"; then _ok "DaemonSet/$n rendered"
+    else _note "diagnose.sh expects DaemonSet/$n — the chart does not render that name"; fi
+  done
+}
+
+main() {
+  set -uo pipefail
+  echo "── source-of-truth drift checks ─────────────────────────────"
+  _drift_backend_hosts
+  _drift_workload_names
+  echo "─────────────────────────────────────────────────────────────"
+  if [[ "$_drift" -gt 0 ]]; then
+    echo "DRIFT: $_drift divergence(s) above. Update both sides (or the contract in check-drift.sh) and re-run." >&2
+    return 1
+  fi
+  echo "no drift."
+  return 0
+}
+
+# Run only when executed directly (bats sources this file to test the helpers).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then main "$@"; fi

--- a/scripts/tests/e2e-cluster.sh
+++ b/scripts/tests/e2e-cluster.sh
@@ -33,6 +33,8 @@ source "$LIB/common.sh"
 source "$LIB/setup-linux.sh"
 # shellcheck source=/dev/null
 source "$LIB/cluster.sh"
+# shellcheck source=/dev/null
+source "$LIB/preflight.sh"   # provides _pf_recheck_runtime_mem (called by create_cluster)
 
 cleanup() { k3d cluster delete "$CLUSTER_NAME" >/dev/null 2>&1 || true; }
 trap cleanup EXIT

--- a/scripts/tests/install-k8s.Tests.ps1
+++ b/scripts/tests/install-k8s.Tests.ps1
@@ -453,6 +453,45 @@ Describe "Test-Preflight" {
     Mock Test-PfUrl { "ok" }
     { Test-Preflight } | Should -Not -Throw
   }
+  It "memory below floor -> warn-only on Windows (does not throw)" {
+    Mock Test-PfUrl { "ok" }; Mock Get-PfMemGb { 3 }
+    { Test-Preflight } | Should -Not -Throw
+  }
+  It "PF_MIN_MEM_GB override relaxes the floor" {
+    Mock Test-PfUrl { "ok" }; Mock Get-PfMemGb { 3 }; $env:PF_MIN_MEM_GB = "2"
+    { Test-Preflight } | Should -Not -Throw
+    $env:PF_MIN_MEM_GB = $null
+  }
+}
+
+Describe "Get-Pf* runtime (Docker VM) view preference" {
+  It "Get-PfMemGb prefers docker MemTotal over the host" {
+    Mock docker { '8589934592' }          # 8 GiB, in bytes
+    Get-PfMemGb | Should -Be 8
+  }
+  It "Get-PfCpu prefers docker NCPU over the host" {
+    Mock docker { '2' }
+    Get-PfCpu | Should -Be 2
+  }
+  It "Get-PfRuntimeMemGb: junk value -> null (forces host fallback)" {
+    Mock docker { 'lots' }
+    Get-PfRuntimeMemGb | Should -BeNullOrEmpty
+  }
+  It "Get-PfRuntimeMemGb: docker errors -> null" {
+    Mock docker { throw "daemon down" }
+    Get-PfRuntimeMemGb | Should -BeNullOrEmpty
+  }
+}
+
+Describe "Test-PreflightRuntimeMem (post-Docker, warn-only)" {
+  It "small Docker VM -> warns, does not throw" {
+    Mock Get-PfRuntimeMemGb { 4 }
+    { Test-PreflightRuntimeMem } | Should -Not -Throw
+  }
+  It "daemon not reporting (null) -> no-op, does not throw" {
+    Mock Get-PfRuntimeMemGb { $null }
+    { Test-PreflightRuntimeMem } | Should -Not -Throw
+  }
 }
 
 # --- reboot persistence (Set-ClusterAutostart) -------------------------------

--- a/scripts/tests/preflight.bats
+++ b/scripts/tests/preflight.bats
@@ -14,6 +14,9 @@ setup() {
   _pf_free_kb() { echo $((50 * 1024 * 1024)); }       # 50 GB
   _pf_total_mem_kb() { echo $((8 * 1024 * 1024)); }   # 8 GB
   _pf_ncpu() { echo 4; }
+  _pf_runtime_mem_kb() { echo ""; }   # daemon "down" in tests → selectors/src use host
+  _pf_runtime_ncpu() { echo ""; }
+  _pf_avail_mem_kb() { echo $((50 * 1024 * 1024)); }   # 50 GB available (Linux warn off)
   _pf_amd64_emulation_available() { return 0; }
   docker() { return 1; }   # keep _pf_docker_root off the real daemon
   has() { return 0; }      # pretend tools present (conds empty) unless overridden
@@ -118,14 +121,47 @@ setup() {
   PF_HARD_FAIL=0; _pf_disk >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
 }
 
-@test "_pf_memory: low RAM -> warn" {
-  _pf_total_mem_kb() { echo $((2 * 1024 * 1024)); }
-  run _pf_memory; [[ "$output" == *"recommended"* ]]
+@test "_pf_memory: below floor on Linux -> hard fail + resize hint" {
+  OS=Linux; _pf_total_mem_kb() { echo $((3 * 1024 * 1024)); }   # 3 GB
+  run _pf_memory; [[ "$output" == *"to run the tracebloc client"* ]]
+  PF_HARD_FAIL=0; _pf_memory >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 1 ]
+}
+
+@test "_pf_memory: between floor and warn -> warn, no hard fail" {
+  OS=Linux; _pf_total_mem_kb() { echo $((6 * 1024 * 1024)); }   # 6 GB
+  run _pf_memory; [[ "$output" == *"recommended to train"* ]]
+  PF_HARD_FAIL=0; _pf_memory >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
 }
 
 @test "_pf_memory: ample RAM -> success" {
-  _pf_total_mem_kb() { echo $((8 * 1024 * 1024)); }
-  run _pf_memory; [[ "$output" == *"8 GB"* ]]
+  OS=Linux; _pf_total_mem_kb() { echo $((16 * 1024 * 1024)); }
+  run _pf_memory; [[ "$output" == *"16 GB"* ]]
+  PF_HARD_FAIL=0; _pf_memory >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_memory: macOS below floor -> WARN only, never hard fail" {
+  OS=Darwin; _pf_total_mem_kb() { echo $((3 * 1024 * 1024)); }
+  run _pf_memory; [[ "$output" == *"Settings"* ]]
+  PF_HARD_FAIL=0; _pf_memory >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_memory: 64 MiB grace -> a hair under the floor still passes" {
+  OS=Linux; _pf_total_mem_kb() { echo $(( 5 * 1024 * 1024 - 1000 )); }   # ~5 GB minus a bit
+  PF_HARD_FAIL=0; _pf_memory >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_memory: PF_MIN_MEM_GB override relaxes the floor" {
+  OS=Linux; PF_MIN_MEM_GB=2; PF_WARN_MEM_GB=2
+  _pf_total_mem_kb() { echo $((3 * 1024 * 1024)); }   # 3 GB now passes
+  run _pf_memory; [[ "$output" == *"3 GB"* ]]
+  PF_HARD_FAIL=0; _pf_memory >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_memory: Linux MemAvailable tight -> extra warn (total fine)" {
+  OS=Linux; _pf_total_mem_kb() { echo $((16 * 1024 * 1024)); }   # total fine
+  _pf_avail_mem_kb() { echo $((2 * 1024 * 1024)); }              # only 2 GB free now
+  run _pf_memory; [[ "$output" == *"available right now"* ]]
+  PF_HARD_FAIL=0; _pf_memory >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
 }
 
 @test "_pf_cpu: too few cores -> warn" {
@@ -136,6 +172,56 @@ setup() {
 @test "_pf_cpu: enough cores -> success" {
   _pf_ncpu() { echo 4; }
   run _pf_cpu; [[ "$output" == *"4 cores"* ]]
+}
+
+@test "_pf_cpu: between min and recommended -> warn (train), no hard fail" {
+  _pf_ncpu() { echo 3; }
+  run _pf_cpu; [[ "$output" == *"recommended to train"* ]]
+  PF_HARD_FAIL=0; _pf_cpu >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]   # CPU never hard-fails
+}
+
+# ── selectors: container-runtime view preferred, host fallback ───────────────
+@test "_pf_total_mem_kb: prefers runtime view over host (the Mac trap)" {
+  source "${BATS_TEST_DIRNAME}/../lib/preflight.sh"   # restore the real selectors
+  _pf_runtime_mem_kb() { echo $((4 * 1024 * 1024)); }    # Docker VM = 4 GB
+  _pf_host_mem_kb()    { echo $((36 * 1024 * 1024)); }   # host = 36 GB
+  run _pf_total_mem_kb; [ "$output" -eq $((4 * 1024 * 1024)) ]
+}
+
+@test "_pf_total_mem_kb: falls back to host when runtime empty" {
+  source "${BATS_TEST_DIRNAME}/../lib/preflight.sh"
+  _pf_runtime_mem_kb() { echo ""; }
+  _pf_host_mem_kb()    { echo $((8 * 1024 * 1024)); }
+  run _pf_total_mem_kb; [ "$output" -eq $((8 * 1024 * 1024)) ]
+}
+
+@test "_pf_ncpu: prefers runtime, falls back to host" {
+  source "${BATS_TEST_DIRNAME}/../lib/preflight.sh"
+  _pf_runtime_ncpu() { echo 2; }; _pf_host_ncpu() { echo 16; }
+  run _pf_ncpu; [ "$output" -eq 2 ]
+  _pf_runtime_ncpu() { echo ""; }
+  run _pf_ncpu; [ "$output" -eq 16 ]
+}
+
+@test "_pf_runtime_mem_kb: junk/zero MemTotal -> empty (forces fallback)" {
+  source "${BATS_TEST_DIRNAME}/../lib/preflight.sh"
+  has() { return 0; }
+  docker() { case "$*" in *MemTotal*) echo 0 ;; *) return 0 ;; esac; }
+  run _pf_runtime_mem_kb; [ -z "$output" ]
+}
+
+# ── _pf_recheck_runtime_mem (post-Docker, warn-only) ─────────────────────────
+@test "_pf_recheck_runtime_mem: small Docker VM -> warn, never hard fail" {
+  source "${BATS_TEST_DIRNAME}/../lib/preflight.sh"
+  OS=Linux; _pf_runtime_mem_kb() { echo $((4 * 1024 * 1024)); }   # 4 GB Docker VM
+  run _pf_recheck_runtime_mem; [[ "$output" == *"Docker is running with 4 GB"* ]]
+  PF_HARD_FAIL=0; _pf_recheck_runtime_mem >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_recheck_runtime_mem: daemon not reporting -> silent no-op" {
+  source "${BATS_TEST_DIRNAME}/../lib/preflight.sh"
+  _pf_runtime_mem_kb() { echo ""; }
+  run _pf_recheck_runtime_mem; [ -z "$output" ]
 }
 
 # ── run_preflight orchestration ──────────────────────────────────────────────

--- a/scripts/tests/setup-linux.bats
+++ b/scripts/tests/setup-linux.bats
@@ -49,6 +49,14 @@ setup() {
   [[ "$PM_INSTALL" == *"NEEDRESTART_MODE=a"* ]]
   [[ "$PM_INSTALL" == *"sudo env"* ]]
 }
+# apt must WAIT (bounded) for the dpkg lock instead of hanging forever behind
+# apt-daily/unattended-upgrades on a freshly-booted host (#210).
+@test "setup_pm: apt waits for the dpkg lock with a bounded timeout (#210)" {
+  PRESENT_CMDS="apt-get"
+  setup_pm
+  [[ "$PM_INSTALL" == *"DPkg::Lock::Timeout="* ]]
+  [[ "$PM_UPDATE"  == *"DPkg::Lock::Timeout="* ]]
+}
 @test "setup_pm: dnf detected" {
   PRESENT_CMDS="dnf"
   setup_pm

--- a/scripts/tests/setup-linux.bats
+++ b/scripts/tests/setup-linux.bats
@@ -39,6 +39,16 @@ setup() {
   setup_pm
   [[ "$PM_INSTALL" == *"apt-get install"* ]]
 }
+# Ubuntu 22.04+ needrestart opens a hidden "restart services?" prompt under
+# spin_cmd that `-y` doesn't suppress → the install hangs. apt must be fully
+# non-interactive, with the env passed through `sudo env` (sudo resets env).
+@test "setup_pm: apt is non-interactive (needrestart/debconf guard)" {
+  PRESENT_CMDS="apt-get"
+  setup_pm
+  [[ "$PM_INSTALL" == *"DEBIAN_FRONTEND=noninteractive"* ]]
+  [[ "$PM_INSTALL" == *"NEEDRESTART_MODE=a"* ]]
+  [[ "$PM_INSTALL" == *"sudo env"* ]]
+}
 @test "setup_pm: dnf detected" {
   PRESENT_CMDS="dnf"
   setup_pm
@@ -119,6 +129,9 @@ setup() {
   run install_docker_engine
   run mock_calls
   [[ "$output" == *"get.docker.com"* ]]
+  # the convenience script runs apt-get internally → must be non-interactive too
+  [[ "$output" == *"DEBIAN_FRONTEND=noninteractive"* ]]
+  [[ "$output" == *"NEEDRESTART_MODE=a"* ]]
 }
 @test "install_docker_engine: docker already present -> no install" {
   PRESENT_CMDS="docker"; TEST_DISTRO=ubuntu


### PR DESCRIPTION
Promotes the unreleased `develop` commits to `main`. The installer helper scripts are served from `raw.githubusercontent.com/tracebloc/client/main/scripts/` at runtime (`bash <(curl -fsSL https://tracebloc.io/i.sh)`), so **merging this to `main` ships the installer fixes to users immediately** — none of these commits touch the Helm chart templates, so no chart release is required.

### Contains (unreleased since v1.5.0)
- #217 — hard-gate low RAM + measure the container-runtime's memory view (fixes node OOM on small Ubuntu VMs).
- #218 — source-of-truth drift CI guard (CI-only).
- #210 / #211 — bound the apt dpkg-lock wait so a held lock can't hang installs.
- #212 — keep apt non-interactive so needrestart/conntrack can't hang Ubuntu 22.04+ installs.

### Chart release (optional — your call)
The chart stays at **1.5.0**; nothing in `client/` or `ingestor/` templates changed. If you want a versioned marker release (as with v1.4.3 "installer hardening"), bump `client/Chart.yaml` → 1.5.1 and publish a GitHub Release after merge — it's a tracking marker only, since the fix already ships via `main`.

### Gate
Targets `main`, so `fr-gate` runs and blocks merge until all contained kanban items (#217, #218, #210, #211, #212) are in **Ready for prod**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time gates and Linux package install behavior that affect all new deployments; risk is mitigated by extensive bats/Pester updates and CI-only chart contract tests rather than runtime chart changes.
> 
> **Overview**
> **Installer hardening** so small VMs and flaky Ubuntu apt behavior fail fast instead of hanging or OOMing later. Preflight now uses **Docker/Colima VM memory and CPU** when the daemon is up (with host fallback), raises floors (**5 GB RAM** hard-fail on Linux, **10 GB disk**), adds train-oriented warnings, and **re-checks Docker VM RAM** at cluster create (`_pf_recheck_runtime_mem` / `Test-PreflightRuntimeMem`). **Linux apt** paths force non-interactive installs (`DEBIAN_FRONTEND`, `NEEDRESTART_MODE`), bound dpkg lock waits (`DPkg::Lock::Timeout`, `apt_wait_for_lock`), including get.docker.com and WSL NVIDIA toolkit install. **macOS Colima** default sizing bumps to 4 CPU / 6 GB RAM.
> 
> Adds **`scripts/tests/check-drift.sh`** plus a **Drift checks** GitHub workflow (and shellcheck/bats coverage) to keep **backend API hosts** and **chart workload names** aligned with `summary.sh` / `diagnose.sh`. **Helm unittest** files lock down ingestion authz ConfigMap behavior and the stable `jobs-manager` Service contract (tests only; no template edits in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d381f7464fef0c90475dd4f4f174956ddbd84b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->