### PR TITLE
Sync develop → main for v1.5.1 chart release

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.5.0
-appVersion: "1.5.0"
+version: 1.5.1
+appVersion: "1.5.1"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -213,12 +213,15 @@ images:
   # Customers can also override per-install via the ingestor subchart's
   # `image.digest` for one-off testing, independent of this value.
   ingestor:
-    # Current baseline digest: v0.3.2 (2026-06-03, from #184). Patch on
-    # top of v0.3.1 carrying customer-impacting fixes —
-    # tracebloc/data-ingestors#139 (MLM tokenizer fix, relaxed PascalVOC
-    # `difficult` flag, reserved-id guard; closes #137 / #135) — plus the
-    # first multi-arch image (amd64 + arm64, #24) so arm64 nodes can run
-    # the ingestor. Bump only when greenfield installs should start on a
+    # Current baseline digest: v0.3.6 (2026-06-08, from #227). Skips
+    # 0.3.3–0.3.5 to land on the latest 0.3.x patch, carrying the
+    # cumulative NULL / empty-value ingestion fixes on top of v0.3.2 —
+    # tracebloc/data-ingestors#150 (stop counting missing values as
+    # "non-numeric" in DataValidator — the regression a customer hit on
+    # the stale 0.3.2 baseline), #167 / #168 / #170 / #172 (VARCHAR/CHAR/
+    # TEXT, DATE/TIME, JSON null + empty-string tolerance) and #176 / #179
+    # (null-like values round-trip end-to-end as SQL NULL; Python bool not
+    # stringified). Bump only when greenfield installs should start on a
     # different version; ongoing rollouts are managed by image-refresh.
     #
     # This digest MUST be a multi-arch index (linux/amd64 + linux/arm64).
@@ -227,7 +230,7 @@ images:
     # Graviton) with "no match for platform" / ImagePullBackOff (#186; the
     # amd64-only v0.3.1 pin in #160 was the regression). Enforced by the
     # `ingestor-multiarch` job in .github/workflows/helm-ci.yaml.
-    digest: "sha256:d361fa778554ab171adcc2671eaf109c32f3d2af339c7920a2d38d102ce53678"
+    digest: "sha256:dfdaa7e633a8df0f46b403e9422eba5c16bdb7d9c39047e6d3738f9e38fbdba8"
     # Floating tag polled by image-refresh. The team's ghcr.io
     # publishing convention uses semver-style float tags — `0` tracks
     # the latest 0.x, `0.3` tracks the latest 0.3.x patch. Default is


### PR DESCRIPTION
## Promote develop → main for the **v1.5.1** chart release

Ships the ingestor greenfield-baseline bump to customers. On merge, create a GitHub Release `v1.5.1` to trigger `release-helm-chart.yaml` (packages + publishes to the gh-pages helm repo).

### What this carries

Exactly one commit — the baseline bump (#228, toward #227):

| File | Change |
|---|---|
| `client/values.yaml` | `images.ingestor.digest` `0.3.2` (`d361fa77…`) → `0.3.6` (`dfdaa7e6…`, multi-arch) |
| `client/Chart.yaml` | `version` + `appVersion` 1.5.0 → 1.5.1 |

### Why

A customer (a customer) is stuck on ingestor **v0.3.2**, hitting `data-ingestors#150` ("empty cells flagged as non-numeric", fixed in 0.3.3). main currently publishes chart 1.5.0, whose pinned baseline **is** v0.3.2 — so fresh installs and `helm upgrade` keep landing there. Bumping the baseline to v0.3.6 means fresh installs and upgrades land on the fixed image.

Precedent: the previous baseline bump (v0.3.1→v0.3.2) shipped as chart **v1.4.4** the same way.

### After merge

1. Create GitHub Release **`v1.5.1`** (tag on main) → publishes chart to `https://tracebloc.github.io/client`.
2. Customer: `helm repo update && helm upgrade … tracebloc/client` → lands on v0.3.6.

Toward #227. Release-gated promotion — fr-gate + second approver (no self-approve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm values and chart version only; no template or runtime logic changes, with a targeted image digest bump for a known customer regression.
> 
> **Overview**
> Releases **client chart v1.5.1** by promoting the ingestor greenfield baseline from **v0.3.2** to **v0.3.6** (`images.ingestor.digest` in `client/values.yaml`), with matching `version` / `appVersion` bumps in `client/Chart.yaml`.
> 
> Fresh installs and `helm upgrade` will seed **jobs-manager**’s `INGESTOR_IMAGE_DIGEST` with the v0.3.6 multi-arch image so ingestion Jobs no longer land on the stale 0.3.2 pin (including the empty-cell / NULL handling fixes called out in the values comments). The floating `images.ingestor.tag` (`0.3`) is unchanged; ongoing drift is still handled by image-refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f2a70a443452cd5c4c9c9c1c340086b1ea7daec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->