### PR TITLE
fix(#229): dedupe NO_PROXY — exclude proxy keys from generic env passthrough

### DIFF
--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -1,3 +1,5 @@
+{{- /* #229: these env keys are owned by tracebloc.proxyEnv, which emits HTTP(S)_PROXY and a merged, cluster-safe NO_PROXY. Exclude them from the generic .Values.env passthrough below so a user-set NO_PROXY (or proxy var) is not re-emitted UNMERGED after proxyEnv — Kubernetes keeps the LAST duplicate env, which would drop the cluster-internal NO_PROXY entries and route in-cluster traffic through the proxy. */ -}}
+{{- $proxyKeys := list "HTTP_PROXY_HOST" "HTTP_PROXY_PORT" "HTTP_PROXY_USERNAME" "HTTP_PROXY_PASSWORD" "NO_PROXY" "no_proxy" "HTTP_PROXY" "HTTPS_PROXY" "http_proxy" "https_proxy" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -149,7 +151,7 @@ spec:
         - name: SINGLE_NODE
           value: {{ if hasKey .Values.env "SINGLE_NODE" }}{{ .Values.env.SINGLE_NODE | quote }}{{ else }}{{ (default dict .Values.hostPath).enabled | default false | quote }}{{ end }}
         {{- range $key, $value := .Values.env }}
-        {{- if and (ne $key "CLIENT_ENV") (ne $key "RESOURCE_REQUESTS") (ne $key "RESOURCE_LIMITS") (ne $key "GPU_REQUESTS") (ne $key "GPU_LIMITS") (ne $key "RUNTIME_CLASS_NAME") (ne $key "SINGLE_NODE") (ne $key "CLIENT_ID") $value }}
+        {{- if and (ne $key "CLIENT_ENV") (ne $key "RESOURCE_REQUESTS") (ne $key "RESOURCE_LIMITS") (ne $key "GPU_REQUESTS") (ne $key "GPU_LIMITS") (ne $key "RUNTIME_CLASS_NAME") (ne $key "SINGLE_NODE") (ne $key "CLIENT_ID") (not (has $key $proxyKeys)) $value }}
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}
@@ -206,7 +208,7 @@ spec:
         - name: SINGLE_NODE
           value: {{ if hasKey .Values.env "SINGLE_NODE" }}{{ .Values.env.SINGLE_NODE | quote }}{{ else }}{{ (default dict .Values.hostPath).enabled | default false | quote }}{{ end }}
         {{- range $key, $value := .Values.env }}
-        {{- if and (ne $key "CLIENT_ENV") (ne $key "RESOURCE_REQUESTS") (ne $key "RESOURCE_LIMITS") (ne $key "GPU_REQUESTS") (ne $key "GPU_LIMITS") (ne $key "RUNTIME_CLASS_NAME") (ne $key "SINGLE_NODE") (ne $key "CLIENT_ID") $value }}
+        {{- if and (ne $key "CLIENT_ENV") (ne $key "RESOURCE_REQUESTS") (ne $key "RESOURCE_LIMITS") (ne $key "GPU_REQUESTS") (ne $key "GPU_LIMITS") (ne $key "RUNTIME_CLASS_NAME") (ne $key "SINGLE_NODE") (ne $key "CLIENT_ID") (not (has $key $proxyKeys)) $value }}
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}

--- a/client/tests/proxy_env_test.yaml
+++ b/client/tests/proxy_env_test.yaml
@@ -95,3 +95,27 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content: {name: HTTP_PROXY, value: "http://bob:pw@proxy.example.com:8080"}
+  # ===== #229 regression: a custom NO_PROXY must not be re-emitted UNMERGED =====
+  # tracebloc.proxyEnv merges the user's NO_PROXY with the cluster-internal
+  # defaults. The generic .Values.env passthrough must NOT re-emit the bare
+  # user value afterwards — k8s keeps the LAST duplicate env, so an unmerged
+  # copy would win and route in-cluster traffic (mysql, requests-proxy) through
+  # the proxy. Guards both jobs-manager containers (api + pods-monitor).
+  - it: a custom NO_PROXY is merged once, never re-emitted unmerged (jobs-manager)
+    template: templates/jobs-manager-deployment.yaml
+    set: {env.HTTP_PROXY_HOST: proxy.example.com, env.HTTP_PROXY_PORT: "8080", env.NO_PROXY: "myinternal.example"}
+    asserts:
+      # api container: only the merged value (custom + cluster-internal) is present
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: NO_PROXY, value: "myinternal.example,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.svc.cluster.local,.cluster.local,host.k3d.internal"}
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content: {name: NO_PROXY, value: "myinternal.example"}
+      # pods-monitor container: same guarantee
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content: {name: NO_PROXY, value: "myinternal.example,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.svc.cluster.local,.cluster.local,host.k3d.internal"}
+      - notContains:
+          path: spec.template.spec.containers[1].env
+          content: {name: NO_PROXY, value: "myinternal.example"}


### PR DESCRIPTION
Fixes #236. Found by Cursor Bugbot on the v1.6.0 release PR #235.

jobs-manager's `api` + `pods-monitor` containers include `tracebloc.proxyEnv` (merged, cluster-safe `NO_PROXY`) AND a generic `.Values.env` passthrough that re-emitted a user-set `NO_PROXY` **unmerged** afterwards. k8s keeps the last duplicate, so the unmerged copy won — dropping cluster-internal entries (`.svc`, `10.0.0.0/8`, …) and routing in-cluster traffic through the proxy. Affects proxy customers (#229's target audience); invisible to non-proxy installs.

**Fix:** exclude proxy-owned keys from both passthrough loops via a shared `$proxyKeys` list (proxyEnv stays the sole source). Adds a `proxy_env_test` regression (custom NO_PROXY + proxy → one merged NO_PROXY, no unmerged copy) for both containers.

**Validation:** helm unittest 195 pass (+1), render-verified single merged NO_PROXY, non-proxy passthrough intact, lint + 4-platform render clean.

Blocks the v1.6.0 release (#234) — re-cut after this lands on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Affects proxy-enabled installs only but fixes incorrect in-cluster routing; change is narrow Helm template logic with a targeted regression test.
> 
> **Overview**
> Fixes a **Helm templating bug** in `jobs-manager-deployment` where proxy-related values could be emitted twice: `tracebloc.proxyEnv` first (merged `NO_PROXY` + `HTTP(S)_PROXY`), then again from the generic `.Values.env` loop.
> 
> Kubernetes keeps the **last** duplicate env entry, so a user-set `NO_PROXY` without cluster-internal suffixes could override the merged value and send in-cluster traffic (e.g. `mysql-client`, `requests-proxy`) through the corporate proxy.
> 
> The change introduces a shared **`$proxyKeys`** list and skips those keys in both the **api** and **pods-monitor** passthrough loops so proxy env comes only from `proxyEnv`. A **helm unittest** regression asserts a custom `NO_PROXY` appears once, merged with cluster defaults, on both containers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 576761f0b8f794a7134756e0a4952de8f44966eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->