### PR TITLE
chore(#227): bump greenfield ingestor baseline to v0.3.6

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.5.0
-appVersion: "1.5.0"
+version: 1.5.1
+appVersion: "1.5.1"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -213,12 +213,15 @@ images:
   # Customers can also override per-install via the ingestor subchart's
   # `image.digest` for one-off testing, independent of this value.
   ingestor:
-    # Current baseline digest: v0.3.2 (2026-06-03, from #184). Patch on
-    # top of v0.3.1 carrying customer-impacting fixes —
-    # tracebloc/data-ingestors#139 (MLM tokenizer fix, relaxed PascalVOC
-    # `difficult` flag, reserved-id guard; closes #137 / #135) — plus the
-    # first multi-arch image (amd64 + arm64, #24) so arm64 nodes can run
-    # the ingestor. Bump only when greenfield installs should start on a
+    # Current baseline digest: v0.3.6 (2026-06-08, from #227). Skips
+    # 0.3.3–0.3.5 to land on the latest 0.3.x patch, carrying the
+    # cumulative NULL / empty-value ingestion fixes on top of v0.3.2 —
+    # tracebloc/data-ingestors#150 (stop counting missing values as
+    # "non-numeric" in DataValidator — the regression a customer hit on
+    # the stale 0.3.2 baseline), #167 / #168 / #170 / #172 (VARCHAR/CHAR/
+    # TEXT, DATE/TIME, JSON null + empty-string tolerance) and #176 / #179
+    # (null-like values round-trip end-to-end as SQL NULL; Python bool not
+    # stringified). Bump only when greenfield installs should start on a
     # different version; ongoing rollouts are managed by image-refresh.
     #
     # This digest MUST be a multi-arch index (linux/amd64 + linux/arm64).
@@ -227,7 +230,7 @@ images:
     # Graviton) with "no match for platform" / ImagePullBackOff (#186; the
     # amd64-only v0.3.1 pin in #160 was the regression). Enforced by the
     # `ingestor-multiarch` job in .github/workflows/helm-ci.yaml.
-    digest: "sha256:d361fa778554ab171adcc2671eaf109c32f3d2af339c7920a2d38d102ce53678"
+    digest: "sha256:dfdaa7e633a8df0f46b403e9422eba5c16bdb7d9c39047e6d3738f9e38fbdba8"
     # Floating tag polled by image-refresh. The team's ghcr.io
     # publishing convention uses semver-style float tags — `0` tracks
     # the latest 0.x, `0.3` tracks the latest 0.3.x patch. Default is


### PR DESCRIPTION
## Why

A customer (a customer / the customer contact) reported the data ingestor still hitting the **"empty cells flagged as non-numeric"** error — that's [`tracebloc/data-ingestors#150`](https://github.com/tracebloc/data-ingestors/issues/150), fixed in **v0.3.3**. Root cause: the chart's greenfield ingestor baseline is frozen at **v0.3.2**.

- `images.ingestor.digest: sha256:d361fa77…` is exactly `ghcr.io/tracebloc/ingestor:0.3.2` (verified on ghcr).
- Pinned 2026-06-03 (#184), never bumped across 0.3.3 / 0.3.4 / 0.3.5 / 0.3.6 (RELEASING.md step 7 made optional in data-ingestors#144).
- The floating `0.3` tag auto-refreshes *running* deployments, but the baseline still wins on **fresh installs** (run 0.3.2 for ~15–30 min before converging) and on **`helm upgrade`** (re-asserts the baseline) — exactly the customer's situation (new namespace + upgrades).

## What

| File | Change |
|---|---|
| `client/values.yaml` | `images.ingestor.digest` → `sha256:dfdaa7e6…` (`ingestor:0.3.6`, multi-arch amd64+arm64); comment updated with the cumulative 0.3.3→0.3.6 fixes |
| `client/Chart.yaml` | `version` + `appVersion` 1.5.0 → 1.5.1 |

Fresh installs and `helm upgrade` now land on the fixed v0.3.6 image. The new digest is a multi-arch index, so the `ingestor-multiarch` CI guard stays green. Precedent: #161 (v0.3.0→v0.3.1), #185 (v0.3.1→v0.3.2).

Closes #227.

## Not in this PR

- **#190** (image-refresh silently skipping when the ghcr digest can't resolve) — if the customer's on-prem cluster can't reach ghcr.io, auto-refresh never rolls forward and he'd be permanently stuck on the baseline. Needs his cluster diagnostics; tracked separately.
- **Immediate customer unblock** (independent of this chart release): `helm upgrade <release> tracebloc/client -n <ns> --reuse-values --set images.ingestor.digest=sha256:dfdaa7e633a8df0f46b403e9422eba5c16bdb7d9c39047e6d3738f9e38fbdba8`.

## Note for reviewers

Release-gated chart change — needs a second approver (no self-approve), and the chart must be **promoted/published** (develop→main) before customers can `helm upgrade` onto 1.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only digest and version pinning in the Helm chart; no runtime logic changes in this repo, with the new digest remaining a multi-arch index per existing CI expectations.
> 
> **Overview**
> Bumps the **client Helm chart** to **1.5.1** and moves the greenfield **`images.ingestor.digest`** baseline from **ingestor v0.3.2** to **v0.3.6** (`sha256:dfdaa7e6…`), so fresh installs and `helm upgrade` start jobs-manager with the fixed ingestor image instead of staying on the stale pin.
> 
> The **`values.yaml`** comment is updated to document why the jump skips 0.3.3–0.3.5 (cumulative NULL/empty-cell ingestion fixes, including data-ingestors#150). The floating **`images.ingestor.tag: "0.3"`** is unchanged; only the explicit baseline digest and chart version move forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c5284c2813918469bdbd9697a9381754252980a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->