### PR TITLE
fix(#222): wire SINGLE_NODE — chart default from hostPath.enabled + installer

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.5.0
-appVersion: "1.5.0"
+version: 1.5.1
+appVersion: "1.5.1"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/MIGRATION.md
+++ b/client/MIGRATION.md
@@ -2,6 +2,44 @@
 
 This guide explains how to migrate from the legacy per-platform charts (`aks/`, `bm/`, `eks/`, `oc/`) to the unified `client/` chart.
 
+## Upgrading to 1.5.1 — single-node gating of the GPU→CPU pending fallback
+
+[client-runtime#92](https://github.com/tracebloc/client-runtime/issues/92) /
+[#222](https://github.com/tracebloc/client/issues/222): jobs-manager's
+GPU→CPU fallback (a GPU pod stuck `Pending` past the scheduling-overdue
+interval is stopped and respun as a CPU job) is now gated on a new
+`env.SINGLE_NODE` flag.
+
+**Why:** on a multi-node / elastic cluster (EKS cluster-autoscaler / Karpenter,
+AKS) a `Pending` GPU pod usually just means a GPU node is still autoscaling in
+(3–10 min). Downgrading to CPU after ~180s is premature — it silently moves a
+GPU experiment onto CPU and drives the stop→respin token churn behind the
+[client-runtime#80](https://github.com/tracebloc/client-runtime/issues/80) 401
+race. On a fixed single-node cluster (installer-provisioned k3d) GPU presence is
+known at install time and no node will autoscale in, so the fallback is correct.
+
+**What you need to do: nothing for most clusters.** `SINGLE_NODE` defaults to
+`hostPath.enabled`, so the behavior tracks your existing topology across the
+hands-off auto-upgrade:
+
+| Deployment | `hostPath.enabled` | `SINGLE_NODE` default | Behavior |
+|---|---|---|---|
+| Installer k3d / bare-metal single-host | `true` | `"true"` | GPU→CPU fallback **on** (unchanged) |
+| EKS / AKS / OpenShift (dynamic PVC) | `false` | `"false"` | Pending GPU pods left for the autoscaler |
+
+- **EKS/AKS/OpenShift** automatically stop the premature downgrade on the next
+  auto-upgrade — no value change needed.
+- **The installer** now writes `env.SINGLE_NODE: "true"` explicitly for new k3d
+  installs, so they don't depend on the heuristic.
+- **A fixed multi-node bare-metal cluster** (e.g. an NFS-backed cluster with
+  `hostPath.enabled: false`) that *wants* the hard CPU/GPU fallback must set it
+  explicitly: `env.SINGLE_NODE: "true"`. Must be a quoted string.
+
+`SINGLE_NODE` requires the matching jobs-manager image (it ships in the same
+release train). During the brief window where image-refresh rolls the new image
+before this chart upgrade injects the var, an absent `SINGLE_NODE` is treated as
+single-node (fallback on), so a single-node cluster is never regressed mid-rollout.
+
 ## Upgrading to 1.3.4 — parent chart owns the shared ingestor ServiceAccount
 
 [#129](https://github.com/tracebloc/client/issues/129): the ingestor

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -118,8 +118,20 @@ spec:
           value: {{ if hasKey .Values.env "GPU_LIMITS" }}{{ .Values.env.GPU_LIMITS | quote }}{{ else }}"nvidia.com/gpu=1"{{ end }}
         - name: RUNTIME_CLASS_NAME
           value: {{ if hasKey .Values.env "RUNTIME_CLASS_NAME" }}{{ .Values.env.RUNTIME_CLASS_NAME | quote }}{{ else }}""{{ end }}
+        # client-runtime#92: gates jobs-manager's GPU->CPU pending-job fallback.
+        # Default tracks hostPath.enabled — a fixed single-host cluster
+        # (installer-provisioned k3d / bare-metal hostPath) applies the hard
+        # CPU-or-GPU rule (downgrade a Pending GPU pod to CPU); managed
+        # dynamic-PVC clusters (EKS/AKS/OpenShift, hostPath.enabled=false) leave
+        # a Pending GPU pod for the autoscaler instead of prematurely
+        # downgrading. An explicit env.SINGLE_NODE always wins. Emitted as a
+        # quoted string (schema: env.additionalProperties is string); the
+        # runtime parses true/false. hostPath is nil-guarded so a pre-this-key
+        # --reset-then-reuse-values upgrade can't crash templating.
+        - name: SINGLE_NODE
+          value: {{ if hasKey .Values.env "SINGLE_NODE" }}{{ .Values.env.SINGLE_NODE | quote }}{{ else }}{{ (default dict .Values.hostPath).enabled | default false | quote }}{{ end }}
         {{- range $key, $value := .Values.env }}
-        {{- if and (ne $key "CLIENT_ENV") (ne $key "RESOURCE_REQUESTS") (ne $key "RESOURCE_LIMITS") (ne $key "GPU_REQUESTS") (ne $key "GPU_LIMITS") (ne $key "RUNTIME_CLASS_NAME") (ne $key "CLIENT_ID") $value }}
+        {{- if and (ne $key "CLIENT_ENV") (ne $key "RESOURCE_REQUESTS") (ne $key "RESOURCE_LIMITS") (ne $key "GPU_REQUESTS") (ne $key "GPU_LIMITS") (ne $key "RUNTIME_CLASS_NAME") (ne $key "SINGLE_NODE") (ne $key "CLIENT_ID") $value }}
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}
@@ -168,8 +180,14 @@ spec:
           value: {{ if hasKey .Values.env "GPU_LIMITS" }}{{ .Values.env.GPU_LIMITS | quote }}{{ else }}"nvidia.com/gpu=1"{{ end }}
         - name: RUNTIME_CLASS_NAME
           value: {{ if hasKey .Values.env "RUNTIME_CLASS_NAME" }}{{ .Values.env.RUNTIME_CLASS_NAME | quote }}{{ else }}""{{ end }}
+        # Kept in sync with the api container (client-runtime#92). pods-monitor
+        # does not consume SINGLE_NODE, but injecting it here keeps both env
+        # blocks + their range-exclusion lists symmetric, matching how
+        # GPU_REQUESTS et al. are already handled.
+        - name: SINGLE_NODE
+          value: {{ if hasKey .Values.env "SINGLE_NODE" }}{{ .Values.env.SINGLE_NODE | quote }}{{ else }}{{ (default dict .Values.hostPath).enabled | default false | quote }}{{ end }}
         {{- range $key, $value := .Values.env }}
-        {{- if and (ne $key "CLIENT_ENV") (ne $key "RESOURCE_REQUESTS") (ne $key "RESOURCE_LIMITS") (ne $key "GPU_REQUESTS") (ne $key "GPU_LIMITS") (ne $key "RUNTIME_CLASS_NAME") (ne $key "CLIENT_ID") $value }}
+        {{- if and (ne $key "CLIENT_ENV") (ne $key "RESOURCE_REQUESTS") (ne $key "RESOURCE_LIMITS") (ne $key "GPU_REQUESTS") (ne $key "GPU_LIMITS") (ne $key "RUNTIME_CLASS_NAME") (ne $key "SINGLE_NODE") (ne $key "CLIENT_ID") $value }}
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -91,3 +91,42 @@ tests:
             name: JOB_IMAGE_HOST
             value: "docker.io/"
 
+  # client-runtime#92: SINGLE_NODE gates jobs-manager's GPU->CPU pending
+  # fallback; it defaults to hostPath.enabled so managed (dynamic-PVC)
+  # clusters never auto-downgrade while installer/bare-metal single-host
+  # clusters keep the hard rule.
+  - it: should default SINGLE_NODE to "false" on managed (hostPath disabled) clusters
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SINGLE_NODE
+            value: "false"
+
+  - it: should set SINGLE_NODE to "true" when hostPath is enabled
+    set:
+      hostPath:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SINGLE_NODE
+            value: "true"
+
+  - it: should let an explicit env.SINGLE_NODE override the hostPath-derived default
+    set:
+      hostPath:
+        enabled: true
+      env:
+        SINGLE_NODE: "false"
+    asserts:
+      # explicit "false" wins over hostPath.enabled=true, and is emitted
+      # exactly once (not duplicated by the generic env range).
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SINGLE_NODE
+            value: "false"
+          count: 1
+

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -39,7 +39,11 @@
           "default": "nvidia.com/gpu=1",
           "description": "Optional GPU limits for spawned jobs (defaults to 'nvidia.com/gpu=1' if not set)"
         },
-        "RUNTIME_CLASS_NAME": { "type": "string" }
+        "RUNTIME_CLASS_NAME": { "type": "string" },
+        "SINGLE_NODE": {
+          "type": "string",
+          "description": "Single-node (fixed, non-elastic) cluster flag. Gates jobs-manager's GPU->CPU pending-job fallback (client-runtime#92). 'true' -> downgrade a stuck Pending GPU pod to CPU (correct on fixed single-host clusters where GPU presence is known at install time); 'false' -> leave it for the autoscaler/backend (correct for EKS/AKS/OpenShift). If unset, defaults to hostPath.enabled."
+        }
       },
       "additionalProperties": {
         "type": "string"

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -23,6 +23,21 @@ env: {
   # GPU_LIMITS: "nvidia.com/gpu=1"
   # Optional: runtime class for GPU jobs (defaults to "" if not provided)
   # RUNTIME_CLASS_NAME: ""
+  # Optional: single-node (fixed, non-elastic) cluster flag — gates
+  # jobs-manager's GPU->CPU pending-job fallback (client-runtime#92).
+  #   "true"  -> a GPU pod stuck Pending past the scheduling-overdue interval
+  #              is downgraded to a CPU job. Correct on a fixed single-host
+  #              cluster (installer k3d / bare-metal) where GPU presence is
+  #              known at install time and no node will autoscale in.
+  #   "false" -> a Pending GPU pod is left for the autoscaler/backend. Correct
+  #              for EKS/AKS/OpenShift, where a GPU node may still be
+  #              provisioning and a premature downgrade breaks the run.
+  # If unset, DEFAULTS to hostPath.enabled (true on installer-provisioned
+  # single-host clusters, false on managed dynamic-PVC clusters), so existing
+  # clusters keep correct behaviour across auto-upgrade without re-running the
+  # installer. Set explicitly to override (e.g. a fixed multi-node bare-metal
+  # cluster that wants the fallback). Must be a quoted string.
+  # SINGLE_NODE: "true"
 }
 # -- StorageClass configuration
 # When create: true, the StorageClass name is release-unique (e.g. "<release-name>-storage-class")

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -313,6 +313,11 @@ $([ -n "${CLIENT_ENV:-}" ] && printf '  CLIENT_ENV: "%s"\n' "$CLIENT_ENV")
   GPU_LIMITS: "$gpu_val"
   GPU_REQUESTS: "$gpu_val"
   RUNTIME_CLASS_NAME: ""
+  # client-runtime#92: installer-provisioned k3d is a fixed single-host cluster
+  # that cannot autoscale, so jobs-manager applies the hard CPU-or-GPU rule —
+  # a Pending GPU pod is downgraded to CPU rather than waiting for a GPU node
+  # that will never arrive.
+  SINGLE_NODE: "true"
 
 storageClass:
   create: true

--- a/scripts/tests/install-client-helm.bats
+++ b/scripts/tests/install-client-helm.bats
@@ -132,6 +132,9 @@ setup() {
   [[ "$output" == *"Connected to tracebloc"* ]]
   grep -q 'clientId: "myid"' "$HOST_DATA_DIR/values.yaml"
   grep -q "clientPassword: 'mypw'" "$HOST_DATA_DIR/values.yaml"
+  # client-runtime#92: installer-provisioned k3d is a fixed single-host cluster,
+  # so it declares SINGLE_NODE=true -> jobs-manager applies the hard CPU/GPU rule.
+  grep -q 'SINGLE_NODE: "true"' "$HOST_DATA_DIR/values.yaml"
   mock_calls | grep -q "helm upgrade --install tracebloc"
 }
 


### PR DESCRIPTION
Companion to **tracebloc/client-runtime#92** ([PR #93](https://github.com/tracebloc/client-runtime/pull/93)), which gates jobs-manager's GPU→CPU pending-job fallback behind a `SINGLE_NODE` env var. This PR wires the flag through the chart + installer.

## Why
On multi-node/elastic clusters (EKS/AKS) a `Pending` GPU pod usually means a GPU node is still autoscaling in; the runtime's premature GPU→CPU downgrade silently moves the experiment to CPU and drives the client-runtime#80 token race. On single-node k3d the fallback is correct. `SINGLE_NODE` lets the runtime tell them apart.

## Auto-update safe
The client self-upgrades via the `auto-upgrade` CronJob (`helm upgrade --reset-then-reuse-values`). Existing clusters never re-run the installer, so their stored values have no `SINGLE_NODE`. The chart default is therefore derived from a signal already in stored values — `hostPath.enabled`:

| Deployment | `hostPath.enabled` | `SINGLE_NODE` default | Behavior |
|---|---|---|---|
| Installer k3d / bare-metal single-host | `true` | `"true"` | GPU→CPU fallback on (unchanged) |
| EKS / AKS / OpenShift (dynamic PVC) | `false` | `"false"` | Pending GPU pods left for the autoscaler |

So existing EKS/AKS clusters **auto-stop the premature downgrade** on next upgrade with no value change, and existing single-node installs keep today's behavior. An explicit `env.SINGLE_NODE` always wins (e.g. a fixed multi-node bare-metal/NFS cluster that wants the fallback sets `"true"`).

## Changes
- **jobs-manager-deployment.yaml**: inject `SINGLE_NODE` into both containers = `env.SINGLE_NODE` if set, else `hostPath.enabled` (quoted; `hostPath` nil-guarded for `--reset-then-reuse-values`); added to the generic-range exclusion so it's never double-emitted.
- **install-client-helm.sh**: installer writes `env.SINGLE_NODE: "true"` for new k3d installs.
- **values.yaml** + **values.schema.json**: document the flag (quoted string; `env.additionalProperties` already allows it — schema correctly rejects a bare boolean).
- **MIGRATION.md**: 1.5.1 upgrade note.
- **Chart.yaml**: `1.5.0 → 1.5.1` so auto-upgrade actually ships the template change.

## Tests
+3 helm-unittest (default `"false"`; `"true"` when `hostPath.enabled`; explicit override wins and is emitted exactly once) and +1 installer bats assertion. **178 chart tests green**, `helm lint` clean. Rendered all scenarios manually (EKS→`false`, bare-metal→`true`, `--set-string` override).

Closes #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GPU job scheduling behavior on upgrade for EKS/AKS (intended fix) and depends on a matching jobs-manager image; mis-set SINGLE_NODE could leave GPU jobs pending or trigger unwanted CPU downgrades.
> 
> **Overview**
> **Chart 1.5.1** wires **`env.SINGLE_NODE`** into jobs-manager so runtime can gate the GPU→CPU **pending-pod fallback** (client-runtime#92): on elastic clusters, long-pending GPU jobs stay on GPU instead of being downgraded after ~180s.
> 
> The jobs-manager Deployment now sets **`SINGLE_NODE`** on both containers: explicit `env.SINGLE_NODE` wins; otherwise it defaults to **`hostPath.enabled`** (quoted, nil-safe for `--reset-then-reuse-values`). The generic `env` range excludes `SINGLE_NODE` so it is not duplicated. The **installer** writes `SINGLE_NODE: "true"` for new k3d installs; **values**, **schema**, and **MIGRATION.md** document the flag and auto-upgrade behavior.
> 
> **Tests:** three helm-unittest cases for default/override behavior and one installer bats check for generated values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeaf8109352d1386d1a2ed4d7e8ab58c0878b805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->