### PR TITLE
Sync develop → main for v1.6.1 chart release

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -3,7 +3,7 @@ name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
 version: 1.6.0
-appVersion: "1.5.1"
+appVersion: "1.6.0"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.6.0
-appVersion: "1.6.0"
+version: 1.6.1
+appVersion: "1.6.1"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -1,5 +1,8 @@
-{{- /* #229: these env keys are owned by tracebloc.proxyEnv, which emits HTTP(S)_PROXY and a merged, cluster-safe NO_PROXY. Exclude them from the generic .Values.env passthrough below so a user-set NO_PROXY (or proxy var) is not re-emitted UNMERGED after proxyEnv — Kubernetes keeps the LAST duplicate env, which would drop the cluster-internal NO_PROXY entries and route in-cluster traffic through the proxy. */ -}}
-{{- $proxyKeys := list "HTTP_PROXY_HOST" "HTTP_PROXY_PORT" "HTTP_PROXY_USERNAME" "HTTP_PROXY_PASSWORD" "NO_PROXY" "no_proxy" "HTTP_PROXY" "HTTPS_PROXY" "http_proxy" "https_proxy" -}}
+{{- /* #229/#238: when HTTP_PROXY_HOST is set, tracebloc.proxyEnv owns these keys — it emits HTTP(S)_PROXY and a merged, cluster-safe NO_PROXY. Exclude them from the generic .Values.env passthrough below so a user-set NO_PROXY (or proxy var) is not re-emitted UNMERGED after proxyEnv — Kubernetes keeps the LAST duplicate env, which would drop the cluster-internal NO_PROXY entries and route in-cluster traffic through the proxy. When HTTP_PROXY_HOST is UNSET, proxyEnv renders nothing, so the exclusion list stays empty and the passthrough still emits a directly-set env.HTTP_PROXY / NO_PROXY — the pre-1.6.0 way to configure a corporate proxy. Dropping those unconditionally was an upgrade regression (#238): gate the exclusion on proxyEnv being active. */ -}}
+{{- $proxyKeys := list -}}
+{{- if .Values.env.HTTP_PROXY_HOST -}}
+{{- $proxyKeys = list "HTTP_PROXY_HOST" "HTTP_PROXY_PORT" "HTTP_PROXY_USERNAME" "HTTP_PROXY_PASSWORD" "NO_PROXY" "no_proxy" "HTTP_PROXY" "HTTPS_PROXY" "http_proxy" "https_proxy" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/client/tests/proxy_env_test.yaml
+++ b/client/tests/proxy_env_test.yaml
@@ -119,3 +119,29 @@ tests:
       - notContains:
           path: spec.template.spec.containers[1].env
           content: {name: NO_PROXY, value: "myinternal.example"}
+  # ===== #238 regression: a directly-set env.HTTP_PROXY survives when HTTP_PROXY_HOST is UNSET =====
+  # Before 1.6.0 a corporate proxy was configured by setting env.HTTP_PROXY (a
+  # full URL) directly; tracebloc.proxyEnv (the HTTP_PROXY_HOST-driven helper)
+  # did not exist. The #229 proxy-key exclusion must therefore stay INACTIVE
+  # when HTTP_PROXY_HOST is unset — otherwise the passthrough drops the user's
+  # HTTP_PROXY and their backend/registry egress breaks on upgrade to 1.6.0.
+  # proxyEnv renders nothing here, so the generic passthrough is the sole (and
+  # correct) source: the direct values pass through verbatim, NO_PROXY unmerged.
+  - it: a directly-set env.HTTP_PROXY survives when HTTP_PROXY_HOST is unset (jobs-manager)
+    template: templates/jobs-manager-deployment.yaml
+    set: {env.HTTP_PROXY: "http://corp-proxy.example.com:3128", env.NO_PROXY: "myinternal.example"}
+    asserts:
+      # api container: directly-set proxy vars pass through (proxyEnv inactive)
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: HTTP_PROXY, value: "http://corp-proxy.example.com:3128"}
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: NO_PROXY, value: "myinternal.example"}
+      # pods-monitor container: same
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content: {name: HTTP_PROXY, value: "http://corp-proxy.example.com:3128"}
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content: {name: NO_PROXY, value: "myinternal.example"}


### PR DESCRIPTION
Sync `develop` → `main` to cut **client chart v1.6.1** (fast-follow to 1.6.0). Tracks #240.

`develop` is ahead of `main` by the #239 fixes:
- #238 — gate jobs-manager proxy-key exclusion on `HTTP_PROXY_HOST` (fixes a 1.6.0 upgrade regression for raw-`HTTP_PROXY` proxy clusters).
- Chart `version`/`appVersion` lockstep restored — both → **1.6.1** (1.6.0 stranded `appVersion` at 1.5.1).

Delta over 1.6.0 is template-only and a no-op for any non-proxy cluster (entire known fleet). CI gate green on #239 (lint, render×4, schema×4, 196 unit, drift, multi-arch, Bugbot).

`skip-fr-gate` applied per the v1.6.0 sync (#235) precedent for release-promotion PRs.

After merge: publishing GitHub Release **v1.6.1** triggers `release-helm-chart.yaml` → packages client + ingestor from the tag → gh-pages index.yaml. NOTE: this flips fleet-wide auto-upgrade — auto-upgrade-ON clients converge 1.6.0 → 1.6.1 at their next :23 cronjob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only change scoped to jobs-manager proxy env wiring; no-op for the known non-proxy fleet and restores pre-1.6.0 behavior for direct HTTP_PROXY setups.
> 
> **Overview**
> Cuts **client Helm chart v1.6.1** with `version` and `appVersion` both set to **1.6.1** (fixing 1.6.0’s stranded `appVersion`).
> 
> **#238 fix in `jobs-manager-deployment`:** proxy-related env keys are only excluded from the generic `.Values.env` passthrough when `HTTP_PROXY_HOST` is set (i.e. when `tracebloc.proxyEnv` is active). Clusters that still configure a corporate proxy via raw `env.HTTP_PROXY` / `NO_PROXY` keep those values on upgrade instead of having them stripped.
> 
> Adds a Helm unit test that asserts direct `HTTP_PROXY` and `NO_PROXY` survive on both jobs-manager containers when `HTTP_PROXY_HOST` is unset. No behavior change for clusters without proxy or those using `HTTP_PROXY_HOST`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7241c0f0cdfdc6dd7e0fce98bf26cd612580cddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->