### PR TITLE
test(jobs-manager): lock spawned-job RESOURCE_REQUESTS/LIMITS default at 8Gi

### DIFF
--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -183,3 +183,56 @@ tests:
             value: "false"
           count: 1
 
+  # tracebloc/backend#745: the per-spawned-training-job resource request/limit
+  # the jobs-manager hands to each Job it creates. The chart is the single
+  # effective source of truth — it ALWAYS injects RESOURCE_REQUESTS /
+  # RESOURCE_LIMITS, so client-runtime's jobs_manager.py only falls back to its
+  # own default when they are absent. Pin the rendered value here so the two
+  # cannot silently diverge again, on BOTH containers that receive it
+  # (api + pods-monitor).
+  - it: defaults spawned-job RESOURCE_REQUESTS/LIMITS to cpu=2,memory=8Gi (req==limit => Guaranteed QoS)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_REQUESTS
+            value: "cpu=2,memory=8Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_LIMITS
+            value: "cpu=2,memory=8Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: RESOURCE_REQUESTS
+            value: "cpu=2,memory=8Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: RESOURCE_LIMITS
+            value: "cpu=2,memory=8Gi"
+          count: 1
+
+  - it: lets operators override spawned-job resources via env.RESOURCE_REQUESTS/LIMITS
+    set:
+      env:
+        RESOURCE_REQUESTS: "cpu=4,memory=16Gi"
+        RESOURCE_LIMITS: "cpu=4,memory=16Gi"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_REQUESTS
+            value: "cpu=4,memory=16Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_LIMITS
+            value: "cpu=4,memory=16Gi"
+          count: 1
+


### PR DESCRIPTION
## What

Adds helm-unittest assertions pinning the rendered per-spawned-training-job `RESOURCE_REQUESTS` / `RESOURCE_LIMITS` env to `cpu=2,memory=8Gi` on **both** containers that receive it (`api` + `pods-monitor`), plus an operator-override case.

## Why

The chart is the single **effective** source of truth for these values — `jobs-manager-deployment.yaml` always injects them with a templated `"cpu=2,memory=8Gi"` fallback, and `client-runtime`'s `jobs_manager.py` only falls back to its own default when they're absent. Those two had silently drifted (the chart said 8Gi; the code's dead-code default was ~202Mi request / 20G limit). This guard renders the template and asserts the value so the drift can't recur unnoticed — the "render-and-assert test" called for in tracebloc/backend#745.

The two `contains` blocks per container also guard against one of the template's two RESOURCE_* blocks being edited without the other.

## Test

```
helm unittest -f 'tests/jobs_manager_test.yaml' ./client   # 17 passed
```

## Companion

The actual reconciliation (code fallback → 8Gi) lives in the runtime: tracebloc/client-runtime#111.

Refs tracebloc/backend#745

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no Helm template or runtime behavior is modified in this PR.
> 
> **Overview**
> Adds **helm-unittest** coverage in `jobs_manager_test.yaml` so the jobs-manager chart cannot silently drift from the intended per-spawned-training-job resource env vars.
> 
> New cases **render** `jobs-manager-deployment.yaml` and assert that **`RESOURCE_REQUESTS`** and **`RESOURCE_LIMITS`** default to **`cpu=2,memory=8Gi`** on **both** the api (`containers[0]`) and pods-monitor (`containers[1]`) containers, each emitted **once**. A second test confirms operators can override those values via **`values.env.RESOURCE_REQUESTS`** / **`RESOURCE_LIMITS`**.
> 
> This is a **contract test** for tracebloc/backend#745: the chart is the effective source of truth for what `client-runtime` sees when spawning training Jobs (companion runtime change is elsewhere).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 431fe9d16acb4967a39425f26ae7702e317ede42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->