### PR TITLE
fix(mysql): probe over TCP so a moved socket can't kill a healthy DB

### DIFF
--- a/client/templates/mysql-deployment.yaml
+++ b/client/templates/mysql-deployment.yaml
@@ -104,23 +104,30 @@ spec:
         # routinely needs >1s to even spawn, which kubelet reports as a probe
         # failure and kills the container. 5s is generous enough to survive
         # transient CPU pressure but still catch a real hang within ~25s.
+        #
+        # Probe over TCP (-h 127.0.0.1), NOT the unix socket (-h localhost):
+        # the mysql-client image writes its socket to /var/lib/mysql/mysql.sock,
+        # not the client default /var/run/mysqld/mysqld.sock, so a socket-based
+        # `mysqladmin ping` can't reach a perfectly healthy mysqld — the startup
+        # probe then exhausts and the kubelet kill-loops the DB. TCP is immune to
+        # where the image places the socket. Do not change back to `localhost`.
         startupProbe:
           exec:
-            command: ["mysqladmin", "ping", "-h", "localhost"]
+            command: ["mysqladmin", "ping", "-h", "127.0.0.1"]
           initialDelaySeconds: 10
           periodSeconds: 5
           timeoutSeconds: 5
           failureThreshold: 24
         livenessProbe:
           exec:
-            command: ["mysqladmin", "ping", "-h", "localhost"]
+            command: ["mysqladmin", "ping", "-h", "127.0.0.1"]
           initialDelaySeconds: 0
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 5
         readinessProbe:
           exec:
-            command: ["mysqladmin", "ping", "-h", "localhost"]
+            command: ["mysqladmin", "ping", "-h", "127.0.0.1"]
           initialDelaySeconds: 0
           periodSeconds: 5
           timeoutSeconds: 3

--- a/client/tests/mysql_test.yaml
+++ b/client/tests/mysql_test.yaml
@@ -140,3 +140,41 @@ tests:
       - equal:
           path: spec.selector.app
           value: mysql-client
+
+  # --- Regression guards (backend#767): the kill-loop was a healthy mysqld
+  # killed by a probe pointed at the wrong socket. Lock the probe to TCP so a
+  # future edit (or an image socket-path change) can't reintroduce it. ---
+  - it: all three probes must use TCP (127.0.0.1), never the unix socket (-h localhost)
+    template: templates/mysql-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].startupProbe.exec.command
+          content: "127.0.0.1"
+      - contains:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          content: "127.0.0.1"
+      - contains:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          content: "127.0.0.1"
+      - notContains:
+          path: spec.template.spec.containers[0].startupProbe.exec.command
+          content: "localhost"
+      - notContains:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          content: "localhost"
+      - notContains:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          content: "localhost"
+  - it: mysqld keeps its writable scratch mounts under readOnlyRootFilesystem (socket/pid dir + tmp)
+    template: templates/mysql-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: mysql-run
+            mountPath: /var/run/mysqld
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: mysql-tmp
+            mountPath: /tmp


### PR DESCRIPTION
## Summary

All three MySQL probes (`startupProbe`, `livenessProbe`, `readinessProbe`) ran `mysqladmin ping -h localhost`, which connects over the **client-default unix socket** `/var/run/mysqld/mysqld.sock`. The `mysql-client` image actually writes its socket to **`/var/lib/mysql/mysql.sock`**, so the probe can never reach a perfectly healthy mysqld — the `startupProbe` exhausts (~130s) and the kubelet kill-loops the database, cascading `jobs-manager` and `requests-proxy` into CrashLoopBackOff.

This switches all three probes to **TCP** (`mysqladmin ping -h 127.0.0.1`, port 3306), which is immune to wherever the image places its socket, and adds a comment so it isn't reverted.

## Why it slipped

Mutable image tag `:prod` + `imagePullPolicy: IfNotPresent`: cached clusters keep an older working image, but **every fresh install pulling the current `:prod` is broken**. Reproduced on a clean cluster (RAM and proxy/`NO_PROXY` both ruled out). Full root-cause writeup: tracebloc/backend#767.

## Type

- [x] Bug fix (regression)

## Test plan

- `helm template` renders cleanly (1998 lines, valid YAML) with `ci/bm-values.yaml`; all three rendered probes show `-h 127.0.0.1`.
- `mysqladmin ping` returns "mysqld is alive" (exit 0) over TCP without credentials — same auth behavior as the previous `-h localhost`, just TCP transport.
- Verified live on an affected cluster via the equivalent runtime patch: `mysql-client` went `1/1` with 0 restarts and the cascade recovered.

## Checklist

- [x] Targets `develop`
- [x] No customer identifiers
- [ ] Reviewer to confirm CI (`helm-ci`, `installer-tests`) green

## Follow-ups (tracked in backend#767, not in this PR)

- Pin `mysql-client` by digest (`images.mysqlClient.digest`) — a mutable `:prod` tag is how this shipped silently.
- A secrets-gated full-stack E2E (waits for `mysql-client`/`jobs-manager` Ready) under the install-journey epic #736 would have caught it.
