### PR TITLE
release: client chart 1.6.1 — proxy-key exclusion gate (#238) + appVersion lockstep

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -3,7 +3,7 @@ name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
 version: 1.6.0
-appVersion: "1.5.1"
+appVersion: "1.6.0"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.6.0
-appVersion: "1.6.0"
+version: 1.6.1
+appVersion: "1.6.1"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -1,5 +1,8 @@
-{{- /* #229: these env keys are owned by tracebloc.proxyEnv, which emits HTTP(S)_PROXY and a merged, cluster-safe NO_PROXY. Exclude them from the generic .Values.env passthrough below so a user-set NO_PROXY (or proxy var) is not re-emitted UNMERGED after proxyEnv — Kubernetes keeps the LAST duplicate env, which would drop the cluster-internal NO_PROXY entries and route in-cluster traffic through the proxy. */ -}}
-{{- $proxyKeys := list "HTTP_PROXY_HOST" "HTTP_PROXY_PORT" "HTTP_PROXY_USERNAME" "HTTP_PROXY_PASSWORD" "NO_PROXY" "no_proxy" "HTTP_PROXY" "HTTPS_PROXY" "http_proxy" "https_proxy" -}}
+{{- /* #229/#238: when HTTP_PROXY_HOST is set, tracebloc.proxyEnv owns these keys — it emits HTTP(S)_PROXY and a merged, cluster-safe NO_PROXY. Exclude them from the generic .Values.env passthrough below so a user-set NO_PROXY (or proxy var) is not re-emitted UNMERGED after proxyEnv — Kubernetes keeps the LAST duplicate env, which would drop the cluster-internal NO_PROXY entries and route in-cluster traffic through the proxy. When HTTP_PROXY_HOST is UNSET, proxyEnv renders nothing, so the exclusion list stays empty and the passthrough still emits a directly-set env.HTTP_PROXY / NO_PROXY — the pre-1.6.0 way to configure a corporate proxy. Dropping those unconditionally was an upgrade regression (#238): gate the exclusion on proxyEnv being active. */ -}}
+{{- $proxyKeys := list -}}
+{{- if .Values.env.HTTP_PROXY_HOST -}}
+{{- $proxyKeys = list "HTTP_PROXY_HOST" "HTTP_PROXY_PORT" "HTTP_PROXY_USERNAME" "HTTP_PROXY_PASSWORD" "NO_PROXY" "no_proxy" "HTTP_PROXY" "HTTPS_PROXY" "http_proxy" "https_proxy" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/client/tests/proxy_env_test.yaml
+++ b/client/tests/proxy_env_test.yaml
@@ -119,3 +119,29 @@ tests:
       - notContains:
           path: spec.template.spec.containers[1].env
           content: {name: NO_PROXY, value: "myinternal.example"}
+  # ===== #238 regression: a directly-set env.HTTP_PROXY survives when HTTP_PROXY_HOST is UNSET =====
+  # Before 1.6.0 a corporate proxy was configured by setting env.HTTP_PROXY (a
+  # full URL) directly; tracebloc.proxyEnv (the HTTP_PROXY_HOST-driven helper)
+  # did not exist. The #229 proxy-key exclusion must therefore stay INACTIVE
+  # when HTTP_PROXY_HOST is unset — otherwise the passthrough drops the user's
+  # HTTP_PROXY and their backend/registry egress breaks on upgrade to 1.6.0.
+  # proxyEnv renders nothing here, so the generic passthrough is the sole (and
+  # correct) source: the direct values pass through verbatim, NO_PROXY unmerged.
+  - it: a directly-set env.HTTP_PROXY survives when HTTP_PROXY_HOST is unset (jobs-manager)
+    template: templates/jobs-manager-deployment.yaml
+    set: {env.HTTP_PROXY: "http://corp-proxy.example.com:3128", env.NO_PROXY: "myinternal.example"}
+    asserts:
+      # api container: directly-set proxy vars pass through (proxyEnv inactive)
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: HTTP_PROXY, value: "http://corp-proxy.example.com:3128"}
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: NO_PROXY, value: "myinternal.example"}
+      # pods-monitor container: same
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content: {name: HTTP_PROXY, value: "http://corp-proxy.example.com:3128"}
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content: {name: NO_PROXY, value: "myinternal.example"}


### PR DESCRIPTION
Cuts client chart **1.6.1** as a fast-follow to the (still-unpublished) 1.6.0, bundling two release-hygiene fixes plus the version bump. All verified on `develop`: **196 helm-unittest pass**, lint + 4-platform render (aks/bm/eks/oc) clean.

**Chart:** `version` 1.6.0 → **1.6.1**, `appVersion` 1.5.1 → **1.6.1** (kept in lockstep).

---

## 1. Closes #238 — gate proxy-key exclusion on `HTTP_PROXY_HOST`
Refines #236 (already on `develop`), flagged by Cursor Bugbot on release PR #235.

**Problem (upgrade regression):** #236 excluded the proxy-owned keys (`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`/… + the `HTTP_PROXY_*` inputs) from jobs-manager's generic `.Values.env` passthrough **unconditionally**, intending `tracebloc.proxyEnv` to be the sole source. But `proxyEnv` only emits when `HTTP_PROXY_HOST` is set ([`_helpers.tpl:215`](https://github.com/tracebloc/client/blob/develop/client/templates/_helpers.tpl#L215)). When it's **unset**, `proxyEnv` renders nothing **and** the passthrough now drops a directly-set `env.HTTP_PROXY` (a full proxy URL — the pre-1.6.0 way to configure a corporate proxy). Clusters that used the raw `HTTP_PROXY` value instead of `HTTP_PROXY_HOST` lose backend/registry egress on upgrade.

**Fix:** build `$proxyKeys` empty and only populate it when `.Values.env.HTTP_PROXY_HOST` is set (mirrors `proxyEnv`'s own gate). The passthrough loops already key off `$proxyKeys`:
- **host unset** → list empty → passthrough emits directly-set proxy vars verbatim (**prior behavior preserved**).
- **host set** → list populated → exclusion holds exactly as in #236 (`proxyEnv` authoritative; a stray direct `HTTP_PROXY` is dropped).

**Regression test:** a direct `env.HTTP_PROXY` + `NO_PROXY` with **no** `HTTP_PROXY_HOST` passes through on **both** jobs-manager containers. Confirmed it fails (4 asserts) against the unconditional #236 template and passes against the gate. Render-verified both scenarios.

## 2. Restore Chart `version`/`appVersion` lockstep
The 1.6.0 bump (#231) moved `version` 1.5.1 → 1.6.0 but left `appVersion` at "1.5.1" — every prior release (1.1.0 … 1.5.1) bumped both together. [`tracebloc.labels`](https://github.com/tracebloc/client/blob/develop/client/templates/_helpers.tpl#L7) emits `app.kubernetes.io/version` from `.Chart.AppVersion`, so the chart labelled every resource (and reported to cluster info, which reads that standard label) with a stale app version while `helm.sh/chart` was correct — two disagreeing version signals. The 1.6.1 bump sets both fields to 1.6.1.

## 3. Bump chart → 1.6.1
Ship #1 and #2 as 1.6.1 (per #238's "land as 1.6.1 / fast-follow") rather than folding into the unpublished 1.6.0.

---

## Release sequencing
- 1.6.0 (from the frozen `sync/develop-to-main-v1.6.0` branch behind #235) is unaffected — it ships, or not, as its own historical release without these fixes. `develop` moves to the **1.6.1** line here.
- After merge: a develop→main sync + GitHub Release **v1.6.1** triggers `release-helm-chart.yaml` → publishes client-1.6.1 to gh-pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to jobs-manager env templating and chart metadata; restores prior proxy passthrough when HTTP_PROXY_HOST is unset without changing the HTTP_PROXY_HOST-driven path.
> 
> **Overview**
> Fixes an **upgrade regression (#238)** in jobs-manager proxy handling and bumps the Helm chart to **1.6.1** with aligned `version` / `appVersion`.
> 
> **Proxy (#238):** The jobs-manager template now builds the proxy-key exclusion list only when `env.HTTP_PROXY_HOST` is set—the same condition `tracebloc.proxyEnv` uses. With the host unset, direct `env.HTTP_PROXY` / `NO_PROXY` values pass through the generic `.Values.env` loop again (pre-1.6.0 behavior). With the host set, #229 behavior is unchanged: `proxyEnv` owns merged proxy vars and passthrough must not re-emit duplicates.
> 
> **Chart:** `Chart.yaml` moves to **1.6.1** for both `version` and `appVersion`.
> 
> **Tests:** New helm-unittest cases assert both jobs-manager containers keep verbatim `HTTP_PROXY` and `NO_PROXY` when `HTTP_PROXY_HOST` is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54feeee188c40d9a3609900d219c597b15000c25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->