### PR TITLE
test(charts): add helm-unittest suite for requests-proxy-service template

### DIFF
--- a/client/tests/requests_proxy_service_test.yaml
+++ b/client/tests/requests_proxy_service_test.yaml
@@ -1,0 +1,76 @@
+suite: requests-proxy Service
+templates:
+  - templates/requests-proxy-service.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: should render a single Service document
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+
+  - it: should name the Service requests-proxy-service (stable in-cluster name contract)
+    asserts:
+      - equal:
+          path: metadata.name
+          value: requests-proxy-service
+
+  - it: should be ClusterIP only (no external exposure of the egress proxy)
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should not be a NodePort or LoadBalancer
+    asserts:
+      - notEqual:
+          path: spec.type
+          value: NodePort
+      - notEqual:
+          path: spec.type
+          value: LoadBalancer
+
+  - it: should select the requests-proxy pods via app=requests-proxy
+    asserts:
+      - equal:
+          path: spec.selector.app
+          value: requests-proxy
+
+  - it: should expose the proxy HTTP port 8888 over TCP
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].port
+          value: 8888
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8888
+      - equal:
+          path: spec.ports[0].protocol
+          value: TCP
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+
+  - it: should carry the app=requests-proxy label and standard chart labels
+    asserts:
+      - equal:
+          path: metadata.labels.app
+          value: requests-proxy
+      - isNotNullOrEmpty:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+      - isNotNullOrEmpty:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: should live in the release namespace
+    release:
+      namespace: my-custom-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-custom-ns


### PR DESCRIPTION
## What

Adds a `helm-unittest` suite for the previously-untested `templates/requests-proxy-service.yaml` Service template.

The `requests-proxy-service` fronts the egress requests-proxy (the component issuing stateless signed pod-proxy tokens), so its **ClusterIP-only** posture is a security-relevant property. This suite locks that in alongside the Service's name/selector/port contract.

## Coverage delta

- +1 template suite (`requests-proxy-service`); 8 tests / 16 assertions
- Chart suites: 17 → 18
- `requests-proxy-service` was the highest-priority remaining untested template (Service tier, security-relevant) — `requests-proxy-deployment` was already covered in client#194.

## Assertions

- single Service document, `kind: Service`
- stable name `requests-proxy-service`
- `spec.type: ClusterIP` and explicitly **not** NodePort / LoadBalancer (no external exposure of the egress proxy)
- selector `app=requests-proxy`
- single `http` port `8888/8888 TCP`
- `app=requests-proxy` + standard chart labels (`managed-by`, `helm.sh/chart`)
- renders into the release namespace

Verified green locally: `helm unittest -f 'tests/requests_proxy_service_test.yaml' ./client` → 8 passed.

Tests-only; no source/template/values changes; security invariants unchanged.

Tracking epic: tracebloc/client#193

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or chart template modifications.
> 
> **Overview**
> Adds a **helm-unittest** suite for `templates/requests-proxy-service.yaml`, which had no chart tests before.
> 
> The eight tests pin the egress **requests-proxy** Service contract: one `Service` named `requests-proxy-service`, **ClusterIP** only (explicitly not NodePort/LoadBalancer), selector `app=requests-proxy`, a single TCP `http` port on **8888**, standard chart labels, and release-namespace placement.
> 
> Tests-only; no Helm template or values changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d433cb2a542c46a61a102123dcd191b8ad126bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->