### PR TITLE
chore(chart): bump client 1.7.1 → 1.8.0 (version + appVersion)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.7.1
-appVersion: "1.7.1"
+version: 1.8.0
+appVersion: "1.8.0"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
Version bump for the **v1.8.0** chart release. Promotes the 9 commits merged to `develop` since v1.7.1 (2026-06-15). Must land on `develop` before the `Sync develop → main` PR.

Bumps `client/Chart.yaml` `version` **and** `appVersion` 1.7.1 → 1.8.0 in lockstep (the `app.kubernetes.io/version` label cluster-info reads tracks `appVersion`).

**Minor, not patch:** #262 places datasets on a network mount while MySQL stays local — a real change to PVC placement at install time, so this batch is not inert like v1.7.0/v1.7.1.

Part of #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only chart version metadata changes in this diff; install-time risk from bundled v1.8.0 behavior lives in other commits on the release branch, not in this file.
> 
> **Overview**
> Bumps **`client/Chart.yaml`** **`version`** and **`appVersion`** from **1.7.1** to **1.8.0** in lockstep for the v1.8.0 chart release. **`appVersion`** drives the **`app.kubernetes.io/version`** label used by cluster-info.
> 
> This PR is metadata-only in the diff; it tags the chart release that packages recent **`develop`** work (including dataset PVC placement changes referenced in the release notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 887cee19136cb55d0cc15e8336b283b31d748662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->