### PR TITLE
fix(#244): configure host Docker daemon proxy when a host proxy is detected

### DIFF
--- a/scripts/lib/setup-linux.sh
+++ b/scripts/lib/setup-linux.sh
@@ -95,14 +95,36 @@ _ensure_kernel_modules() {
 # install-client-helm.sh (chart values, #242): when the host has a proxy,
 # propagate it to every layer that needs it. Idempotent — only restarts dockerd
 # when the drop-in content actually changes, so a re-run never bounces a running
-# cluster. (Linux/systemd only; Docker Desktop on macOS manages its own proxy.)
+# cluster; and if the host proxy is later REMOVED, a re-run deletes the drop-in
+# we wrote (tagged with a marker) so dockerd stops routing pulls through a dead
+# proxy, while a foreign http-proxy.conf is left untouched. (Linux/systemd only;
+# Docker Desktop on macOS manages its own proxy.)
 _configure_docker_proxy() {
   has systemctl || return 0                       # only systemd-managed Docker
+  local dir="${TB_DOCKER_DROPIN_DIR:-/etc/systemd/system/docker.service.d}"
+  local conf="$dir/http-proxy.conf"
+  local marker="# Managed by tracebloc installer (#244)"
+
   local proxy="" var
   for var in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy; do
     [[ -n "${!var:-}" ]] && { proxy="${!var}"; break; }
   done
-  [[ -z "$proxy" ]] && return 0                   # no host proxy → nothing to do
+
+  # No host proxy → remove a drop-in WE wrote on a previous run (the proxy was
+  # removed since), so dockerd doesn't keep pulling through a proxy that no
+  # longer exists. Only touch our own file (identified by the marker); a
+  # user/IT-managed http-proxy.conf is left alone.
+  if [[ -z "$proxy" ]]; then
+    if [[ -f "$conf" ]] && sudo grep -qF "$marker" "$conf" 2>/dev/null; then
+      sudo rm -f "$conf"
+      sudo systemctl daemon-reload 2>/dev/null || true
+      if sudo systemctl is-active --quiet docker 2>/dev/null; then
+        spin_cmd "Removing stale Docker proxy settings…" sudo systemctl restart docker || true
+      fi
+      log "Removed stale tracebloc-managed Docker daemon proxy (no host proxy set)."
+    fi
+    return 0
+  fi
 
   local https="${HTTPS_PROXY:-${https_proxy:-$proxy}}"
   local noproxy
@@ -112,11 +134,9 @@ _configure_docker_proxy() {
     noproxy="${NO_PROXY:-${no_proxy:-}}"
   fi
 
-  local dir="${TB_DOCKER_DROPIN_DIR:-/etc/systemd/system/docker.service.d}"
-  local conf="$dir/http-proxy.conf"
   local desired
-  printf -v desired '[Service]\nEnvironment="HTTP_PROXY=%s"\nEnvironment="HTTPS_PROXY=%s"\nEnvironment="NO_PROXY=%s"\n' \
-    "$proxy" "$https" "$noproxy"
+  printf -v desired '%s\n[Service]\nEnvironment="HTTP_PROXY=%s"\nEnvironment="HTTPS_PROXY=%s"\nEnvironment="NO_PROXY=%s"\n' \
+    "$marker" "$proxy" "$https" "$noproxy"
 
   # Unchanged → leave dockerd alone (a restart would bounce a running cluster).
   # Compare with cmp, not "$(cat)" == , so a trailing newline isn't stripped by

--- a/scripts/lib/setup-linux.sh
+++ b/scripts/lib/setup-linux.sh
@@ -86,6 +86,57 @@ _ensure_kernel_modules() {
   fi
 }
 
+# ── Corporate-proxy support for the host Docker daemon (#244) ────────────────
+# dockerd pulls the k3d node image (rancher/k3s) and other images via the HOST
+# daemon, which does NOT inherit the shell's HTTP_PROXY — it reads a systemd
+# drop-in instead. Without it, `k3d cluster create` fails on a strict proxy-only
+# host with "failed to pull rancher/k3s … i/o timeout", BEFORE the client is
+# ever installed. Mirrors cluster.sh (k3d node env, #166) and
+# install-client-helm.sh (chart values, #242): when the host has a proxy,
+# propagate it to every layer that needs it. Idempotent — only restarts dockerd
+# when the drop-in content actually changes, so a re-run never bounces a running
+# cluster. (Linux/systemd only; Docker Desktop on macOS manages its own proxy.)
+_configure_docker_proxy() {
+  has systemctl || return 0                       # only systemd-managed Docker
+  local proxy="" var
+  for var in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy; do
+    [[ -n "${!var:-}" ]] && { proxy="${!var}"; break; }
+  done
+  [[ -z "$proxy" ]] && return 0                   # no host proxy → nothing to do
+
+  local https="${HTTPS_PROXY:-${https_proxy:-$proxy}}"
+  local noproxy
+  if declare -F _augment_no_proxy >/dev/null 2>&1; then
+    noproxy="$(_augment_no_proxy)"                 # host NO_PROXY ∪ cluster-internal ranges
+  else
+    noproxy="${NO_PROXY:-${no_proxy:-}}"
+  fi
+
+  local dir="${TB_DOCKER_DROPIN_DIR:-/etc/systemd/system/docker.service.d}"
+  local conf="$dir/http-proxy.conf"
+  local desired
+  printf -v desired '[Service]\nEnvironment="HTTP_PROXY=%s"\nEnvironment="HTTPS_PROXY=%s"\nEnvironment="NO_PROXY=%s"\n' \
+    "$proxy" "$https" "$noproxy"
+
+  # Unchanged → leave dockerd alone (a restart would bounce a running cluster).
+  # Compare with cmp, not "$(cat)" == , so a trailing newline isn't stripped by
+  # command substitution (which would make the check always report "changed").
+  if [[ -f "$conf" ]] && printf '%s' "$desired" | sudo cmp -s - "$conf" 2>/dev/null; then
+    log "Docker daemon proxy already configured."
+    return 0
+  fi
+
+  sudo mkdir -p "$dir"
+  printf '%s' "$desired" | sudo tee "$conf" >/dev/null
+  sudo systemctl daemon-reload 2>/dev/null || true
+  # Restart only if the daemon is already up; on a fresh install the start in
+  # install_docker_engine brings it up with the drop-in already in place.
+  if sudo systemctl is-active --quiet docker 2>/dev/null; then
+    spin_cmd "Applying Docker proxy settings…" sudo systemctl restart docker || true
+  fi
+  log "Configured Docker daemon proxy for image pulls behind a corporate proxy (HTTP_PROXY=$proxy)."
+}
+
 # ── Docker Engine ────────────────────────────────────────────────────────────
 install_docker_engine() {
   # os-release path is overridable (TB_OS_RELEASE_FILE) so the distro detection
@@ -131,6 +182,10 @@ install_docker_engine() {
   # Load the kernel modules dockerd's bridge driver + k3s need BEFORE starting,
   # so minimal RHEL/AlmaLinux images don't fail with the "addrtype" iptables error.
   _ensure_kernel_modules
+
+  # Give the host Docker daemon the corporate proxy BEFORE it starts and before
+  # k3d uses it to pull rancher/k3s (#244) — dockerd doesn't read the shell env.
+  _configure_docker_proxy
 
   # Clear any failed/throttled state from a previous attempt first — a crashed
   # daemon leaves the unit in "Start request repeated too quickly", which makes

--- a/scripts/tests/setup-linux.bats
+++ b/scripts/tests/setup-linux.bats
@@ -204,3 +204,67 @@ setup() {
   [[ "$output" == *"modprobe xt_addrtype"* ]]
   [[ "$output" == *"kernel-modules-"* ]]           # RHEL fallback install fired
 }
+
+# ── _configure_docker_proxy (#244: host proxy -> dockerd systemd drop-in) ────
+# These tests run `sudo` as a pass-through so tee/cat/mkdir actually touch a
+# temp drop-in dir (TB_DOCKER_DROPIN_DIR), letting us assert the file content.
+@test "_configure_docker_proxy: no host proxy -> no drop-in written" {
+  unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy NO_PROXY no_proxy
+  PRESENT_CMDS="systemctl"
+  TB_DOCKER_DROPIN_DIR="$BATS_TEST_TMPDIR/dropin"
+  sudo() { "$@"; }
+  run _configure_docker_proxy
+  [ "$status" -eq 0 ]
+  [ ! -e "$TB_DOCKER_DROPIN_DIR/http-proxy.conf" ]
+}
+
+@test "_configure_docker_proxy: not systemd-managed -> no-op" {
+  PRESENT_CMDS=""                                  # has systemctl -> false
+  HTTP_PROXY="http://proxy.corp:3128"
+  TB_DOCKER_DROPIN_DIR="$BATS_TEST_TMPDIR/dropin"
+  sudo() { "$@"; }
+  run _configure_docker_proxy
+  [ "$status" -eq 0 ]
+  [ ! -e "$TB_DOCKER_DROPIN_DIR/http-proxy.conf" ]
+}
+
+@test "_configure_docker_proxy: host proxy -> writes dockerd drop-in (HTTP/HTTPS/NO_PROXY)" {
+  unset HTTPS_PROXY http_proxy https_proxy no_proxy
+  PRESENT_CMDS="systemctl"
+  HTTP_PROXY="http://proxy.corp:3128"; NO_PROXY="localhost,.corp"
+  TB_DOCKER_DROPIN_DIR="$BATS_TEST_TMPDIR/dropin"
+  sudo() { "$@"; }
+  systemctl() { return 1; }                        # is-active false (fresh) -> no restart
+  run _configure_docker_proxy
+  [ "$status" -eq 0 ]
+  f="$TB_DOCKER_DROPIN_DIR/http-proxy.conf"
+  [ -f "$f" ]
+  grep -q 'Environment="HTTP_PROXY=http://proxy.corp:3128"' "$f"
+  grep -q 'Environment="HTTPS_PROXY=http://proxy.corp:3128"' "$f"
+  grep -q 'Environment="NO_PROXY=localhost,.corp"' "$f"
+}
+
+@test "_configure_docker_proxy: authenticated proxy URL preserved verbatim" {
+  unset HTTPS_PROXY http_proxy https_proxy NO_PROXY no_proxy
+  PRESENT_CMDS="systemctl"
+  HTTP_PROXY="http://user:p@ss@proxy.corp:3128"
+  TB_DOCKER_DROPIN_DIR="$BATS_TEST_TMPDIR/dropin"
+  sudo() { "$@"; }
+  systemctl() { return 1; }
+  run _configure_docker_proxy
+  grep -q 'Environment="HTTP_PROXY=http://user:p@ss@proxy.corp:3128"' "$TB_DOCKER_DROPIN_DIR/http-proxy.conf"
+}
+
+@test "_configure_docker_proxy: idempotent -> unchanged config does not restart docker" {
+  unset HTTPS_PROXY http_proxy https_proxy NO_PROXY no_proxy
+  PRESENT_CMDS="systemctl"
+  HTTP_PROXY="http://proxy.corp:3128"
+  TB_DOCKER_DROPIN_DIR="$BATS_TEST_TMPDIR/dropin"
+  sudo() { "$@"; }
+  systemctl() { record "systemctl $*"; return 0; }  # is-active -> true (running)
+  _configure_docker_proxy                           # 1st: writes (+restart, since active)
+  : > "$MOCK_CALLS"                                 # reset records
+  run _configure_docker_proxy                       # 2nd: unchanged -> early return
+  run mock_calls
+  [[ "$output" != *"restart docker"* ]]
+}

--- a/scripts/tests/setup-linux.bats
+++ b/scripts/tests/setup-linux.bats
@@ -242,6 +242,7 @@ setup() {
   grep -q 'Environment="HTTP_PROXY=http://proxy.corp:3128"' "$f"
   grep -q 'Environment="HTTPS_PROXY=http://proxy.corp:3128"' "$f"
   grep -q 'Environment="NO_PROXY=localhost,.corp"' "$f"
+  grep -qF '# Managed by tracebloc installer' "$f"   # marker → safe to remove later
 }
 
 @test "_configure_docker_proxy: authenticated proxy URL preserved verbatim" {
@@ -267,4 +268,34 @@ setup() {
   run _configure_docker_proxy                       # 2nd: unchanged -> early return
   run mock_calls
   [[ "$output" != *"restart docker"* ]]
+}
+
+# Bugbot #245: proxy removed since last run -> the stale drop-in we wrote must
+# be deleted, else dockerd keeps pulling through a proxy that no longer exists.
+@test "_configure_docker_proxy: host proxy removed -> deletes our stale drop-in" {
+  unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy NO_PROXY no_proxy
+  PRESENT_CMDS="systemctl"
+  TB_DOCKER_DROPIN_DIR="$BATS_TEST_TMPDIR/dropin"
+  mkdir -p "$TB_DOCKER_DROPIN_DIR"
+  printf '# Managed by tracebloc installer (#244)\n[Service]\nEnvironment="HTTP_PROXY=http://old:3128"\n' \
+    > "$TB_DOCKER_DROPIN_DIR/http-proxy.conf"
+  sudo() { "$@"; }
+  systemctl() { return 1; }                         # not active -> no restart
+  run _configure_docker_proxy
+  [ "$status" -eq 0 ]
+  [ ! -e "$TB_DOCKER_DROPIN_DIR/http-proxy.conf" ]  # ours -> removed
+}
+
+@test "_configure_docker_proxy: host proxy removed -> leaves a foreign drop-in untouched" {
+  unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy NO_PROXY no_proxy
+  PRESENT_CMDS="systemctl"
+  TB_DOCKER_DROPIN_DIR="$BATS_TEST_TMPDIR/dropin"
+  mkdir -p "$TB_DOCKER_DROPIN_DIR"
+  printf '[Service]\nEnvironment="HTTP_PROXY=http://it-managed:3128"\n' \
+    > "$TB_DOCKER_DROPIN_DIR/http-proxy.conf"      # no tracebloc marker
+  sudo() { "$@"; }
+  run _configure_docker_proxy
+  [ "$status" -eq 0 ]
+  [ -f "$TB_DOCKER_DROPIN_DIR/http-proxy.conf" ]   # NOT ours -> left alone
+  grep -q 'it-managed' "$TB_DOCKER_DROPIN_DIR/http-proxy.conf"
 }


### PR DESCRIPTION
## Problem
On a strict proxy-only host, the installer fails at **k3d cluster creation** — *before* the chart is applied — because the **host Docker daemon** has no proxy:

```
k3d: docker failed to pull 'rancher/k3s:v1.29.4-k3s1': dial tcp …:443: i/o timeout
```

`rancher/k3s` is pulled by the host `dockerd`, which doesn't read the shell's `HTTP_PROXY` — it needs a systemd drop-in. The installer wired the proxy into the k3d **node env** (#166) and the **chart values** (#242), but not the **host daemon**. This is the missing layer; it blocks everything before #242 can even matter.

## Fix
`_configure_docker_proxy` in `setup-linux.sh`, called inside `install_docker_engine` before the daemon starts / before `create_cluster`. When a host `HTTP_PROXY`/`HTTPS_PROXY` is set and Docker is systemd-managed, it writes:

```
/etc/systemd/system/docker.service.d/http-proxy.conf
[Service]
Environment="HTTP_PROXY=<host proxy>"
Environment="HTTPS_PROXY=<host proxy>"
Environment="NO_PROXY=<host NO_PROXY ∪ cluster-internal ranges>"
```

then `systemctl daemon-reload`. Details:
- Reuses `cluster.sh`'s `_augment_no_proxy`; authenticated proxy URLs (`http://user:pass@host:port`) preserved verbatim.
- **Idempotent** (`cmp -s`): only restarts dockerd when the drop-in actually changes, so a re-run never bounces a running k3d cluster.
- Linux/systemd only; macOS Docker Desktop manages its own proxy.

## How it was found
A faithful forced-proxy EC2 repro (client box whose SG egress was locked to a Squid proxy box). On a clean strict host the old installer died at the `rancher/k3s` pull. Dropping the dockerd config by hand let the rest proceed — and confirmed the **#242** chart-values fix end-to-end: `jobs-manager` reached **2/2 Running** and the Squid access log showed `CONNECT api.tracebloc.io:443` from the pods. This PR automates that dockerd step so a clean strict host works unattended.

## Validation
- `shellcheck -x` clean for the new code (remaining infos are pre-existing).
- **+5 bats** (`setup-linux.bats`): writes drop-in with HTTP/HTTPS/NO_PROXY, no-proxy → no-op, non-systemd → no-op, authenticated URL preserved, idempotent → no docker restart. Full suite **25/25**.

Refs #166, #242. Closes #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dockerd startup behavior via systemd drop-ins and optional restarts; misconfiguration could break image pulls, but logic is idempotent and scoped to tagged installer files on Linux/systemd only.
> 
> **Overview**
> Adds **`_configure_docker_proxy`** so the Linux installer configures the **host Docker daemon** (not just shell/k3d/chart) when `HTTP_PROXY`/`HTTPS_PROXY` is set on systemd-managed hosts.
> 
> On proxy detection it writes a tagged `http-proxy.conf` under `docker.service.d` with HTTP/HTTPS/NO_PROXY (reusing `_augment_no_proxy` when available), reloads systemd, and restarts dockerd only if the file changed. If the host proxy is cleared later, it removes **only** installer-managed drop-ins and leaves IT-owned configs alone. **`install_docker_engine`** invokes this **before** `systemctl start docker`, so `k3d` image pulls (e.g. `rancher/k3s`) work on strict proxy-only machines.
> 
> **`setup-linux.bats`** gains coverage for no-op paths, drop-in content, authenticated URLs, idempotency, and stale/foreign drop-in handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 117a9a53eca262618550daa5c64dc3d42a09ede9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->