### PR TITLE
fix(ingestor): bump baseline image digest v0.3.2 → v0.3.6 (fixes a customer helm-upgrade regression)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: "1.5.0"
 keywords:
   - tracebloc

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -213,13 +213,19 @@ images:
   # Customers can also override per-install via the ingestor subchart's
   # `image.digest` for one-off testing, independent of this value.
   ingestor:
-    # Current baseline digest: v0.3.2 (2026-06-03, from #184). Patch on
-    # top of v0.3.1 carrying customer-impacting fixes —
-    # tracebloc/data-ingestors#139 (MLM tokenizer fix, relaxed PascalVOC
-    # `difficult` flag, reserved-id guard; closes #137 / #135) — plus the
-    # first multi-arch image (amd64 + arm64, #24) so arm64 nodes can run
-    # the ingestor. Bump only when greenfield installs should start on a
-    # different version; ongoing rollouts are managed by image-refresh.
+    # Current baseline digest: v0.3.6 (2026-06-08). Carries the
+    # customer-impacting ingest fixes — NULL / empty-column tolerance in
+    # the numeric + string + date validators (data-ingestors #150 / #167 /
+    # #168), full-file per-chunk type conversion (#166), and the MLM
+    # tokenizer fix (#139) — on a multi-arch image (amd64 + arm64, #24).
+    # BUMP THIS ON EVERY INGESTOR RELEASE: jobs-manager pins this digest,
+    # and a `helm upgrade` resets the live env to it (overwriting whatever
+    # image-refresh applied), so a stale baseline silently reverts
+    # customers to an old ingestor. The v0.3.2 baseline here caused the LMU
+    # "empty columns rejected as non-numeric" regression — it predated #150,
+    # so a customer `helm upgrade` reverted them to a validator without the
+    # NaN-tolerance. Ongoing rollouts are otherwise managed by image-refresh
+    # against the `tag` below.
     #
     # This digest MUST be a multi-arch index (linux/amd64 + linux/arm64).
     # jobs-manager spawns the ingestor Job by this pinned digest, so an
@@ -227,7 +233,7 @@ images:
     # Graviton) with "no match for platform" / ImagePullBackOff (#186; the
     # amd64-only v0.3.1 pin in #160 was the regression). Enforced by the
     # `ingestor-multiarch` job in .github/workflows/helm-ci.yaml.
-    digest: "sha256:d361fa778554ab171adcc2671eaf109c32f3d2af339c7920a2d38d102ce53678"
+    digest: "sha256:dfdaa7e633a8df0f46b403e9422eba5c16bdb7d9c39047e6d3738f9e38fbdba8"
     # Floating tag polled by image-refresh. The team's ghcr.io
     # publishing convention uses semver-style float tags — `0` tracks
     # the latest 0.x, `0.3` tracks the latest 0.3.x patch. Default is


### PR DESCRIPTION
## Summary

Bump the chart's **baseline ingestor digest from v0.3.2 → v0.3.6** (multi-arch index `sha256:dfdaa7e6…`). The baseline had gone stale and was silently reverting customers to an old ingestor on `helm upgrade`.

## Why (the a customer regression)

`jobs-manager-deployment.yaml` sets `INGESTOR_IMAGE_DIGEST` from `.Values.images.ingestor.digest`. That baseline was pinned to **v0.3.2 (2026-06-03)** — which **predates the empty-column / NaN ingest fixes** (data-ingestors #150 float-NaN, #167 string-NaN, #168 date-NaN, #166 per-chunk conversion).

The image-refresh CronJob had imperatively patched the live env (`kubectl set env`) to the current `0.3` image, so ingestion worked. But a customer **`helm upgrade` re-renders the deployment and resets the env back to the stale baseline digest**, overwriting the refresh → the ingestor reverts to v0.3.2.

Result at a customer: empty biomarker columns were rejected again — now as **"non-numeric"** (the CLI fix correctly types empty columns FLOAT, but v0.3.2's float validator lacks the #150 NaN-tolerance).

## What

- `images.ingestor.digest` → `sha256:dfdaa7e633a8df0f46b403e9422eba5c16bdb7d9c39047e6d3738f9e38fbdba8` (v0.3.6, current stable, all validator fixes).
- Multi-arch confirmed: the digest is the `exporting manifest list` index from the v0.3.6 release-image CI run, and `ghcr.io/tracebloc/ingestor:0.3` resolves to it — so it passes the `ingestor-multiarch` CI gate.
- Updated the baseline comment to record the "bump every release / helm-upgrade resets to this" gotcha. Chart `1.5.0 → 1.5.1`.

## Follow-up (separate issue, filed)

The deeper bug: `helm upgrade` (declarative) clobbers the image-refresh (imperative `kubectl set env`) — they fight and upgrade wins, so the digest silently regresses between releases. Needs a design fix (refresh writes release values, or the template doesn't reset a refresh-managed digest). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
