### PR TITLE
feat(egress-proxy): deploy-time egress-enforcement pre-flight (non-blocking) [client-runtime#104]

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.7.0
-appVersion: "1.7.0"
+version: 1.7.1
+appVersion: "1.7.1"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/egress-enforcement-check.yaml
+++ b/client/templates/egress-enforcement-check.yaml
@@ -1,14 +1,15 @@
-{{- if and (default dict .Values.networkPolicy.training).enabled (not (dig "allowExternalHttps" true .Values.networkPolicy.training)) (dig "enforcementProbeHost" "" .Values.networkPolicy.training) }}
+{{- if and (default dict .Values.networkPolicy.training).enabled (not (dig "allowExternalHttps" true .Values.networkPolicy.training)) (dig "enforcementProbeHost" "1.1.1.1" .Values.networkPolicy.training) }}
 {{- /*
-  Egress-lockdown enforcement pre-flight (SECURITY §8.2 / client-runtime#104).
+  Egress-lockdown enforcement check (SECURITY §8.2 / client-runtime#104).
   Renders ONLY when the lockdown is enabled (allowExternalHttps=false) and a probe
-  host is set. A post-install/post-upgrade hook runs a `tracebloc.io/workload:
-  training`-labelled pod (so the training-egress NetworkPolicy governs it) that
-  curls a canary external host DIRECTLY: blocked => the CNI enforces egress (good);
-  reachable => NOT enforced => the lockdown is a silent no-op. NON-BLOCKING: the
-  probe always exits 0 and just logs a loud warning, so it never fails an
-  install/upgrade (including the hourly auto-upgrade). Set enforcementProbeHost=""
-  to disable (e.g. air-gapped clusters with no external host to test against).
+  host is set. This is a `helm test` hook — run `helm test <release>` after flipping
+  the lockdown to verify it. A `tracebloc.io/workload: training`-labelled pod (so the
+  training-egress NetworkPolicy governs it) curls a canary external host DIRECTLY:
+  blocked => the CNI enforces egress (test PASSES); reachable => NOT enforced => the
+  lockdown is a silent no-op (test FAILS, exit 1). Because it's a test hook it never
+  runs during install/upgrade, so it can NEVER block them or the hourly auto-upgrade.
+  The probe-host default is 1.1.1.1; set enforcementProbeHost="" to disable (e.g.
+  air-gapped clusters with no external host to test against).
 */ -}}
 {{- $host := dig "enforcementProbeHost" "1.1.1.1" .Values.networkPolicy.training }}
 apiVersion: batch/v1
@@ -19,8 +20,7 @@ metadata:
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "5"
+    "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 0
@@ -65,11 +65,11 @@ spec:
                 echo "WARNING  the SECURITY §8.2 lockdown is INACTIVE and training pods can"
                 echo "WARNING  still reach the open internet."
                 echo "WARNING  Fix: enable egress NetworkPolicy on the CNI (Calico/Cilium, or"
-                echo "WARNING  EKS VPC-CNI enableNetworkPolicy=true), then re-run the upgrade."
+                echo "WARNING  EKS VPC-CNI enableNetworkPolicy=true), then re-run 'helm test'."
                 echo "WARNING ================================================================"
-              else
-                echo "OK  egress lockdown verified: direct external egress is blocked (curl -> ${code:-blocked})."
+                exit 1
               fi
+              echo "OK  egress lockdown verified: direct external egress is blocked (curl -> ${code:-blocked})."
               exit 0
           resources:
             requests:

--- a/client/templates/egress-enforcement-check.yaml
+++ b/client/templates/egress-enforcement-check.yaml
@@ -1,0 +1,85 @@
+{{- if and (default dict .Values.networkPolicy.training).enabled (not (dig "allowExternalHttps" true .Values.networkPolicy.training)) (dig "enforcementProbeHost" "" .Values.networkPolicy.training) }}
+{{- /*
+  Egress-lockdown enforcement pre-flight (SECURITY §8.2 / client-runtime#104).
+  Renders ONLY when the lockdown is enabled (allowExternalHttps=false) and a probe
+  host is set. A post-install/post-upgrade hook runs a `tracebloc.io/workload:
+  training`-labelled pod (so the training-egress NetworkPolicy governs it) that
+  curls a canary external host DIRECTLY: blocked => the CNI enforces egress (good);
+  reachable => NOT enforced => the lockdown is a silent no-op. NON-BLOCKING: the
+  probe always exits 0 and just logs a loud warning, so it never fails an
+  install/upgrade (including the hourly auto-upgrade). Set enforcementProbeHost=""
+  to disable (e.g. air-gapped clusters with no external host to test against).
+*/ -}}
+{{- $host := dig "enforcementProbeHost" "1.1.1.1" .Values.networkPolicy.training }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-egress-enforcement-check
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 120
+  template:
+    metadata:
+      labels:
+        {{- include "tracebloc.selectorLabels" . | nindent 8 }}
+        tracebloc.io/workload: training
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        # curlimages/curl's default user is non-numeric (curl_user); runAsNonRoot
+        # can't verify that, so pin the image's uid explicitly.
+        runAsUser: 100
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: probe
+          image: {{ include "tracebloc.image" (dict "repository" "curlimages/curl" "tag" "8.20.0" "digest" "sha256:b3f1fb2a51d923260350d21b8654bbc607164a987e2f7c84a0ac199a67df812a" "registry" "docker.io") | quote }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          command:
+            - sh
+            - -c
+            - |
+              HOST={{ $host | quote }}
+              echo "[egress-enforcement-check] probing direct egress to https://$HOST (must be BLOCKED when the lockdown is enforced)..."
+              code=$(curl --noproxy '*' -s -m 5 -o /dev/null -w '%{http_code}' "https://$HOST" 2>/dev/null || true)
+              if [ -n "$code" ] && [ "$code" != "000" ]; then
+                echo "WARNING ================================================================"
+                echo "WARNING  EGRESS LOCKDOWN NOT ENFORCED on this cluster."
+                echo "WARNING  A tracebloc.io/workload=training pod reached https://$HOST"
+                echo "WARNING  directly (HTTP $code). networkPolicy.training.allowExternalHttps"
+                echo "WARNING  is false, but the CNI is NOT enforcing egress NetworkPolicy, so"
+                echo "WARNING  the SECURITY §8.2 lockdown is INACTIVE and training pods can"
+                echo "WARNING  still reach the open internet."
+                echo "WARNING  Fix: enable egress NetworkPolicy on the CNI (Calico/Cilium, or"
+                echo "WARNING  EKS VPC-CNI enableNetworkPolicy=true), then re-run the upgrade."
+                echo "WARNING ================================================================"
+              else
+                echo "OK  egress lockdown verified: direct external egress is blocked (curl -> ${code:-blocked})."
+              fi
+              exit 0
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
+      {{- if include "tracebloc.useImagePullSecrets" . }}
+      imagePullSecrets:
+        - name: {{ include "tracebloc.registrySecretName" . }}
+      {{- end }}
+{{- end }}

--- a/client/tests/egress_enforcement_check_test.yaml
+++ b/client/tests/egress_enforcement_check_test.yaml
@@ -34,7 +34,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: renders as a post-install/post-upgrade hook Job when the lockdown is enabled
+  - it: renders as a helm test hook Job when the lockdown is enabled
     set:
       networkPolicy:
         training:
@@ -46,7 +46,7 @@ tests:
           of: Job
       - equal:
           path: metadata.annotations["helm.sh/hook"]
-          value: post-install,post-upgrade
+          value: test
       - equal:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
           value: before-hook-creation,hook-succeeded
@@ -76,7 +76,7 @@ tests:
           path: spec.template.spec.automountServiceAccountToken
           value: false
 
-  - it: probes the configured host directly (no proxy) and is non-blocking
+  - it: probes the configured host directly (no proxy) and fails the test on non-enforcement
     set:
       networkPolicy:
         training:
@@ -91,7 +91,7 @@ tests:
           pattern: "curl --noproxy '\\*'"
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: "exit 0"
+          pattern: "exit 1"
 
   - it: pins the curl probe image by digest
     set:

--- a/client/tests/egress_enforcement_check_test.yaml
+++ b/client/tests/egress_enforcement_check_test.yaml
@@ -1,0 +1,104 @@
+suite: Egress-lockdown enforcement pre-flight hook
+# SECURITY §8.2 / client-runtime#104. A post-install/post-upgrade hook that, when
+# the lockdown is enabled (allowExternalHttps=false), runs a training-labelled probe
+# to verify the CNI actually blocks egress — and warns (non-blocking) if it doesn't.
+# Guards: renders ONLY when the lockdown is on + a probe host is set; never otherwise.
+templates:
+  - templates/egress-enforcement-check.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: does NOT render by default (lockdown off — allowExternalHttps defaults true)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does NOT render when training NetworkPolicy is disabled
+    set:
+      networkPolicy:
+        training:
+          enabled: false
+          allowExternalHttps: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does NOT render when the probe host is empty (disabled, e.g. air-gapped)
+    set:
+      networkPolicy:
+        training:
+          allowExternalHttps: false
+          enforcementProbeHost: ""
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders as a post-install/post-upgrade hook Job when the lockdown is enabled
+    set:
+      networkPolicy:
+        training:
+          allowExternalHttps: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+
+  - it: probe pod is training-labelled (so the lockdown netpol governs it) and PSA-restricted
+    set:
+      networkPolicy:
+        training:
+          allowExternalHttps: false
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["tracebloc.io/workload"]
+          value: training
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 100
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: "ALL"
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: probes the configured host directly (no proxy) and is non-blocking
+    set:
+      networkPolicy:
+        training:
+          allowExternalHttps: false
+          enforcementProbeHost: "canary.example.net"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "HOST=.?canary\\.example\\.net"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "curl --noproxy '\\*'"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "exit 0"
+
+  - it: pins the curl probe image by digest
+    set:
+      networkPolicy:
+        training:
+          allowExternalHttps: false
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^docker\\.io/curlimages/curl@sha256:[a-f0-9]{64}$"

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -228,7 +228,7 @@
             },
             "enforcementProbeHost": {
               "type": "string",
-              "description": "Host the enforcement pre-flight hook curls directly (when allowExternalHttps=false) to verify the CNI actually blocks egress; non-enforcement logs a non-blocking warning (client-runtime#104). Empty string disables the check (e.g. air-gapped clusters)."
+              "description": "Host the `helm test` enforcement check curls directly (when allowExternalHttps=false) to verify the CNI blocks egress; non-enforcement fails the test (a test hook never affects install/upgrade) — client-runtime#104. Empty string disables it (e.g. air-gapped clusters)."
             },
             "dnsNamespace": {
               "type": "string",

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -226,6 +226,10 @@
               "default": true,
               "description": "When false, drop the 0.0.0.0/0:443 egress rule so training pods reach only DNS, MySQL, requests-proxy and the egress gateway (SECURITY §8.2 / client-runtime#102). Default true keeps existing behaviour; flip per-fleet after verifying the egress gateway works (G2)."
             },
+            "enforcementProbeHost": {
+              "type": "string",
+              "description": "Host the enforcement pre-flight hook curls directly (when allowExternalHttps=false) to verify the CNI actually blocks egress; non-enforcement logs a non-blocking warning (client-runtime#104). Empty string disables the check (e.g. air-gapped clusters)."
+            },
             "dnsNamespace": {
               "type": "string",
               "default": "kube-system",

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -176,10 +176,11 @@ networkPolicy:
     # nil-guards this key, so a `helm upgrade --reuse-values` from a release
     # predating it keeps the old behaviour (rule present).
     allowExternalHttps: true
-    # client-runtime#104: deploy-time enforcement pre-flight. When the lockdown is
-    # enabled (allowExternalHttps=false), a post-upgrade hook curls this host directly
-    # from a training-labelled pod; if it's reachable the CNI isn't enforcing egress
-    # and the hook logs a loud, non-blocking warning. Set "" to disable (air-gapped).
+    # client-runtime#104: enforcement check, run via `helm test <release>` after
+    # flipping the lockdown (allowExternalHttps=false). The test curls this host
+    # directly from a training-labelled pod; reachable => the CNI isn't enforcing
+    # egress => the test FAILS (a test hook never affects install/upgrade). Set ""
+    # to disable (e.g. air-gapped clusters with no external host to test against).
     enforcementProbeHost: "1.1.1.1"
     dnsNamespace: kube-system
     # CoreDNS pod selector — varies per platform. Override in ci/<platform>-values.yaml.

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -176,6 +176,11 @@ networkPolicy:
     # nil-guards this key, so a `helm upgrade --reuse-values` from a release
     # predating it keeps the old behaviour (rule present).
     allowExternalHttps: true
+    # client-runtime#104: deploy-time enforcement pre-flight. When the lockdown is
+    # enabled (allowExternalHttps=false), a post-upgrade hook curls this host directly
+    # from a training-labelled pod; if it's reachable the CNI isn't enforcing egress
+    # and the hook logs a loud, non-blocking warning. Set "" to disable (air-gapped).
+    enforcementProbeHost: "1.1.1.1"
     dnsNamespace: kube-system
     # CoreDNS pod selector — varies per platform. Override in ci/<platform>-values.yaml.
     # When empty, the template falls back to {k8s-app: kube-dns}, which works


### PR DESCRIPTION
Closes part of **tracebloc/client-runtime#104**. Chart-only.

## Why
The §8.2 lockdown (`networkPolicy.training.allowExternalHttps=false`) only blocks egress on a CNI that **enforces** egress NetworkPolicy. On a non-enforcing CNI (EKS VPC-CNI without `enableNetworkPolicy` — hit live during the #102 dev validation) the flip is a **silent no-op**: the policy renders, training pods still reach the internet, the operator believes they're protected.

## What
A **`helm test` hook** (`templates/egress-enforcement-check.yaml`, annotated `helm.sh/hook: test`) that renders **only when the lockdown is enabled** (`networkPolicy.training.enabled && !allowExternalHttps && enforcementProbeHost`):
- A `tracebloc.io/workload: training`-labelled probe pod (so the real training-egress NetworkPolicy governs it) curls a canary host **directly** (`--noproxy '*'`, 5s timeout).
- **Blocked** → the CNI is enforcing → `OK  egress lockdown verified`, test passes (`exit 0`). **Reachable** → not enforcing → loud `WARNING  EGRESS LOCKDOWN NOT ENFORCED …` and the test **fails** (`exit 1`).
- **Never runs during install/upgrade.** As a test hook it can't fail or block them — including the hourly fleet auto-upgrade. Operators run `helm test <release>` after flipping the lockdown for a clear pass/fail.

## Scope / design
- **Chart-only.** No backend, no client-runtime, no jobs-manager image dependency. Enforcement is treated as a per-fleet **prerequisite**, so no central audit is built — this just gives operators a deliberate pass/fail check when they enable the lockdown.
- **Ships dormant:** gated on the lockdown being on (default off), so it renders nothing on today's fleet and only on clusters that have flipped `allowExternalHttps=false`.
- `networkPolicy.training.enforcementProbeHost` (default `1.1.1.1`; `""` disables — e.g. air-gapped) + schema. Gate `dig`-defaults the host to `1.1.1.1`, so a `--reuse-values` upgrade from a release predating the key still renders the check.
- curl probe image **digest-pinned** (multi-arch amd64+arm64), PSA-restricted, `runAsUser: 100` (curlimages/curl's non-numeric user needs an explicit uid — learned during the #102 EKS probe).
- Chart `1.7.0 → 1.7.1` (version + appVersion lockstep).

## Tests
`helm lint` + `helm unittest` **248/248** — new `egress_enforcement_check_test.yaml` asserts the hook renders **only** when the lockdown is on (+ host set), is absent otherwise (default / training disabled / empty host), carries `helm.sh/hook: test`, and that the probe pod is training-labelled, PSA-restricted, digest-pinned, exits 1 on non-enforcement, and curls the configured host with `--noproxy`.

## e2e (manual, per-fleet)
After enabling `allowExternalHttps=false`, run `helm test <release>`: on a non-enforcing CNI the probe reaches the host and the test **FAILS** with the `WARNING` block; on an enforcing CNI egress is blocked and the test **PASSES** (`OK`). `kubectl logs job/<release>-egress-enforcement-check`.

> Note: drain/sequencing on flip/rollback (the in-flight-pod disruption seen during dev validation) is a separate operational/runbook item, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart-only, dormant by default (`allowExternalHttps` stays true); the probe runs only on explicit `helm test` after lockdown is enabled.
> 
> **Overview**
> Adds an optional **`helm test`** Job that verifies the §8.2 training egress lockdown is actually enforced by the CNI when `networkPolicy.training.allowExternalHttps` is **false**.
> 
> The new template renders only when training NetworkPolicy is enabled, lockdown is on, and `enforcementProbeHost` is non-empty (default **`1.1.1.1`**; **`""`** disables for air-gapped). A **`tracebloc.io/workload: training`** probe curls the host with **`--noproxy`**; blocked egress passes the test, reachable HTTPS **fails** with loud warnings. The Job is annotated **`helm.sh/hook: test`**, so it does not run on install/upgrade—operators run **`helm test`** after flipping the lockdown.
> 
> Also documents **`networkPolicy.training.enforcementProbeHost`** in **`values.yaml`** / **`values.schema.json`**, adds **`egress_enforcement_check_test.yaml`** (render guards, PSA-hardened probe, digest-pinned curl), and bumps the chart to **1.7.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00104c26bdf50eb53a2a14143067b9fc1988ebeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
