### PR TITLE
feat(installer): non-interactive credentials + softer connect copy (#834)

### DIFF
--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -216,7 +216,15 @@ install_client_helm() {
   local default_client_id=""
   local default_client_password=""
 
-  if [[ -f "$values_file" ]]; then
+  # Non-interactive credentials (RFC-0001 Phase 0): set TRACEBLOC_CLIENT_ID +
+  # TRACEBLOC_CLIENT_PASSWORD to provision without typing the secret inline
+  # (CI / automation / golden images). Verified the same way as the prompt.
+  local _noninteractive_creds=0
+  if [[ -n "${TRACEBLOC_CLIENT_ID:-}" && -n "${TRACEBLOC_CLIENT_PASSWORD:-}" ]]; then
+    _noninteractive_creds=1
+  fi
+
+  if [[ "$_noninteractive_creds" == 0 && -f "$values_file" ]]; then
     hint "Previous configuration found."
     while true; do
       read -r -p "  Use previous settings as defaults? [Y/n]: " use_existing
@@ -242,11 +250,28 @@ install_client_helm() {
   # ── Step 4/4: Connect to tracebloc network ──────────────────────────────
   step 4 5 "Connect to tracebloc network"
 
-  prompt_header "To connect this machine, you need a tracebloc client."
+  if [[ "$_noninteractive_creds" == 1 ]]; then
+    # Credentials supplied via env — verify once, no prompt, no re-prompt.
+    TB_CLIENT_ID=$(_sanitize_credential "$TRACEBLOC_CLIENT_ID")
+    TB_CLIENT_PASSWORD=$(_sanitize_credential "$TRACEBLOC_CLIENT_PASSWORD")
+    [[ -n "$TB_CLIENT_ID" && -n "$TB_CLIENT_PASSWORD" ]] || \
+      error "TRACEBLOC_CLIENT_ID / TRACEBLOC_CLIENT_PASSWORD must be non-empty."
+    info "Verifying credentials with tracebloc…"
+    case "$(verify_credentials "$TB_CLIENT_ID" "$TB_CLIENT_PASSWORD")" in
+      valid)      success "Credentials verified." ;;
+      invalid)    error "TRACEBLOC_CLIENT_ID / TRACEBLOC_CLIENT_PASSWORD was rejected by tracebloc — check it at https://ai.tracebloc.io/clients and re-run." ;;
+      inactive)   error "This tracebloc account is not active yet. Check your email for the activation link, then re-run." ;;
+      unverified) warn "Couldn't reach tracebloc to verify credentials right now — continuing (the client will stay offline if they are wrong)." ;;
+    esac
+  else
+
+  prompt_header "Connect this machine to a tracebloc client."
   hint "A client links your secure environment to the tracebloc"
   hint "platform so vendors can submit models for evaluation."
   echo ""
-  hint "Create one here (free):"
+  hint "Already have one? Enter its credentials below — or set"
+  hint "TRACEBLOC_CLIENT_ID / TRACEBLOC_CLIENT_PASSWORD to skip this prompt."
+  hint "Need one? Create it (free) at:"
   echo -e "    ${BOLD}${WHITE}https://ai.tracebloc.io/clients${RESET}"
   echo ""
 
@@ -300,6 +325,7 @@ install_client_helm() {
     # Force an active re-entry on retry (don't silently reuse a rejected default).
     default_client_id=""; default_client_password=""
   done
+  fi
 
   # ── One-client-per-machine guard ─────────────────────────────────────────
   # A machine runs exactly one tracebloc client: it shares this cluster and the

--- a/scripts/tests/install-client-helm.bats
+++ b/scripts/tests/install-client-helm.bats
@@ -141,6 +141,38 @@ setup() {
   mock_calls | grep -q "helm upgrade --install tracebloc"
 }
 
+@test "install_client_helm: TRACEBLOC_CLIENT_* env -> non-interactive (no prompt), writes values.yaml + helm" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  verify_credentials() { printf valid; }
+  export TRACEBLOC_CLIENT_ID=envid TRACEBLOC_CLIENT_PASSWORD=envpw
+  run install_client_helm </dev/null    # no stdin: must not prompt
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Credentials verified"* ]]
+  [[ "$output" != *"Client ID:"* ]]
+  grep -q 'clientId: "envid"' "$HOST_DATA_DIR/values.yaml"
+  grep -q "clientPassword: 'envpw'" "$HOST_DATA_DIR/values.yaml"
+  mock_calls | grep -q "helm upgrade --install tracebloc"
+}
+
+@test "install_client_helm: TRACEBLOC_CLIENT_* with rejected creds -> errors, no helm" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  verify_credentials() { printf invalid; }
+  export TRACEBLOC_CLIENT_ID=envid TRACEBLOC_CLIENT_PASSWORD=envpw
+  run install_client_helm </dev/null
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"rejected"* ]]
+  run mock_calls
+  [[ "$output" != *"helm upgrade"* ]]
+}
+
 @test "install_client_helm: points kubeconfig at the client namespace (so the CLI needs no -n)" {
   HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
   _ensure_tracebloc_dirs() { :; }


### PR DESCRIPTION
## Summary

**RFC-0001 Phase 0** (epic backend#830) — the no-backend-dependency installer quick wins. **Part of `tracebloc/backend#834`** (partial — ships env-var credentials + softer copy; the `--token` / `TRACEBLOC_ENROLL_TOKEN` enrollment token and full removal of the create-a-client step need backend work and land in a later phase).

1. **Non-interactive credentials** — accept `TRACEBLOC_CLIENT_ID` / `TRACEBLOC_CLIENT_PASSWORD` so CI / automation / golden images can provision **without typing the secret inline**. They're verified exactly like the prompt (`verify_credentials`), and a bad credential fails the install (no re-prompt in non-interactive mode). The interactive prompt path is **unchanged** — it's just moved into the `else` branch.
2. **Softer "connect" copy** — stop framing client-creation as a mandatory pre-step ("to connect this machine you *need* a client / create one") and reframe to "already have one? enter it (or set the env vars) — need one? create it." Browser sign-in replaces this entirely in Phase 1.

## Why now

Phase 0 needs no backend work and removes the two sharpest onboarding pain points immediately: a secret typed into a `curl | bash` process, and the forced detour to `/clients`.

## Test plan

- ✅ `bash -n` clean.
- ✅ Two new bats cases: env creds → non-interactive (no prompt), writes `values.yaml`, runs helm; rejected env creds → errors, no helm.
- ✅ The interactive flow tests all still pass unchanged (re-prompt-on-invalid, inactive→error, unverified→proceeds, dev-mode values-file, defaults reuse, max-attempts, one-client guard).

⚠️ **Pre-existing, not from this PR:** bats `#16 _extract_yaml_value: single-quoted with '' escape` fails in my local run (macOS bash). The diff doesn't touch `_extract_yaml_value` (confirmed — 0 occurrences in the diff), so it's a pre-existing failure; flagging so it's not attributed here, and worth confirming against CI / a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

