### PR TITLE
fix(proxy): make all egress workloads proxy-aware (wire the dead HTTP_PROXY_* values)

### DIFF
--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -207,3 +207,41 @@ Usage: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" 
 {{ $registry }}/{{ .repository }}:{{ .tag | default "prod" }}
 {{- end -}}
 {{- end }}
+
+{{/*
+tracebloc.proxyEnv — corporate-proxy env for egress-needing workloads.
+Derives HTTP(S)_PROXY + an auto-augmented NO_PROXY from .Values.env.HTTP_PROXY_*
+so workload pods can reach the backend / registries through a corporate proxy.
+Renders nothing when HTTP_PROXY_HOST is unset (non-proxy installs unchanged).
+NO_PROXY always carries the cluster-internal ranges so in-cluster + MySQL
+traffic never traverses the proxy (mirrors scripts/lib/cluster.sh defaults).
+Usage inside a container's env: list:
+  {{- include "tracebloc.proxyEnv" . | nindent 8 }}
+*/}}
+{{- define "tracebloc.proxyEnv" -}}
+{{- if .Values.env.HTTP_PROXY_HOST }}
+{{- $host := .Values.env.HTTP_PROXY_HOST -}}
+{{- $port := .Values.env.HTTP_PROXY_PORT | default "" -}}
+{{- $user := .Values.env.HTTP_PROXY_USERNAME | default "" -}}
+{{- $pass := .Values.env.HTTP_PROXY_PASSWORD | default "" -}}
+{{- $hostport := $host -}}
+{{- if $port }}{{- $hostport = printf "%s:%v" $host $port -}}{{- end -}}
+{{- $cred := "" -}}
+{{- if $user }}{{- $cred = printf "%s:%s@" $user $pass -}}{{- end -}}
+{{- $url := printf "http://%s%s" $cred $hostport -}}
+{{- $noProxy := "localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.svc.cluster.local,.cluster.local,host.k3d.internal" -}}
+{{- with .Values.env.NO_PROXY }}{{- $noProxy = printf "%s,%s" . $noProxy -}}{{- end }}
+- name: HTTP_PROXY
+  value: {{ $url | quote }}
+- name: HTTPS_PROXY
+  value: {{ $url | quote }}
+- name: http_proxy
+  value: {{ $url | quote }}
+- name: https_proxy
+  value: {{ $url | quote }}
+- name: NO_PROXY
+  value: {{ $noProxy | quote }}
+- name: no_proxy
+  value: {{ $noProxy | quote }}
+{{- end }}
+{{- end -}}

--- a/client/templates/auto-upgrade-cronjob.yaml
+++ b/client/templates/auto-upgrade-cronjob.yaml
@@ -134,6 +134,7 @@ spec:
               # our script instead.
               command: ["/bin/sh", "/scripts/auto-upgrade.sh"]
               env:
+              {{- include "tracebloc.proxyEnv" . | nindent 16 }}
                 - name: RELEASE_NAME
                   value: {{ .Release.Name | quote }}
                 - name: RELEASE_NAMESPACE

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -486,6 +486,7 @@ spec:
               # alpine/k8s entrypoint is kubectl; override to run our script.
               command: ["/bin/sh", "/scripts/image-refresh.sh"]
               env:
+              {{- include "tracebloc.proxyEnv" . | nindent 16 }}
                 # alpine/k8s's kubectl writes a discovery cache under
                 # $HOME/.kube. The pod runs uid 1000 with
                 # readOnlyRootFilesystem, so point HOME at the writable

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -66,6 +66,7 @@ spec:
             subPath: ingestion-authz.yaml
             readOnly: true
         env:
+        {{- include "tracebloc.proxyEnv" . | nindent 8 }}
         - name: CLIENT_ID
           valueFrom:
             secretKeyRef:
@@ -142,6 +143,7 @@ spec:
         - name: logs-volume
           mountPath: "/data/logs"
         env:
+        {{- include "tracebloc.proxyEnv" . | nindent 8 }}
         - name: CLIENT_ID
           valueFrom:
             secretKeyRef:

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -71,6 +71,7 @@ spec:
               cpu: {{ $rpLim.cpu | default "1000m" | quote }}
               memory: {{ $rpLim.memory | default "512Mi" | quote }}
           env:
+          {{- include "tracebloc.proxyEnv" . | nindent 12 }}
             - name: MYSQL_HOST
               value: "mysql-client"
             - name: EXPERIMENTS_QUEUE_NAME

--- a/client/tests/proxy_env_test.yaml
+++ b/client/tests/proxy_env_test.yaml
@@ -1,0 +1,97 @@
+suite: Corporate-proxy env injection (backend#768 — guards proxy-blind workloads)
+templates:
+  - templates/jobs-manager-deployment.yaml
+  - templates/requests-proxy-deployment.yaml
+  - templates/image-refresh-cronjob.yaml
+  - templates/auto-upgrade-cronjob.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  # ===== WITHOUT a proxy: non-proxy installs must be unchanged (no HTTP_PROXY env) =====
+  - it: jobs-manager api has no HTTP_PROXY env by default
+    template: templates/jobs-manager-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content: {name: HTTP_PROXY}
+          any: true
+  - it: jobs-manager pods-monitor has no HTTP_PROXY env by default
+    template: templates/jobs-manager-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[1].env
+          content: {name: HTTP_PROXY}
+          any: true
+  - it: requests-proxy has no HTTP_PROXY env by default
+    template: templates/requests-proxy-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content: {name: HTTP_PROXY}
+          any: true
+  - it: image-refresh has no HTTP_PROXY env by default
+    template: templates/image-refresh-cronjob.yaml
+    documentSelector: {path: kind, value: CronJob}
+    asserts:
+      - notContains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content: {name: HTTP_PROXY}
+          any: true
+  - it: auto-upgrade has no HTTP_PROXY env by default
+    template: templates/auto-upgrade-cronjob.yaml
+    documentSelector: {path: kind, value: CronJob}
+    asserts:
+      - notContains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content: {name: HTTP_PROXY}
+          any: true
+  # ===== WITH a proxy: every egress workload carries HTTP_PROXY + cluster-safe NO_PROXY =====
+  - it: jobs-manager api gets HTTP_PROXY + cluster-safe NO_PROXY when a proxy is set
+    template: templates/jobs-manager-deployment.yaml
+    set: {env.HTTP_PROXY_HOST: proxy.example.com, env.HTTP_PROXY_PORT: "8080"}
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: HTTP_PROXY, value: "http://proxy.example.com:8080"}
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: NO_PROXY, value: "localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.svc.cluster.local,.cluster.local,host.k3d.internal"}
+  - it: jobs-manager pods-monitor gets HTTP_PROXY when a proxy is set
+    template: templates/jobs-manager-deployment.yaml
+    set: {env.HTTP_PROXY_HOST: proxy.example.com, env.HTTP_PROXY_PORT: "8080"}
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content: {name: HTTP_PROXY, value: "http://proxy.example.com:8080"}
+  - it: requests-proxy gets HTTP_PROXY when a proxy is set
+    template: templates/requests-proxy-deployment.yaml
+    set: {env.HTTP_PROXY_HOST: proxy.example.com, env.HTTP_PROXY_PORT: "8080"}
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: HTTP_PROXY, value: "http://proxy.example.com:8080"}
+  - it: image-refresh gets HTTP_PROXY when a proxy is set
+    template: templates/image-refresh-cronjob.yaml
+    documentSelector: {path: kind, value: CronJob}
+    set: {env.HTTP_PROXY_HOST: proxy.example.com, env.HTTP_PROXY_PORT: "8080"}
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content: {name: HTTP_PROXY, value: "http://proxy.example.com:8080"}
+  - it: auto-upgrade gets HTTP_PROXY when a proxy is set
+    template: templates/auto-upgrade-cronjob.yaml
+    documentSelector: {path: kind, value: CronJob}
+    set: {env.HTTP_PROXY_HOST: proxy.example.com, env.HTTP_PROXY_PORT: "8080"}
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content: {name: HTTP_PROXY, value: "http://proxy.example.com:8080"}
+  # ===== authenticated proxy: credentials embed in the URL =====
+  - it: an authenticated proxy embeds the credentials in the proxy URL
+    template: templates/jobs-manager-deployment.yaml
+    set: {env.HTTP_PROXY_HOST: proxy.example.com, env.HTTP_PROXY_PORT: "8080", env.HTTP_PROXY_USERNAME: bob, env.HTTP_PROXY_PASSWORD: pw}
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: HTTP_PROXY, value: "http://bob:pw@proxy.example.com:8080"}


### PR DESCRIPTION
## Summary

Behind a corporate proxy, the chart's workload pods are **proxy-blind**: no pod received `HTTP(S)_PROXY`/`NO_PROXY` env, so any pod making a direct external call (jobs-manager → `api.tracebloc.io`) failed with `[Errno 111] Connection refused` → CrashLoopBackOff. The `env.HTTP_PROXY_HOST/PORT/USERNAME/PASSWORD` values were declared in `values.yaml` + `values.schema.json` but **wired into nothing** — a promise the chart never kept. The installer's proxy hardening (`scripts/lib/cluster.sh`) only covers the **k3s node** (image pulls), not the application pods.

This makes those values real: a `tracebloc.proxyEnv` helper derives `HTTP_PROXY`/`HTTPS_PROXY`/`http_proxy`/`https_proxy` (`http://[user:pass@]host[:port]`) + an **auto-augmented `NO_PROXY`** (always carrying the cluster-internal ranges from `cluster.sh`, so in-cluster + MySQL traffic never traverses the proxy), referenced on every external-egress workload. Renders nothing when no proxy is set → non-proxy installs are byte-unchanged.

Root-cause + egress analysis: **tracebloc/backend#768**.

## Workloads covered (and excluded)

| Workload | External call | Proxy env |
|---|---|---|
| jobs-manager — `api` + `pods-monitor-container` | `api.tracebloc.io` | ✅ |
| requests-proxy | Service Bus / backend | ✅ |
| image-refresh CronJob | docker.io / ghcr.io | ✅ |
| auto-upgrade CronJob | helm repo + registries | ✅ |
| mysql-client / resource-monitor | none / in-cluster | excluded (no egress) |
| ingestor sub-chart (`dataset push`) | `jobs-manager.<ns>.svc` only | excluded (in-cluster) |

This makes the per-pod `kubectl set env` bridge patches used to recover the affected deployment unnecessary going forward.

## Type

- [x] Bug fix (regression — corporate-proxy deployments)

## Test plan (helm template, `ci/bm-values.yaml`)

- **With proxy** (`--set-string env.HTTP_PROXY_HOST=proxy.example.com --set-string env.HTTP_PROXY_PORT=8080`): all **5** egress containers render `HTTP_PROXY=http://proxy.example.com:8080`; `NO_PROXY` includes `172.16.0.0/12`, `10.0.0.0/8`, `.svc`, `.cluster.local`; full manifest parses as valid YAML.
- **Without proxy**: **0** `HTTP_PROXY` entries — non-proxy installs unchanged; parses cleanly.
- Note: `env.HTTP_PROXY_PORT` is a string in the schema → set with `--set-string`.

## Checklist

- [x] Targets `develop`
- [x] No customer identifiers
- [ ] Reviewer to confirm CI (`helm-ci`, `installer-tests`) green

## Follow-ups (in backend#768, not this PR)

- **Installer auto-pass**: have the installer set `env.HTTP_PROXY_HOST/PORT` from the proxy it already detects, so a proxied install is zero-config (no manual values).
- **Extend `e2e-proxy.sh`**: assert a *workload pod* (not just the node) reaches an allowlisted external host through the proxy — the test that would have caught this.
- A helm-unittest assertion for the proxy env (couldn't add here without confirming the repo's unittest layout — flag for the reviewer).
