### PR TITLE
ci: add concurrency cancellation + job timeouts to chart CI

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -16,8 +16,16 @@ on:
       - 'scripts/tests/e2e-auto-upgrade.sh'
       - '.github/workflows/helm-ci.yaml'
 
+concurrency:
+  # Cancel superseded runs on PRs — this is the repo's heaviest workflow
+  # (a real k3d cluster in upgrade-e2e plus two 4-platform matrices). Never
+  # cancel push/schedule runs.
+  group: helm-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
+    timeout-minutes: 10
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +55,7 @@ jobs:
         run: helm lint --strict ./ingestor
 
   template:
+    timeout-minutes: 10
     name: Template render
     runs-on: ubuntu-latest
     strategy:
@@ -81,6 +90,7 @@ jobs:
             /tmp/rendered-${{ matrix.platform }}.yaml
 
   unittest:
+    timeout-minutes: 10
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
@@ -98,6 +108,7 @@ jobs:
         run: helm unittest ./client
 
   schema:
+    timeout-minutes: 10
     name: Schema validation
     runs-on: ubuntu-latest
     strategy:
@@ -119,6 +130,7 @@ jobs:
           echo "Schema validation passed for ${{ matrix.platform }}"
 
   ingestor-multiarch:
+    timeout-minutes: 10
     # Guard: the ingestor image the cluster spawns must be a multi-arch index
     # (linux/amd64 + linux/arm64), or arm64 hosts (Apple Silicon, Graviton)
     # fail data ingestion with "no match for platform" / ImagePullBackOff.
@@ -164,6 +176,7 @@ jobs:
           fi
 
   upgrade-e2e:
+    timeout-minutes: 30
     # Fleet auto-upgrade non-regression gate (client-runtime#102 / #245-class
     # regressions): installs the LAST PUBLISHED chart from gh-pages on a real
     # k3d cluster, then upgrades to THIS working tree via both

--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -28,8 +28,16 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Cancel superseded PR runs — this suite is expensive (9-distro
+  # docker-in-docker matrix + real k3d e2e + Windows Pester). Never cancel
+  # push/schedule runs.
+  group: installer-tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   static:
+    timeout-minutes: 10
     name: Static analysis
     runs-on: ubuntu-latest
     steps:
@@ -73,6 +81,7 @@ jobs:
           Write-Host "no PSScriptAnalyzer errors"
 
   unit-bash:
+    timeout-minutes: 10
     name: bats (bash unit, mocked)
     runs-on: ubuntu-latest
     steps:
@@ -83,6 +92,7 @@ jobs:
         run: bats scripts/tests/*.bats
 
   unit-pester:
+    timeout-minutes: 20
     # Pester on Linux pwsh (fast) AND real Windows — the .ps1 installer's actual
     # target. fail-fast:false so a Windows-only surprise doesn't mask Linux signal.
     name: Pester (${{ matrix.os }})
@@ -108,6 +118,7 @@ jobs:
           Invoke-Pester -Configuration $cfg
 
   distro-prereqs:
+    timeout-minutes: 20
     # Runs the installer's REAL Linux prerequisite path in a fresh container for
     # each distro family. Proves the package-manager / Docker / conntrack / helm
     # branches all resolve and install — the layer where every installer bug we
@@ -142,6 +153,7 @@ jobs:
             bash scripts/tests/distro-prereqs.sh
 
   e2e-cluster:
+    timeout-minutes: 30
     # Highest-fidelity check CI can run: brings up an ACTUAL k3d cluster via the
     # installer's own create_cluster() on a real kernel (Docker is preinstalled
     # on the runner), proves it can schedule + run a public workload, then tears
@@ -160,6 +172,7 @@ jobs:
         run: bash scripts/tests/e2e-cluster.sh
 
   e2e-proxy:
+    timeout-minutes: 30
     # Authenticated corporate-proxy E2E (the Charité/hospital archetype): stands
     # up a squid that REQUIRES basic auth, brings the cluster up with the
     # installer's proxy config pointed at it as user:pass@host, and proves the


### PR DESCRIPTION
## Summary

Adds CI hygiene to the two **most expensive workflows in the repo** — both had no concurrency control or job timeouts.

- **`concurrency`** (per-`github.ref` group) on `helm-ci.yaml` and `installer-tests.yaml`, cancelling superseded **PR** runs only. Push and schedule runs are never cancelled (`cancel-in-progress` gated on `github.event_name == 'pull_request'`). Mirrors the pattern already in `client-runtime`'s `tests.yml`.
- **`timeout-minutes`** on every job (10 for lint/static/unit, 20 for Pester/distro-prereqs, 30 for the real-k3d e2e jobs) so a hung cluster/squid/distro step can't run to the 6h default.

Why these two: `helm-ci.yaml` spins a real k3d cluster (`upgrade-e2e`) plus two 4-platform matrices; `installer-tests.yaml` runs a 9-distro docker-in-docker matrix + real-k3d `e2e-cluster` + Windows Pester. Without `cancel-in-progress`, every PR re-push left the previous full run burning to completion.

## Type
- [x] CI hygiene / cost reduction

## Test plan
- Both files parse as valid YAML (`yaml.safe_load`); all 6 jobs in each now carry `timeout-minutes`; top-level `concurrency` present.
- No behavior change to what the jobs *do* — only scheduling/cancellation and timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
