### PR TITLE
fix(egress-proxy): probe reports DNS failure distinctly, not as a TCP connect [#104]

### DIFF
--- a/client/templates/egress-enforcement-check.yaml
+++ b/client/templates/egress-enforcement-check.yaml
@@ -61,13 +61,26 @@ spec:
               # TLS/HTTP outcome is irrelevant. -k disables cert verification so probing an
               # IP (or any host whose cert doesn't match) is NOT misread as a block, and the
               # verdict is keyed on curl's EXIT CODE, not the HTTP status: a blocked egress
-              # yields a timeout (28) or connect failure (7), whereas any TLS-/HTTP-layer
-              # outcome (incl. a cert error) means the TCP connect already succeeded.
+              # yields a timeout (28) or connect failure (7); a DNS failure (6) is inconclusive;
+              # any other outcome (incl. a TLS/cert error) means the TCP connect already succeeded.
               curl --noproxy '*' -k -sS -m 5 -o /dev/null "https://$HOST"; rc=$?
-              if [ "$rc" = "28" ] || [ "$rc" = "7" ]; then
-                echo "OK  egress lockdown verified: TCP to ${HOST}:443 could not be established (curl exit $rc) — egress is blocked."
-                exit 0
-              fi
+              case "$rc" in
+                7|28)
+                  # connect refused (7) / timed out (28): the TCP handshake never completed => egress blocked.
+                  echo "OK  egress lockdown verified: TCP to ${HOST}:443 could not be established (curl exit $rc) — egress is blocked."
+                  exit 0
+                  ;;
+                6)
+                  # DNS resolution failed: no TCP connection was attempted, so enforcement can't be judged.
+                  echo "WARNING  egress enforcement INCONCLUSIVE: could not resolve host '${HOST}' (curl exit 6)."
+                  echo "WARNING  No TCP connection was attempted, so the lockdown was NOT verified. Point"
+                  echo "WARNING  networkPolicy.training.enforcementProbeHost at an external IP (e.g. 1.1.1.1)"
+                  echo "WARNING  or fix in-cluster DNS, then re-run 'helm test'."
+                  exit 1
+                  ;;
+              esac
+              # Any other outcome (0 success, or a TLS-/HTTP-layer error such as 35/52/56/60 — all of
+              # which require the TCP connect to have already succeeded) => the host was reached.
               echo "WARNING ================================================================"
               echo "WARNING  EGRESS LOCKDOWN NOT ENFORCED on this cluster."
               echo "WARNING  A tracebloc.io/workload=training pod reached ${HOST}:443 directly"

--- a/client/tests/egress_enforcement_check_test.yaml
+++ b/client/tests/egress_enforcement_check_test.yaml
@@ -94,6 +94,10 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: "rc=\\$\\?"
+      # a DNS failure (curl exit 6) is reported as inconclusive, not as "TCP connect succeeded"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "could not resolve host"
       # ...NOT the HTTP status — the old logic that conflated a TLS failure (code 000) with a block
       - notMatchRegex:
           path: spec.template.spec.containers[0].command[2]


### PR DESCRIPTION
Bugbot follow-up on the v1.7.1 release PR #254 (rolls under the §8.2 egress epic, client-runtime#104). Low severity, message-accuracy. Chart-only.

## Bug
The non-enforcement `WARNING` block (`…reached ${HOST}:443 directly (curl exit $rc; the TCP connect succeeded)`) was printed for **every** curl exit code outside `{7,28}` — including exit **6 (DNS resolution failure)**, where no TCP connection was ever attempted. The output could flatly contradict what happened and mislead troubleshooting.

## Fix
Split the verdict into a `case`:

| curl exit | meaning | verdict |
|---|---|---|
| `7` / `28` | connect refused / timed out — TCP never established | **blocked** → `OK`, exit 0 (pass) |
| `6` | DNS resolution failed — no TCP attempted | **inconclusive** → accurate "could not resolve host" message, exit 1 (fail) |
| else (`0`, or TLS/HTTP-layer `35/52/56/60` — all require a completed TCP connect) | host reached | **not enforced** → exit 1 (fail) |

Exit 6 fails rather than passing, so a broken-DNS cluster never masquerades as "enforced." The default probe host is an IP (`1.1.1.1`), so exit 6 only arises for a hostname probe on a cluster with broken DNS.

## Tests
`helm unittest` **248/248**, lint clean. The suite now also asserts the script reports the DNS case distinctly (`could not resolve host`).

> Chart stays at **1.7.1** (unreleased). After merge to `develop` I'll re-sync `sync/develop-to-main-v1.7.1` so PR #254 carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart-only messaging and probe branching for the §8.2 helm test hook; no runtime auth or data-path changes.
> 
> **Overview**
> The **egress enforcement** `helm test` probe no longer treats **curl exit 6** (DNS resolution failure) like a successful TCP connect to the canary host.
> 
> Verdict logic moves from a simple `{7,28}` check to a **`case` on exit code**: `7`/`28` still mean blocked (pass); **`6` is inconclusive** — it prints a dedicated “could not resolve host” warning, advises using an external IP (e.g. `1.1.1.1`) or fixing DNS, and **fails the test** so broken DNS cannot look like enforcement. All other codes still imply the TCP handshake succeeded and trigger the existing “lockdown not enforced” failure path. Inline comments document the three buckets.
> 
> **Helm unittest** now asserts the rendered script includes **`could not resolve host`** for the DNS branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c1005c7d9e19a96927e7d700d583ba369296cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->