### PR TITLE
fix(test): make install_docker_engine os-release detection mockable so setup-linux.bats passes on macOS

### DIFF
--- a/scripts/lib/setup-linux.sh
+++ b/scripts/lib/setup-linux.sh
@@ -88,15 +88,19 @@ _ensure_kernel_modules() {
 
 # ── Docker Engine ────────────────────────────────────────────────────────────
 install_docker_engine() {
+  # os-release path is overridable (TB_OS_RELEASE_FILE) so the distro detection
+  # below stays testable on hosts without one — e.g. macOS dev machines, where a
+  # bash `[[ -f ]]` file-test can't be mocked the way a command like `grep` can.
+  local os_release="${TB_OS_RELEASE_FILE:-/etc/os-release}"
   if ! has docker; then
-    if [[ -f /etc/os-release ]] && grep -qi 'amzn\|amazon' /etc/os-release; then
+    if [[ -f "$os_release" ]] && grep -qi 'amzn\|amazon' "$os_release"; then
       if has dnf; then spin_cmd "Installing Docker…" sudo dnf install -y docker
       else              spin_cmd "Installing Docker…" sudo yum install -y docker; fi
     elif has pacman; then
       spin_cmd "Installing Docker…" sudo pacman -S --noconfirm docker
     elif has zypper; then
       spin_cmd "Installing Docker…" sudo zypper install -y docker
-    elif [[ -f /etc/os-release ]] && grep -qiE '^ID="?(almalinux|rocky|ol|oracle)"?' /etc/os-release; then
+    elif [[ -f "$os_release" ]] && grep -qiE '^ID="?(almalinux|rocky|ol|oracle)"?' "$os_release"; then
       # get.docker.com rejects RHEL rebuilds (almalinux/rocky/ol) with
       # "Unsupported distribution". Install docker-ce from Docker's official
       # CentOS repo instead — it is RHEL-compatible and works on these distros.

--- a/scripts/tests/setup-linux.bats
+++ b/scripts/tests/setup-linux.bats
@@ -19,18 +19,23 @@ setup() {
   docker()    { return 0; }   # `docker info` succeeds → skip the sg-docker re-exec
   id()        { echo "testuser docker"; }
   curl()      { record "curl $*"; return 0; }
-  # Simulate /etc/os-release matching per TEST_DISTRO; delegate other greps.
-  grep() {
-    if [[ "$*" == *"/etc/os-release"* ]]; then
-      case "$TEST_DISTRO" in
-        amzn) [[ "$*" == *amzn* ]] ;;
-        alma) [[ "$*" == *almalinux* ]] ;;
-        *)    return 1 ;;
-      esac
-      return
-    fi
-    command grep "$@"
+
+  # macOS has no /etc/os-release, and a bash `[[ -f ]]` file-test can't be mocked
+  # the way `grep` can — so install_docker_engine's amzn/RHEL-clone branches
+  # short-circuited off-Linux and fell through to get.docker.com. Write a real
+  # os-release fixture for $TEST_DISTRO and point the function at it via
+  # TB_OS_RELEASE_FILE, so its distro detection (real `[[ -f ]]` + real `grep`)
+  # is exercised on every dev host. Re-call after changing TEST_DISTRO in a test.
+  write_os_release() {
+    : "${TB_OS_RELEASE_FILE:=$(mktemp)}"
+    case "$TEST_DISTRO" in
+      amzn) printf '%s\n' 'NAME="Amazon Linux"' 'ID="amzn"'      'VERSION_ID="2023"'  ;;
+      alma) printf '%s\n' 'NAME="AlmaLinux"'    'ID="almalinux"' 'VERSION_ID="9.4"'   ;;
+      *)    printf '%s\n' 'NAME="Ubuntu"'        'ID=ubuntu'      'VERSION_ID="22.04"' ;;
+    esac >"$TB_OS_RELEASE_FILE"
+    export TB_OS_RELEASE_FILE
   }
+  write_os_release   # default ($TEST_DISTRO=ubuntu); tests re-call for amzn/alma
 }
 
 # ── setup_pm ───────────────────────────────────────────────────────────────
@@ -108,7 +113,7 @@ setup() {
 
 # ── install_docker_engine: branch selection ────────────────────────────────
 @test "install_docker_engine: Amazon Linux -> dnf docker" {
-  PRESENT_CMDS="dnf"; TEST_DISTRO=amzn
+  PRESENT_CMDS="dnf"; TEST_DISTRO=amzn; write_os_release
   run install_docker_engine
   run mock_calls
   [[ "$output" == *"dnf install -y docker"* ]]
@@ -126,7 +131,7 @@ setup() {
   [[ "$output" == *"zypper install -y docker"* ]]
 }
 @test "install_docker_engine: RHEL clone (#719) -> docker-ce dnf repo" {
-  PRESENT_CMDS=""; TEST_DISTRO=alma
+  PRESENT_CMDS=""; TEST_DISTRO=alma; write_os_release
   run install_docker_engine
   run mock_calls
   [[ "$output" == *"docker-ce.repo"* ]]


### PR DESCRIPTION
Closes #232.

## Problem

Two `bats` tests in `scripts/tests/setup-linux.bats` failed on **macOS** dev hosts (green in CI on Linux):

- `install_docker_engine: Amazon Linux -> dnf docker`
- `install_docker_engine: RHEL clone (#719) -> docker-ce dnf repo`

`install_docker_engine()` gated the Amazon Linux and AlmaLinux/Rocky branches on `[[ -f /etc/os-release ]] && grep -qi ... /etc/os-release`. The suite mocks `grep`, but a bash builtin **file-test** (`[[ -f /etc/os-release ]]`) can't be intercepted by a function mock. On macOS `/etc/os-release` doesn't exist, so both branches short-circuited and the function fell through to the get.docker.com path — the asserted strings were never recorded. The pacman/zypper/ubuntu branches passed because they gate on `has <cmd>` (mockable via `PRESENT_CMDS`).

CI was unaffected: `unit-bash` runs on ubuntu (os-release present), and the real RHEL/Amazon docker paths are independently exercised by the `distro-prereqs` matrix in actual almalinux/amazonlinux containers.

## Fix

- **`scripts/lib/setup-linux.sh`** — `install_docker_engine` reads the os-release path from `${TB_OS_RELEASE_FILE:-/etc/os-release}`, used for both the `[[ -f ]]` test and the `grep`. Defaults to the exact prior behaviour when the env var is unset (production / CI).
- **`scripts/tests/setup-linux.bats`** — `setup()` writes a real os-release fixture per `$TEST_DISTRO` to a temp file and exports `TB_OS_RELEASE_FILE`. This replaces the old `grep` mock, so distro detection (real `[[ -f ]]` + real `grep`) is exercised on every dev host — keeping the coverage meaningful on macOS rather than skipping it.

## Verification

- `bats scripts/tests/setup-linux.bats` → **20/20 pass on macOS** (was 18/20).
- Verified on both this host's `grep` (ugrep 7.5.0) and stock `/usr/bin/grep` (BSD grep 2.6.0-FreeBSD, GNU-compatible) — the `\|` BRE and ERE alternations both match, so real grep is robust across macOS dev hosts.
- No behaviour change when `TB_OS_RELEASE_FILE` is unset.
- No new shellcheck findings (additions are quoted; remaining SC2086/SC2016 are pre-existing and untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only hook with default path unchanged; no change to installer behavior when TB_OS_RELEASE_FILE is unset.
> 
> **Overview**
> Fixes **macOS** failures in `setup-linux.bats` for Amazon Linux and AlmaLinux Docker install paths by making os-release detection testable without mocking bash `[[ -f ]]`.
> 
> **`install_docker_engine`** now reads the os-release path from **`TB_OS_RELEASE_FILE`** (default **`/etc/os-release`**), used for both the file existence check and **`grep`** distro matching. Unset env var keeps production/CI behavior unchanged.
> 
> The bats **`setup()`** drops the **`grep`** mock and adds **`write_os_release`**, which writes a temp fixture per **`TEST_DISTRO`** and exports **`TB_OS_RELEASE_FILE`**. Amazon and RHEL-clone tests call **`write_os_release`** so real **`[[ -f ]]`** + **`grep`** exercise the intended branches on hosts without **`/etc/os-release`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1d6daa7ecc8f24e34ba689ba9b0da3744e0b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->