### PR TITLE
Sync develop → main for v1.8.0 chart release (network-mount datasets, backend-reachability test, installer hardening)

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -16,8 +16,16 @@ on:
       - 'scripts/tests/e2e-auto-upgrade.sh'
       - '.github/workflows/helm-ci.yaml'
 
+concurrency:
+  # Cancel superseded runs on PRs — this is the repo's heaviest workflow
+  # (a real k3d cluster in upgrade-e2e plus two 4-platform matrices). Never
+  # cancel push/schedule runs.
+  group: helm-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
+    timeout-minutes: 10
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +55,7 @@ jobs:
         run: helm lint --strict ./ingestor
 
   template:
+    timeout-minutes: 10
     name: Template render
     runs-on: ubuntu-latest
     strategy:
@@ -81,6 +90,7 @@ jobs:
             /tmp/rendered-${{ matrix.platform }}.yaml
 
   unittest:
+    timeout-minutes: 10
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
@@ -98,6 +108,7 @@ jobs:
         run: helm unittest ./client
 
   schema:
+    timeout-minutes: 10
     name: Schema validation
     runs-on: ubuntu-latest
     strategy:
@@ -119,6 +130,7 @@ jobs:
           echo "Schema validation passed for ${{ matrix.platform }}"
 
   ingestor-multiarch:
+    timeout-minutes: 10
     # Guard: the ingestor image the cluster spawns must be a multi-arch index
     # (linux/amd64 + linux/arm64), or arm64 hosts (Apple Silicon, Graviton)
     # fail data ingestion with "no match for platform" / ImagePullBackOff.
@@ -164,6 +176,7 @@ jobs:
           fi
 
   upgrade-e2e:
+    timeout-minutes: 30
     # Fleet auto-upgrade non-regression gate (client-runtime#102 / #245-class
     # regressions): installs the LAST PUBLISHED chart from gh-pages on a real
     # k3d cluster, then upgrades to THIS working tree via both

--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -28,8 +28,16 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Cancel superseded PR runs — this suite is expensive (9-distro
+  # docker-in-docker matrix + real k3d e2e + Windows Pester). Never cancel
+  # push/schedule runs.
+  group: installer-tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   static:
+    timeout-minutes: 10
     name: Static analysis
     runs-on: ubuntu-latest
     steps:
@@ -73,6 +81,7 @@ jobs:
           Write-Host "no PSScriptAnalyzer errors"
 
   unit-bash:
+    timeout-minutes: 10
     name: bats (bash unit, mocked)
     runs-on: ubuntu-latest
     steps:
@@ -83,6 +92,7 @@ jobs:
         run: bats scripts/tests/*.bats
 
   unit-pester:
+    timeout-minutes: 20
     # Pester on Linux pwsh (fast) AND real Windows — the .ps1 installer's actual
     # target. fail-fast:false so a Windows-only surprise doesn't mask Linux signal.
     name: Pester (${{ matrix.os }})
@@ -108,6 +118,7 @@ jobs:
           Invoke-Pester -Configuration $cfg
 
   distro-prereqs:
+    timeout-minutes: 20
     # Runs the installer's REAL Linux prerequisite path in a fresh container for
     # each distro family. Proves the package-manager / Docker / conntrack / helm
     # branches all resolve and install — the layer where every installer bug we
@@ -142,6 +153,7 @@ jobs:
             bash scripts/tests/distro-prereqs.sh
 
   e2e-cluster:
+    timeout-minutes: 30
     # Highest-fidelity check CI can run: brings up an ACTUAL k3d cluster via the
     # installer's own create_cluster() on a real kernel (Docker is preinstalled
     # on the runner), proves it can schedule + run a public workload, then tears
@@ -160,6 +172,7 @@ jobs:
         run: bash scripts/tests/e2e-cluster.sh
 
   e2e-proxy:
+    timeout-minutes: 30
     # Authenticated corporate-proxy E2E (the Charité/hospital archetype): stands
     # up a squid that REQUIRES basic auth, brings the cluster up with the
     # installer's proxy config pointed at it as user:pass@host, and proves the

--- a/.github/workflows/public-pii-gate-caller.yml
+++ b/.github/workflows/public-pii-gate-caller.yml
@@ -1,0 +1,14 @@
+name: Public PII gate
+
+# Per-repo caller for the public-repo PII gate. Blocks PRs whose title/body/
+# commits contain a denylisted customer/partner name or known secret.
+# Logic lives in tracebloc/.github/.github/workflows/public-pii-gate.yml.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  pii-gate:
+    uses: tracebloc/.github/.github/workflows/public-pii-gate.yml@main
+    secrets: inherit

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.7.1
-appVersion: "1.7.1"
+version: 1.8.0
+appVersion: "1.8.0"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -67,6 +67,20 @@ client-pvc
 {{ .Values.pvc.data | default "50Gi" }}
 {{- end }}
 
+{{/*
+  hostPath base for the DATASET (shared-images) PV ONLY. Defaults to the
+  historical local path /tracebloc so installs without a network dataset mount
+  render byte-identically. When the installer bind-mounts a customer network
+  (NFS) dir at /tracebloc-data (HOST_DATASET_DIR set), it passes
+  hostPath.datasetPath=/tracebloc-data to relocate datasets onto that mount,
+  while mysql + logs ALWAYS stay on the local /tracebloc tree (InnoDB over NFS
+  is unsafe — backend#743). The /<release>/data suffix is appended here.
+  Nil-guarded (default dict) for `--reuse-values` upgrades predating this key.
+*/}}
+{{- define "tracebloc.clientDataHostPath" -}}
+{{ printf "%s/%s/data" ((default dict .Values.hostPath).datasetPath | default "/tracebloc") .Release.Name }}
+{{- end -}}
+
 {{- define "tracebloc.clientLogsPvc" -}}
 client-logs-pvc
 {{- end }}

--- a/client/templates/egress-reachability-check.yaml
+++ b/client/templates/egress-reachability-check.yaml
@@ -73,21 +73,25 @@ spec:
                 *)   HOST="api.tracebloc.io" ;;
               esac
               echo "[egress-reachability-check] CLIENT_ENV=$CLIENT_ENV -> probing backend reachability to https://${HOST}/ (through the proxy if one is configured)..."
-              # Key the verdict on curl's EXIT CODE, not the HTTP status: we only
-              # care whether the TCP+TLS connection to the backend can be made.
-              # No-egress yields connect-refused (7) or timeout (28); a DNS/proxy
-              # resolution failure (6/5) means the host can't be found. Any other
-              # outcome (0, or a TLS/HTTP-layer code) means the connection already
-              # succeeded => the backend is reachable.
+              # Key the verdict on curl's EXIT CODE, not the HTTP status. With no
+              # --fail, curl exits 0 for ANY HTTP response (200/401/404/5xx), so a
+              # 0 exit is the only outcome that proves a full TCP+TLS+HTTP round
+              # trip — the backend is genuinely reachable AND usable. Every
+              # non-zero code is a transport/TLS failure, so we fail closed on it:
+              # connect-refused (7) / timeout (28) = egress blocked; DNS/proxy
+              # resolve (6/5) = host can't be found; a TLS handshake/cert error
+              # (35/51/60/…) = reached the host but TLS is broken (commonly a proxy
+              # intercepting TLS with an untrusted CA), so the API is unusable.
               curl -sS -m 10 -o /dev/null "https://${HOST}/"; rc=$?
               case "$rc" in
+                0)  echo "OK  backend reachable: completed an HTTPS request to ${HOST}:443 (curl exit 0) — the cluster can reach the tracebloc backend."; exit 0 ;;
                 5)  echo "FAIL  could not resolve the configured proxy (curl exit 5) — check HTTP_PROXY settings."; exit 1 ;;
                 6)  echo "FAIL  could not resolve ${HOST} (curl exit 6) — in-cluster DNS or egress is broken."; exit 1 ;;
                 7)  echo "FAIL  connection to ${HOST}:443 refused (curl exit 7) — no egress route to the tracebloc backend."; exit 1 ;;
                 28) echo "FAIL  connection to ${HOST}:443 timed out (curl exit 28) — egress blocked by a firewall/proxy/NetworkPolicy. Experiments can't start without backend egress."; exit 1 ;;
+                35|51|53|58|59|60|66|77|83|91) echo "FAIL  reached ${HOST}:443 but the TLS handshake/certificate check failed (curl exit $rc) — commonly a corporate proxy intercepting TLS with a CA the cluster doesn't trust. The backend API is unusable until that CA is trusted; experiments can't authenticate."; exit 1 ;;
+                *)  echo "FAIL  could not complete an HTTPS request to ${HOST}:443 (curl exit $rc) — backend egress is not working."; exit 1 ;;
               esac
-              echo "OK  backend reachable: connected to ${HOST}:443 (curl exit $rc) — the cluster can reach the tracebloc backend."
-              exit 0
           resources:
             requests:
               cpu: "10m"

--- a/client/templates/egress-reachability-check.yaml
+++ b/client/templates/egress-reachability-check.yaml
@@ -1,0 +1,102 @@
+{{- if dig "enabled" true (default dict .Values.egressReachabilityCheck) }}
+{{- /*
+  In-cluster backend-reachability check (client-runtime#116 WS3 / cli#90).
+  A `helm test` hook: run `helm test <release>` to verify a normal (non-training)
+  pod in this namespace can reach the tracebloc backend API. This is the egress
+  dependency that gates EVERYTHING — the cluster authenticates to the backend to
+  obtain its Service Bus credentials, so if the backend is unreachable from inside
+  the cluster, experiments never start (they sit in Pending). It is the required-
+  egress complement to egress-enforcement-check, which verifies the opposite:
+  that *training* pods are locked OUT.
+
+  Service Bus itself is intentionally NOT probed here: its host is fetched
+  post-auth from the backend (static nowhere in the chart) and its egress is
+  brokered by the requests-proxy, whose readiness `tracebloc cluster doctor`
+  already checks. Reaching the backend is the prerequisite for both.
+
+  The probe pod is deliberately NOT labelled `tracebloc.io/workload: training`, so
+  the training-egress lockdown never selects it — it shares the egress class of
+  the jobs-manager / requests-proxy (the pods that actually reach the backend),
+  and honours the corporate proxy via tracebloc.proxyEnv, so it tests the real
+  path. As a test hook it never runs during install/upgrade, so it can never
+  block them or the hourly auto-upgrade. Set egressReachabilityCheck.enabled=false
+  to disable (e.g. a truly air-gapped cluster with no route to the backend).
+*/ -}}
+{{- $env := .Values.env.CLIENT_ENV | default "prod" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-egress-reachability-check
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 120
+  template:
+    metadata:
+      labels:
+        {{- include "tracebloc.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        # curlimages/curl's default user is non-numeric (curl_user); runAsNonRoot
+        # can't verify that, so pin the image's uid explicitly.
+        runAsUser: 100
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: probe
+          image: {{ include "tracebloc.image" (dict "repository" "curlimages/curl" "tag" "8.20.0" "digest" "sha256:b3f1fb2a51d923260350d21b8654bbc607164a987e2f7c84a0ac199a67df812a" "registry" "docker.io") | quote }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          env:
+            {{- include "tracebloc.proxyEnv" . | nindent 12 }}
+            - name: CLIENT_ENV
+              value: {{ $env | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              case "$CLIENT_ENV" in
+                dev) HOST="dev-api.tracebloc.io" ;;
+                stg) HOST="stg-api.tracebloc.io" ;;
+                *)   HOST="api.tracebloc.io" ;;
+              esac
+              echo "[egress-reachability-check] CLIENT_ENV=$CLIENT_ENV -> probing backend reachability to https://${HOST}/ (through the proxy if one is configured)..."
+              # Key the verdict on curl's EXIT CODE, not the HTTP status: we only
+              # care whether the TCP+TLS connection to the backend can be made.
+              # No-egress yields connect-refused (7) or timeout (28); a DNS/proxy
+              # resolution failure (6/5) means the host can't be found. Any other
+              # outcome (0, or a TLS/HTTP-layer code) means the connection already
+              # succeeded => the backend is reachable.
+              curl -sS -m 10 -o /dev/null "https://${HOST}/"; rc=$?
+              case "$rc" in
+                5)  echo "FAIL  could not resolve the configured proxy (curl exit 5) — check HTTP_PROXY settings."; exit 1 ;;
+                6)  echo "FAIL  could not resolve ${HOST} (curl exit 6) — in-cluster DNS or egress is broken."; exit 1 ;;
+                7)  echo "FAIL  connection to ${HOST}:443 refused (curl exit 7) — no egress route to the tracebloc backend."; exit 1 ;;
+                28) echo "FAIL  connection to ${HOST}:443 timed out (curl exit 28) — egress blocked by a firewall/proxy/NetworkPolicy. Experiments can't start without backend egress."; exit 1 ;;
+              esac
+              echo "OK  backend reachable: connected to ${HOST}:443 (curl exit $rc) — the cluster can reach the tracebloc backend."
+              exit 0
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
+      {{- if include "tracebloc.useImagePullSecrets" . }}
+      imagePullSecrets:
+        - name: {{ include "tracebloc.registrySecretName" . }}
+      {{- end }}
+{{- end }}

--- a/client/templates/shared-images-pvc.yaml
+++ b/client/templates/shared-images-pvc.yaml
@@ -17,7 +17,7 @@ spec:
     name: {{ $name }}
     namespace: {{ .Release.Namespace }}
   hostPath:
-    path: /tracebloc/{{ .Release.Name }}/data
+    path: {{ include "tracebloc.clientDataHostPath" . }}
     type: DirectoryOrCreate
 ---
 {{- end }}

--- a/client/tests/egress_reachability_check_test.yaml
+++ b/client/tests/egress_reachability_check_test.yaml
@@ -1,0 +1,64 @@
+suite: In-cluster backend-reachability check
+# client-runtime#116 WS3 / cli#90. A `helm test` Job that verifies a normal
+# (non-training) pod can reach the tracebloc backend — the egress dependency
+# that gates everything. These guards pin: the on/off flag, the test-hook
+# annotation (so it never runs during install/upgrade), that the probe is NOT
+# labelled as a training workload (so the lockdown netpol never selects it and
+# it keeps the jobs-manager/requests-proxy egress class), and that the probed
+# backend tracks CLIENT_ENV.
+templates:
+  - templates/egress-reachability-check.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: renders a single helm-test Job by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+
+  - it: does not render when disabled
+    set:
+      egressReachabilityCheck.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is NOT labelled as a training workload (keeps its own egress)
+    asserts:
+      - notExists:
+          path: spec.template.metadata.labels["tracebloc.io/workload"]
+
+  - it: defaults the probe to the prod backend
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLIENT_ENV
+            value: prod
+
+  - it: targets the dev backend when CLIENT_ENV=dev
+    set:
+      env.CLIENT_ENV: dev
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLIENT_ENV
+            value: dev
+
+  - it: inherits the corporate proxy env so it tests the real egress path
+    set:
+      env.HTTP_PROXY_HOST: proxy.corp
+      env.HTTP_PROXY_PORT: "3128"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_PROXY
+            value: http://proxy.corp:3128

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -183,3 +183,56 @@ tests:
             value: "false"
           count: 1
 
+  # tracebloc/backend#745: the per-spawned-training-job resource request/limit
+  # the jobs-manager hands to each Job it creates. The chart is the single
+  # effective source of truth — it ALWAYS injects RESOURCE_REQUESTS /
+  # RESOURCE_LIMITS, so client-runtime's jobs_manager.py only falls back to its
+  # own default when they are absent. Pin the rendered value here so the two
+  # cannot silently diverge again, on BOTH containers that receive it
+  # (api + pods-monitor).
+  - it: defaults spawned-job RESOURCE_REQUESTS/LIMITS to cpu=2,memory=8Gi (req==limit => Guaranteed QoS)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_REQUESTS
+            value: "cpu=2,memory=8Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_LIMITS
+            value: "cpu=2,memory=8Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: RESOURCE_REQUESTS
+            value: "cpu=2,memory=8Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: RESOURCE_LIMITS
+            value: "cpu=2,memory=8Gi"
+          count: 1
+
+  - it: lets operators override spawned-job resources via env.RESOURCE_REQUESTS/LIMITS
+    set:
+      env:
+        RESOURCE_REQUESTS: "cpu=4,memory=16Gi"
+        RESOURCE_LIMITS: "cpu=4,memory=16Gi"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_REQUESTS
+            value: "cpu=4,memory=16Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_LIMITS
+            value: "cpu=4,memory=16Gi"
+          count: 1
+

--- a/client/tests/logs_pvc_test.yaml
+++ b/client/tests/logs_pvc_test.yaml
@@ -195,3 +195,18 @@ tests:
           path: spec.storageClassName
           value: existing-sc
         documentIndex: 1
+
+  # backend#743: the dataset storage split (hostPath.datasetPath) must NOT move
+  # the logs PV — logs stay on the local /tracebloc tree.
+  - it: hostPath.datasetPath leaves the logs PV on the local path
+    set:
+      hostPath:
+        enabled: true
+        datasetPath: /tracebloc-data
+    release:
+      name: my-release
+    asserts:
+      - equal:
+          path: spec.hostPath.path
+          value: /tracebloc/my-release/logs
+        documentIndex: 0

--- a/client/tests/mysql_storage_pvc_test.yaml
+++ b/client/tests/mysql_storage_pvc_test.yaml
@@ -175,3 +175,16 @@ tests:
       - equal:
           path: spec.capacity.storage
           value: 8Gi
+
+  # backend#743: the dataset storage split (hostPath.datasetPath) must NOT move
+  # the mysql PV — InnoDB stays on the local /tracebloc tree.
+  - it: hostPath.datasetPath leaves the mysql PV on the local path
+    set:
+      hostPath:
+        enabled: true
+        datasetPath: /tracebloc-data
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.hostPath.path
+          value: /tracebloc/stg/mysql

--- a/client/tests/shared_images_pvc_test.yaml
+++ b/client/tests/shared_images_pvc_test.yaml
@@ -1,0 +1,105 @@
+suite: Client Data (shared-images) PVC
+# Covers templates/shared-images-pvc.yaml — the dataset (shared training data)
+# PV/PVC. backend#743 parameterized the dataset PV's hostPath base
+# (hostPath.datasetPath) so datasets can live on a separate network mount while
+# mysql + logs stay on the local /tracebloc tree. Locks down:
+#   - the dynamic-PVC-only path (managed default) is unaffected
+#   - the default hostPath is byte-identical to before (/tracebloc/<release>/data)
+#   - hostPath.datasetPath relocates ONLY this (dataset) PV
+#   - the helper nil-guards a --reuse-values upgrade predating datasetPath
+templates:
+  - templates/shared-images-pvc.yaml
+release:
+  name: stg
+  namespace: tracebloc
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  # --- dynamic PVC only (managed clusters, the default) ---
+  - it: renders only the PVC when hostPath.enabled is false (default)
+    set:
+      hostPath:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: client-pvc
+
+  # --- hostPath PV + PVC pair (bare-metal) ---
+  - it: renders PV + PVC when hostPath.enabled is true
+    set:
+      hostPath:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: PersistentVolume
+        documentIndex: 0
+      - isKind:
+          of: PersistentVolumeClaim
+        documentIndex: 1
+
+  # --- backend#743: dataset PV hostPath parameterization ---
+  - it: dataset PV defaults to the local /tracebloc path (backward compat)
+    set:
+      hostPath:
+        enabled: true
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.hostPath.path
+          value: /tracebloc/stg/data
+      - equal:
+          path: spec.hostPath.type
+          value: DirectoryOrCreate
+
+  - it: hostPath.datasetPath relocates the dataset PV onto the network mount
+    set:
+      hostPath:
+        enabled: true
+        datasetPath: /tracebloc-data
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.hostPath.path
+          value: /tracebloc-data/stg/data
+
+  - it: PV is hard-bound to the client-pvc via claimRef
+    set:
+      hostPath:
+        enabled: true
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.claimRef.name
+          value: client-pvc
+      - equal:
+          path: spec.claimRef.namespace
+          value: tracebloc
+
+  - it: dataset PV advertises the configured data capacity
+    set:
+      hostPath:
+        enabled: true
+      pvc:
+        data: 100Gi
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.capacity.storage
+          value: 100Gi
+
+  - it: PVC carries the resource-policy keep annotation so datasets survive uninstall
+    set:
+      hostPath:
+        enabled: false
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -93,6 +93,11 @@
         "enabled": {
           "type": "boolean",
           "description": "Enable hostPath PVs (bare-metal only). PV paths are fixed: /tracebloc/data, /tracebloc/logs, /tracebloc/mysql. Directories are created via hostPath type: DirectoryOrCreate."
+        },
+        "datasetPath": {
+          "type": "string",
+          "default": "/tracebloc",
+          "description": "Base host path for the DATASET (shared-images) PV ONLY. Default /tracebloc keeps datasets local alongside mysql/logs; the installer sets /tracebloc-data when a customer network (NFS) dataset mount is provided via HOST_DATASET_DIR (backend#743). mysql + logs PV paths always stay on /tracebloc. The chart appends /<release>/data."
         }
       }
     },

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -205,6 +205,18 @@ networkPolicy:
       - "172.16.0.0/12"
       - "192.168.0.0/16"
 
+# -- In-cluster backend-reachability check (client-runtime#116 WS3 / cli#90).
+# A `helm test` Job that verifies a normal (non-training) pod in this namespace
+# can reach the tracebloc backend API — the egress dependency that gates
+# everything (the cluster authenticates to the backend to obtain its Service Bus
+# credentials, so no backend egress => experiments sit in Pending). It is the
+# required-egress complement to networkPolicy.training.enforcementProbeHost
+# (which verifies the opposite: that training pods are locked out). As a test
+# hook it never runs during install/upgrade. Set enabled=false on a truly
+# air-gapped cluster with no route to the backend.
+egressReachabilityCheck:
+  enabled: true
+
 # -- Egress gateway (squid) — SECURITY §8.2 / client-runtime#102.
 # In-cluster forward proxy that lets a locked-down training pod reach an FQDN
 # allowlist (backend + App Insights) and nothing else. Labelled app=egress-proxy

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -60,6 +60,13 @@ storageClass:
 hostPath:
   enabled: false
   # PV paths are fixed: /tracebloc/data, /tracebloc/logs, /tracebloc/mysql (→ ~/.tracebloc/{data,logs,mysql} when HOST_DATA_DIR is mounted at /tracebloc). Directories are created automatically via hostPath type: DirectoryOrCreate.
+  # Base host path for the DATASET PV ONLY (shared training data). Default
+  # /tracebloc keeps datasets on the local mount alongside mysql/logs. The
+  # installer sets this to /tracebloc-data when a customer network (NFS) dataset
+  # mount is provided via HOST_DATASET_DIR (backend#743) — mysql + logs ALWAYS
+  # stay on the local /tracebloc tree (InnoDB over NFS is unsafe). The chart
+  # appends /<release>/data. mysql/logs PV paths are not affected by this key.
+  datasetPath: /tracebloc
 
 # -- PVC storage sizes (override per-environment if needed)
 pvc:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -257,6 +257,7 @@ helm install my-tracebloc tracebloc/client -n tracebloc -f my-values.yaml
 - [ ] Platform-specific options set (e.g. `storageClass`, `hostPath` for bare-metal, OpenShift `openshift.scc`).
 - [ ] Namespace created or `--create-namespace` used.
 - [ ] Resource requests/limits and storage sizes reviewed in `values.yaml` (e.g. `pvc.mysql`, `pvc.logs`, `pvc.data`).
+- [ ] **MySQL storage is on a LOCAL disk.** The k3d installer's `HOST_DATA_DIR` (and the chart's mysql/logs hostPath) must be local — MySQL/InnoDB corrupts on NFS/CIFS, and the installer preflight fails fast if it is on a network filesystem. To keep large datasets on a network mount, point the installer's `HOST_DATASET_DIR` at that mount: only the dataset volume moves there; MySQL + logs stay local (backend#743).
 - [ ] Lint and template checked: `helm lint ./client -f my-values.yaml` and `helm template my-tracebloc ./client -f my-values.yaml`.
 
 ---

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -267,6 +267,8 @@ The chart does **not** set `runAsUser` on training pods. Training images declare
 
 When `hostPath.enabled: true`, the PVCs backing `/data/shared`, `/data/logs`, and MySQL data are rooted at `/tracebloc/<release>/*` on the node filesystem. Training pods still mount those volumes through the PVC abstraction — the read-only enforcement applies. Operators should be aware that compromising the node directly (outside of tracebloc's threat model) gives filesystem-level access to the same data.
 
+**Network-mounted datasets (backend#743).** MySQL/InnoDB must stay on a local disk — file-locking and `O_DIRECT` over NFS are unsafe — so the installer preflight fails fast when `HOST_DATA_DIR` is on a network filesystem (override: `TRACEBLOC_ALLOW_NETWORK_FS=1`). Large datasets may instead live on a customer network (NFS) mount via `HOST_DATASET_DIR`: only the dataset PV base path (`hostPath.datasetPath`, mounted at `/data/shared`) is relocated there, while mysql + logs stay on the local `/tracebloc` tree. Under NFS `root_squash` a non-admin researcher has access only as their own uid and cannot grant the fixed uid `999` access, so the installer passes the host user's uid/gid to jobs-manager, which runs spawned **ingestion** pods as that uid — dataset writes then land as the user who owns the export, with no chown and no root mapping. Training pods still mount `/data/shared` read-only and keep their arbitrary-UID posture (§5.3); only the ingestion writer is pinned to the host uid.
+
 ---
 
 ## 6. What operators must do themselves

--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -18,7 +18,7 @@
 #    $env:SERVERS       = "1"              default: 1  (control-plane nodes)
 #    $env:AGENTS        = "1"              default: 1  (worker nodes)
 #    $env:K8S_VERSION   = "v1.29.4-k3s1"  default: latest
-#    $env:HOST_DATA_DIR = "C:\data"        default: $env:USERPROFILE\.tracebloc
+#    $env:HOST_DATA_DIR = "C:\data"        default: $env:USERPROFILE\.tracebloc (LOCAL disk; no NFS/UNC)
 #    $env:CLIENT_ENV    = "dev"            optional; if not set, CLIENT_ENV is not added to env in values
 # =============================================================================
 
@@ -1409,6 +1409,21 @@ function Get-PfFreeGb {
   } catch { return $null }
 }
 
+# "network" if $HOST_DATA_DIR is on a UNC path or a mapped network drive
+# (Win32_LogicalDisk DriveType 4); "local" otherwise; $null if undeterminable
+# (e.g. non-Windows under Pester - tests mock this). Mirrors preflight.sh
+# _pf_storage_type: MySQL/InnoDB corrupts or crash-loops on network storage.
+function Get-PfFsType {
+  try {
+    if ($HOST_DATA_DIR -like '\\*') { return "network" }   # UNC path (\\server\share)
+    $qualifier = (Split-Path -Qualifier $HOST_DATA_DIR -ErrorAction SilentlyContinue)
+    if (-not $qualifier) { return "local" }                # no drive letter, not UNC
+    $d = Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='$qualifier'" -ErrorAction Stop
+    if ($d.DriveType -eq 4) { return "network" }           # DriveType 4 = network drive
+    return "local"
+  } catch { return $null }
+}
+
 # Memory/CPU as the container runtime sees it (the Docker Desktop / WSL2 VM budget,
 # which is what the pods actually get — smaller than the host). $null if the daemon
 # is down or the value is junk, so callers fall back to the host (CIM) reader.
@@ -1487,6 +1502,22 @@ function Test-Preflight {
   elseif  ($disk -lt $minDiskGb)   { Write-PfFail "Disk: only $disk GB free - need >= $minDiskGb GB."; $hardFail++; Hint "Free up space or attach a larger disk, then re-run." }
   elseif  ($disk -lt $warnDiskGb)  { Warn "Disk: $disk GB free - recommended >= $warnDiskGb GB; images + data may fill it." }
   else                             { Ok "Disk: $disk GB free" }
+
+  # Network-FS guard: MySQL/InnoDB corrupts or crash-loops on NFS/CIFS/SMB. Fail
+  # fast instead of a cryptic CrashLoopBackOff ~20 min in. (Mirrors preflight.sh.)
+  $fs = Get-PfFsType
+  if     ($null -eq $fs)      { Info "Storage: filesystem type undetermined; assuming local." }
+  elseif ($fs -eq "network") {
+    if ($env:TRACEBLOC_ALLOW_NETWORK_FS) {
+      Warn "Storage: $HOST_DATA_DIR is on a network filesystem - proceeding (TRACEBLOC_ALLOW_NETWORK_FS set); the client database may corrupt or crash-loop."
+    } else {
+      Write-PfFail "Storage: $HOST_DATA_DIR is on a network filesystem - the tracebloc client database (MySQL/InnoDB) corrupts or crash-loops on network storage."
+      $hardFail++
+      Hint "Fix: point HOST_DATA_DIR at a LOCAL disk (the default $env:USERPROFILE\.tracebloc is local)."
+      Hint "  (or set `$env:TRACEBLOC_ALLOW_NETWORK_FS=1 to proceed anyway - not recommended for the database.)"
+    }
+  }
+  else                       { Ok "Storage: $HOST_DATA_DIR local disk" }
 
   Info "Checking outbound connectivity to required services..."
   $backendHost = (Get-BackendUrl) -replace '^https?://','' -replace '/$',''

--- a/scripts/install-k8s.ps1
+++ b/scripts/install-k8s.ps1
@@ -130,6 +130,12 @@ $SERVERS       = if ($env:SERVERS)       { $env:SERVERS }       else { "1" }
 $AGENTS        = if ($env:AGENTS)        { $env:AGENTS }        else { "1" }
 $K8S_VERSION   = if ($env:K8S_VERSION)   { $env:K8S_VERSION }   else { "v1.29.4-k3s1" }
 $HOST_DATA_DIR = if ($env:HOST_DATA_DIR) { $env:HOST_DATA_DIR } else { "$env:USERPROFILE\.tracebloc" }
+# backend#743: optional separate dir for the big dataset volume. Empty (default)
+# keeps datasets under HOST_DATA_DIR. When set, it is bind-mounted at
+# /tracebloc-data and the chart's dataset PV points there (mysql + logs stay
+# local). The host-uid ingestion mechanism for root_squash NFS is Linux-only; on
+# Windows k3d runs in a Linux VM where Docker Desktop handles mount ownership.
+$HOST_DATASET_DIR = if ($env:HOST_DATASET_DIR) { $env:HOST_DATASET_DIR } else { "" }
 $CLIENT_ENV    = $env:CLIENT_ENV
 
 $GPU_VENDOR       = "none"
@@ -193,6 +199,29 @@ function Confirm-Config {
     }
   }
   $script:HOST_DATA_DIR = $dataDir
+
+  # backend#743: optional dataset dir. Unlike HOST_DATA_DIR it MAY live outside
+  # USERPROFILE (a separate / network drive). It must already EXIST and be
+  # writable; we never create a network-share root. System paths stay barred.
+  if ($HOST_DATASET_DIR) {
+    $dsDir = [System.IO.Path]::GetFullPath($HOST_DATASET_DIR)
+    if (-not (Test-Path $dsDir -PathType Container)) {
+      Err ("HOST_DATASET_DIR does not exist: " + $HOST_DATASET_DIR + " (mount the dataset volume before installing)")
+    }
+    try {
+      $probe = Join-Path $dsDir (".tb-write-" + [guid]::NewGuid().ToString("N"))
+      New-Item -ItemType File -Path $probe -ErrorAction Stop | Out-Null
+      Remove-Item $probe -Force -ErrorAction SilentlyContinue
+    } catch {
+      Err ("HOST_DATASET_DIR is not writable: " + $HOST_DATASET_DIR)
+    }
+    foreach ($f in $forbidden) {
+      if ($f -and $dsDir.StartsWith([System.IO.Path]::GetFullPath($f), [StringComparison]::OrdinalIgnoreCase)) {
+        Err ("HOST_DATASET_DIR cannot be a system path: " + $HOST_DATASET_DIR)
+      }
+    }
+    $script:HOST_DATASET_DIR = $dsDir
+  }
 }
 
 # =============================================================================
@@ -802,6 +831,24 @@ function New-K3dCluster {
         Hint "  k3d cluster delete $CLUSTER_NAME  (then re-run this installer)."
       }
     } catch {}
+
+    # backend#743: the dataset bind mount (HOST_DATASET_DIR -> /tracebloc-data)
+    # is baked into the k3d nodes at create time; k3d can't add it to a running
+    # cluster. Re-using an existing cluster without it would point the chart's
+    # datasetPath PV at ephemeral in-node storage (datasets lost on a restart)
+    # instead of the network export. Fail fast with the recreate remedy.
+    if ($HOST_DATASET_DIR) {
+      $dsMounts = ""
+      try { $dsMounts = (docker inspect "k3d-$CLUSTER_NAME-server-0" --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>$null | Out-String) } catch {}
+      if ($dsMounts -and ($dsMounts -notmatch '(?m)^/tracebloc-data\s*$')) {
+        Warn "HOST_DATASET_DIR is set, but the existing '$CLUSTER_NAME' cluster has no /tracebloc-data bind mount."
+        Hint "k3d bakes bind mounts in at create time - they can't be added to a running cluster. Re-using this"
+        Hint "cluster would put datasets on ephemeral in-node storage (lost on a restart), not your network export."
+        Hint "Recreate the cluster so the dataset volume is bound (data under HOST_DATASET_DIR is untouched):"
+        Hint "  k3d cluster delete $CLUSTER_NAME   (then re-run this installer)."
+        Err "Existing cluster is missing the dataset bind mount - refusing to install datasets onto ephemeral storage."
+      }
+    }
   } else {
     if (-not (Test-Path $HOST_DATA_DIR)) {
       New-Item -ItemType Directory -Path $HOST_DATA_DIR -Force | Out-Null
@@ -822,6 +869,11 @@ function New-K3dCluster {
       "--k3s-arg", "--disable=local-storage@server:*",
       "--wait"
     )
+
+    # backend#743: bind-mount the customer dataset volume at a distinct cluster
+    # path so the chart's dataset PV points there while mysql + logs stay on the
+    # local /tracebloc tree. No-op when unset.
+    if ($HOST_DATASET_DIR) { $k3dArgs += @("-v", "${HOST_DATASET_DIR}:/tracebloc-data@all") }
 
     if ($K8S_VERSION -ne "" -and $K8S_VERSION -ne "latest") { $k3dArgs += @("--image", "rancher/k3s:$K8S_VERSION") }
     if ($K3D_GPU_FLAG -ne "") {
@@ -1161,6 +1213,8 @@ function Install-ClientHelm {
   if ($CLIENT_ENV) {
     $envBlock += "  CLIENT_ENV: $CLIENT_ENV`n"
   }
+  # backend#743: relocate the dataset PV onto the network mount when HOST_DATASET_DIR is set.
+  $datasetPathLine = if ($HOST_DATASET_DIR) { "`n  datasetPath: /tracebloc-data" } else { "" }
   $envBlock += @"
   RESOURCE_LIMITS: "cpu=2,memory=8Gi"
   RESOURCE_REQUESTS: "cpu=2,memory=8Gi"
@@ -1176,7 +1230,7 @@ storageClass:
   parameters: {}
 
 hostPath:
-  enabled: true
+  enabled: true$datasetPathLine
 
 pvc:
   mysql: 2Gi

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -27,8 +27,13 @@ _cluster_exists() {
 # Ensure host dirs exist so /tracebloc/data, /tracebloc/logs, /tracebloc/mysql exist inside nodes (HOST_DATA_DIR is mounted as /tracebloc).
 # Only chmod the container data subdirs; do not make HOST_DATA_DIR or files like values.yaml world-readable.
 _ensure_tracebloc_dirs() {
-  mkdir -p "$HOST_DATA_DIR" "$HOST_DATA_DIR/data" "$HOST_DATA_DIR/logs" "$HOST_DATA_DIR/mysql"
-  chmod -R 777 "$HOST_DATA_DIR/data" "$HOST_DATA_DIR/logs" "$HOST_DATA_DIR/mysql" 2>/dev/null || true
+  mkdir -p "$HOST_DATA_DIR" "$HOST_DATA_DIR/logs" "$HOST_DATA_DIR/mysql"
+  chmod -R 777 "$HOST_DATA_DIR/logs" "$HOST_DATA_DIR/mysql" 2>/dev/null || true
+  # backend#743: the dataset dir goes under HOST_DATASET_DIR (a network mount,
+  # bind-mounted at /tracebloc-data) when set, else stays local under HOST_DATA_DIR.
+  local data_base="${HOST_DATASET_DIR:-$HOST_DATA_DIR}"
+  mkdir -p "$data_base/data"
+  chmod -R 777 "$data_base/data" 2>/dev/null || true
 }
 
 # Pre-create the per-release host dirs the chart's hostPath PVs bind to.
@@ -41,8 +46,14 @@ _ensure_release_dirs() {
   local release="$1"
   [[ -z "$release" ]] && return 0
   local base="$HOST_DATA_DIR/$release"
-  mkdir -p "$base/data" "$base/logs" "$base/mysql"
-  chmod -R 777 "$base/data" "$base/logs" "$base/mysql" 2>/dev/null || true
+  mkdir -p "$base/logs" "$base/mysql"
+  chmod -R 777 "$base/logs" "$base/mysql" 2>/dev/null || true
+  # backend#743: dataset dir goes under HOST_DATASET_DIR (network mount) when set,
+  # else stays local. mysql + logs always stay on the local HOST_DATA_DIR.
+  local data_base="${HOST_DATASET_DIR:+$HOST_DATASET_DIR/$release}"
+  data_base="${data_base:-$base}"
+  mkdir -p "$data_base/data"
+  chmod -R 777 "$data_base/data" 2>/dev/null || true
 }
 
 # --- Corporate-proxy support (authenticated proxies + NO_PROXY hardening) ----
@@ -189,6 +200,7 @@ _handle_existing_cluster() {
 
   _check_existing_cluster_proxy
   _check_existing_cluster_bind
+  _check_existing_cluster_dataset_mount
 }
 
 # k3d bakes proxy env into containers at create time; it cannot be added to a
@@ -244,6 +256,32 @@ _check_existing_cluster_bind() {
   fi
 }
 
+# backend#743: the dataset bind mount (HOST_DATASET_DIR -> /tracebloc-data) is
+# baked into the k3d nodes at create time (_create_new_cluster). k3d cannot add
+# a bind mount to a RUNNING cluster, so re-using an existing cluster that lacks
+# it would point the chart's `datasetPath: /tracebloc-data` PV at ephemeral
+# in-node storage — datasets would silently land on disposable storage instead
+# of the network export and vanish on a restart. Fail fast with the recreate
+# remedy rather than installing a quietly-misrouted dataset volume. No-op when
+# HOST_DATASET_DIR is unset or the node can't be inspected.
+_check_existing_cluster_dataset_mount() {
+  [[ -z "${HOST_DATASET_DIR:-}" ]] && return 0
+  local mounts
+  mounts=$(docker inspect "k3d-${CLUSTER_NAME}-server-0" \
+    --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null) || return 0
+  [[ -z "$mounts" ]] && return 0
+  if ! grep -qx '/tracebloc-data' <<<"$mounts"; then
+    echo ""
+    warn "HOST_DATASET_DIR is set, but the existing '$CLUSTER_NAME' cluster has no /tracebloc-data bind mount."
+    hint "k3d bakes bind mounts in at create time — they can't be added to a running cluster. Re-using this"
+    hint "cluster would put datasets on ephemeral in-node storage (lost on a restart), not your network export."
+    hint "Recreate the cluster so the dataset volume is bound (data under HOST_DATASET_DIR is untouched):"
+    hint "  k3d cluster delete $CLUSTER_NAME   &&   re-run this installer."
+    echo ""
+    error "Existing cluster is missing the dataset bind mount — refusing to install datasets onto ephemeral storage."
+  fi
+}
+
 _create_new_cluster() {
   # The tracebloc client is outbound-only: jobs-manager + pods-monitor dial out
   # to the platform, and the only in-cluster Service (mysql-client) is ClusterIP.
@@ -267,6 +305,11 @@ _create_new_cluster() {
     --k3s-arg "--disable=local-storage@server:*"
     --wait
   )
+
+  # backend#743: bind-mount the customer's dataset volume (which may be a network
+  # mount) at a DISTINCT cluster path so the chart's dataset PV can point there
+  # while mysql + logs stay on the local /tracebloc tree. No-op when unset.
+  [[ -n "${HOST_DATASET_DIR:-}" ]] && K3D_ARGS+=(-v "${HOST_DATASET_DIR}:/tracebloc-data@all")
 
   [[ -n "$K8S_VERSION" && "$K8S_VERSION" != "latest" ]] && K3D_ARGS+=(--image "rancher/k3s:${K8S_VERSION}")
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -248,6 +248,12 @@ AGENTS="${AGENTS:-1}"
 # Pinned default; set K8S_VERSION="" to use latest (may break on new k3s releases)
 K8S_VERSION="${K8S_VERSION:-v1.29.4-k3s1}"
 HOST_DATA_DIR="${HOST_DATA_DIR:-$HOME/.tracebloc}"
+# Optional separate host dir for the big DATASET volume (backend#743). Empty
+# (default) keeps datasets under HOST_DATA_DIR. When set — e.g. a network/NFS
+# mount like /data01/tracebloc — the installer bind-mounts it into the cluster
+# at /tracebloc-data and the chart's dataset PV points there, while mysql + logs
+# stay on the local HOST_DATA_DIR (InnoDB over NFS is unsafe).
+HOST_DATASET_DIR="${HOST_DATASET_DIR:-}"
 
 # ── Input validation ────────────────────────────────────────────────────────
 validate_config() {
@@ -278,6 +284,24 @@ validate_config() {
   [[ "$dir" != "$HOME" && "${dir#$HOME/}" == "$dir" ]] && \
     error "HOST_DATA_DIR must be under \$HOME (got: $HOST_DATA_DIR)"
   HOST_DATA_DIR="$dir"
+
+  # Optional dataset dir (backend#743): unlike HOST_DATA_DIR it MAY live outside
+  # $HOME (a mounted network volume like /data01). It must already EXIST and be
+  # WRITABLE as the host user — we never mkdir a network-share root — and is
+  # barred from system paths. The HOST_DATA_DIR rules above are unchanged.
+  if [[ -n "${HOST_DATASET_DIR:-}" ]]; then
+    local ddir="$HOST_DATASET_DIR" rddir
+    [[ "$ddir" == /* ]] || error "HOST_DATASET_DIR must be an absolute path (got '$HOST_DATASET_DIR')"
+    [[ -d "$ddir" ]]    || error "HOST_DATASET_DIR does not exist: $ddir (mount the dataset volume before installing)"
+    [[ -w "$ddir" ]]    || error "HOST_DATASET_DIR is not writable by $(id -un) (uid $(id -u)): $ddir"
+    rddir="$(cd -P "$ddir" 2>/dev/null && pwd)" || error "HOST_DATASET_DIR could not be resolved: $ddir"
+    case "$rddir" in
+      /) error "HOST_DATASET_DIR cannot be root (/)" ;;
+      /etc|/etc/*|/usr|/usr/*|/var|/var/*|/bin|/sbin|/lib|/lib64)
+        error "HOST_DATASET_DIR cannot be a system path: $rddir" ;;
+    esac
+    HOST_DATASET_DIR="$rddir"
+  fi
 }
 
 # ── Runtime globals ──────────────────────────────────────────────────────────

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -376,6 +376,8 @@ Advanced configuration (environment variables):
   AGENTS         Worker nodes                    (default: 1)
   K8S_VERSION    k3s image tag                   (default: v1.29.4-k3s1)
   HOST_DATA_DIR  Persistent data directory       (default: ~/.tracebloc)
+                 Must be on a LOCAL disk — NFS/CIFS/SMB is rejected (the database
+                 corrupts on network storage). TRACEBLOC_ALLOW_NETWORK_FS=1 overrides.
 
 Windows:
   irm https://raw.githubusercontent.com/tracebloc/client/main/scripts/install.ps1 | iex

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -380,7 +380,7 @@ $([ -n "${CLIENT_ENV:-}" ] && printf '  CLIENT_ENV: "%s"\n' "$CLIENT_ENV")${prox
   # a Pending GPU pod is downgraded to CPU rather than waiting for a GPU node
   # that will never arrive.
   SINGLE_NODE: "true"
-
+$([ -n "${HOST_DATASET_DIR:-}" ] && printf '  HOST_UID: "%s"\n  HOST_GID: "%s"\n' "$(id -u)" "$(id -g)")
 storageClass:
   create: true
   name: client-storage-class
@@ -390,7 +390,7 @@ storageClass:
 
 hostPath:
   enabled: true
-
+$([ -n "${HOST_DATASET_DIR:-}" ] && printf '  datasetPath: /tracebloc-data\n')
 pvc:
   mysql: 2Gi
   logs: 10Gi

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -216,7 +216,15 @@ install_client_helm() {
   local default_client_id=""
   local default_client_password=""
 
-  if [[ -f "$values_file" ]]; then
+  # Non-interactive credentials (RFC-0001 Phase 0): set TRACEBLOC_CLIENT_ID +
+  # TRACEBLOC_CLIENT_PASSWORD to provision without typing the secret inline
+  # (CI / automation / golden images). Verified the same way as the prompt.
+  local _noninteractive_creds=0
+  if [[ -n "${TRACEBLOC_CLIENT_ID:-}" && -n "${TRACEBLOC_CLIENT_PASSWORD:-}" ]]; then
+    _noninteractive_creds=1
+  fi
+
+  if [[ "$_noninteractive_creds" == 0 && -f "$values_file" ]]; then
     hint "Previous configuration found."
     while true; do
       read -r -p "  Use previous settings as defaults? [Y/n]: " use_existing
@@ -242,11 +250,28 @@ install_client_helm() {
   # ── Step 4/4: Connect to tracebloc network ──────────────────────────────
   step 4 5 "Connect to tracebloc network"
 
-  prompt_header "To connect this machine, you need a tracebloc client."
+  if [[ "$_noninteractive_creds" == 1 ]]; then
+    # Credentials supplied via env — verify once, no prompt, no re-prompt.
+    TB_CLIENT_ID=$(_sanitize_credential "$TRACEBLOC_CLIENT_ID")
+    TB_CLIENT_PASSWORD=$(_sanitize_credential "$TRACEBLOC_CLIENT_PASSWORD")
+    [[ -n "$TB_CLIENT_ID" && -n "$TB_CLIENT_PASSWORD" ]] || \
+      error "TRACEBLOC_CLIENT_ID / TRACEBLOC_CLIENT_PASSWORD must be non-empty."
+    info "Verifying credentials with tracebloc…"
+    case "$(verify_credentials "$TB_CLIENT_ID" "$TB_CLIENT_PASSWORD")" in
+      valid)      success "Credentials verified." ;;
+      invalid)    error "TRACEBLOC_CLIENT_ID / TRACEBLOC_CLIENT_PASSWORD was rejected by tracebloc — check it at https://ai.tracebloc.io/clients and re-run." ;;
+      inactive)   error "This tracebloc account is not active yet. Check your email for the activation link, then re-run." ;;
+      unverified) warn "Couldn't reach tracebloc to verify credentials right now — continuing (the client will stay offline if they are wrong)." ;;
+    esac
+  else
+
+  prompt_header "Connect this machine to a tracebloc client."
   hint "A client links your secure environment to the tracebloc"
   hint "platform so vendors can submit models for evaluation."
   echo ""
-  hint "Create one here (free):"
+  hint "Already have one? Enter its credentials below — or set"
+  hint "TRACEBLOC_CLIENT_ID / TRACEBLOC_CLIENT_PASSWORD to skip this prompt."
+  hint "Need one? Create it (free) at:"
   echo -e "    ${BOLD}${WHITE}https://ai.tracebloc.io/clients${RESET}"
   echo ""
 
@@ -300,6 +325,7 @@ install_client_helm() {
     # Force an active re-entry on retry (don't silently reuse a rejected default).
     default_client_id=""; default_client_password=""
   done
+  fi
 
   # ── One-client-per-machine guard ─────────────────────────────────────────
   # A machine runs exactly one tracebloc client: it shares this cluster and the

--- a/scripts/lib/preflight.sh
+++ b/scripts/lib/preflight.sh
@@ -10,6 +10,7 @@
 #  Escape hatches:
 #    TRACEBLOC_SKIP_PREFLIGHT=1   skip all checks
 #    TRACEBLOC_ALLOW_ARM64=1      proceed on arm64 despite amd64-only images
+#    TRACEBLOC_ALLOW_NETWORK_FS=1 proceed when HOST_DATA_DIR is on NFS/CIFS/SMB (DB may corrupt)
 #    PF_MIN_MEM_GB / PF_MIN_CPU / PF_MIN_DISK_GB   lower the hard floors (CI / odd sites)
 #
 #  This file is side-effect-safe to source (defaults + function defs only).
@@ -57,6 +58,32 @@ _pf_probe_url() {
 
 # Free space in KB on the filesystem holding $1.
 _pf_free_kb() { df -Pk "$1" 2>/dev/null | awk 'NR==2 {print $4}'; }
+
+# Filesystem type holding $1, lower-cased (e.g. ext4, xfs, apfs, overlay, nfs,
+# nfs4, cifs, smbfs), or empty if undeterminable. $1 may not exist yet at
+# preflight, so walk up to the nearest existing parent. Tries findmnt (util-linux,
+# bind-mount aware), then GNU `stat -f` (Linux only — BSD/macOS `stat -f` means
+# "format string", not filesystem), then df+mount (portable, incl. macOS).
+_pf_fstype() {
+  local p="$1" parent t="" mp
+  while [[ -n "$p" && ! -e "$p" ]]; do
+    parent="$(dirname "$p")"
+    [[ "$parent" == "$p" ]] && break
+    p="$parent"
+  done
+  [[ -z "$p" || ! -e "$p" ]] && return 0
+  if has findmnt; then
+    t="$(findmnt -nro FSTYPE --target "$p" 2>/dev/null | head -1)"
+  fi
+  if [[ -z "$t" && "$OS" != "Darwin" ]]; then
+    t="$(stat -f -c '%T' "$p" 2>/dev/null)"
+  fi
+  if [[ -z "$t" ]] && has df; then
+    mp="$(df "$p" 2>/dev/null | awk 'NR>1 && $NF ~ /^\// {print $NF}' | tail -1)"
+    [[ -n "$mp" ]] && t="$(mount 2>/dev/null | awk -v m="$mp" 'index($0," on "m" (")>0 {sub(/.* \(/,""); sub(/[,)].*/,""); print; exit}')"
+  fi
+  printf '%s' "$t" | tr '[:upper:]' '[:lower:]'
+}
 
 # Memory/CPU as the CONTAINER RUNTIME sees it (the budget the pods actually get).
 # On Docker Desktop / Colima / WSL2 this is the VM's allocation — smaller than the
@@ -255,6 +282,37 @@ _pf_disk() {
   return 0
 }
 
+# Network-filesystem guard for HOST_DATA_DIR. MySQL/InnoDB corrupts or crash-loops
+# on NFS/CIFS/SMB (broken POSIX locking + unsafe O_DIRECT/fsync), and the chart's
+# root chown init-container is blocked by NFS root_squash — so a network data dir
+# fails ~20 min in with a cryptic CrashLoopBackOff. Catch it in seconds here.
+_pf_storage_type() {
+  local target fstype
+  target="${HOST_DATA_DIR:-$HOME/.tracebloc}"
+  fstype="$(_pf_fstype "$target")"
+  if [[ -z "$fstype" ]]; then
+    info "Storage: ${target} — filesystem type undetermined; assuming local."
+    return 0
+  fi
+  case "$fstype" in
+    nfs|nfs3|nfs4|nfsd|cifs|smb|smbfs|smb2|smb3|afpfs|9p|ncpfs|gfs|gfs2|ocfs2|lustre|glusterfs|fuse.glusterfs|ceph|fuse.ceph|beegfs|fuse.sshfs|fuse.s3fs|davfs|fuse.davfs|webdav|fuse.rclone)
+      if [[ -n "${TRACEBLOC_ALLOW_NETWORK_FS:-}" ]]; then
+        warn "Storage: ${target} is on a network filesystem (${fstype}) — proceeding (TRACEBLOC_ALLOW_NETWORK_FS set); the client database may corrupt or crash-loop on network storage."
+        return 0
+      fi
+      _pf_fail_line "Storage: ${target} is on a network filesystem (${fstype}) — the tracebloc client database (MySQL/InnoDB) corrupts or crash-loops on network storage, and NFS root_squash blocks data-dir setup."
+      PF_HARD_FAIL=$(( ${PF_HARD_FAIL:-0} + 1 ))
+      hint "Fix: point HOST_DATA_DIR at a LOCAL disk — the default ~/.tracebloc is local:"
+      hint "  HOST_DATA_DIR=\"\$HOME/.tracebloc\" ./install-k8s.sh"
+      hint "  (or set TRACEBLOC_ALLOW_NETWORK_FS=1 to proceed anyway — not recommended for the database.)"
+      ;;
+    *)
+      success "Storage: ${target} (${fstype})"
+      ;;
+  esac
+  return 0
+}
+
 _pf_connectivity() {
   info "Checking outbound connectivity to required services..."
   # Can't probe without curl — and on the direct ./install-k8s.sh path the
@@ -330,6 +388,7 @@ run_preflight() {
   _pf_cpu          || true
   _pf_memory       || true
   _pf_disk         || true
+  _pf_storage_type || true
   _pf_connectivity || true
 
   if [[ "$PF_HARD_FAIL" -gt 0 ]]; then

--- a/scripts/lib/preflight.sh
+++ b/scripts/lib/preflight.sh
@@ -310,6 +310,12 @@ _pf_storage_type() {
       success "Storage: ${target} (${fstype})"
       ;;
   esac
+  # backend#743: datasets MAY live on a network mount (HOST_DATASET_DIR) — only
+  # the database dir (HOST_DATA_DIR, checked above) must be local. Note it, never fail.
+  if [[ -n "${HOST_DATASET_DIR:-}" ]]; then
+    local dfstype; dfstype="$(_pf_fstype "$HOST_DATASET_DIR")"
+    info "Dataset dir: ${HOST_DATASET_DIR}${dfstype:+ (${dfstype})} — network mounts are supported here (the database stays on local disk)."
+  fi
   return 0
 }
 

--- a/scripts/tests/cluster.bats
+++ b/scripts/tests/cluster.bats
@@ -124,6 +124,40 @@ setup() {
   [[ "$output" != *"--config"* ]]
 }
 
+# ── HOST_DATASET_DIR: second bind-mount + dataset dir split (backend#743) ────
+@test "_create_new_cluster: HOST_DATASET_DIR unset -> single /tracebloc mount" {
+  run _create_new_cluster
+  [ "$status" -eq 0 ]
+  run mock_calls
+  [[ "$output" == *"${HOST_DATA_DIR}:/tracebloc@all"* ]]
+  [[ "$output" != *"/tracebloc-data@all"* ]]
+}
+
+@test "_create_new_cluster: HOST_DATASET_DIR set -> adds a distinct /tracebloc-data mount" {
+  HOST_DATASET_DIR="$BATS_TEST_TMPDIR/ds"; mkdir -p "$HOST_DATASET_DIR"
+  run _create_new_cluster
+  [ "$status" -eq 0 ]
+  run mock_calls
+  [[ "$output" == *"${HOST_DATA_DIR}:/tracebloc@all"* ]]                 # mysql/logs stay local
+  [[ "$output" == *"${HOST_DATASET_DIR}:/tracebloc-data@all"* ]]         # datasets on the mount
+}
+
+@test "_ensure_release_dirs: HOST_DATASET_DIR set -> data on dataset dir, mysql+logs local" {
+  HOST_DATASET_DIR="$BATS_TEST_TMPDIR/ds"; mkdir -p "$HOST_DATASET_DIR"
+  _ensure_release_dirs tracebloc
+  [ -d "$HOST_DATASET_DIR/tracebloc/data" ]    # dataset on the (network) mount
+  [ -d "$HOST_DATA_DIR/tracebloc/logs" ]       # logs stay local
+  [ -d "$HOST_DATA_DIR/tracebloc/mysql" ]      # mysql stays local
+  [ ! -d "$HOST_DATA_DIR/tracebloc/data" ]     # data NOT created on the local tree
+}
+
+@test "_ensure_release_dirs: HOST_DATASET_DIR unset -> data stays local (unchanged)" {
+  _ensure_release_dirs tracebloc
+  [ -d "$HOST_DATA_DIR/tracebloc/data" ]
+  [ -d "$HOST_DATA_DIR/tracebloc/logs" ]
+  [ -d "$HOST_DATA_DIR/tracebloc/mysql" ]
+}
+
 # ── _check_existing_cluster_bind (Gap C) ────────────────────────────────────
 @test "_check_existing_cluster_bind: 0.0.0.0 bind -> warns (created outside installer)" {
   docker() { echo "0.0.0.0 0.0.0.0 "; }
@@ -159,6 +193,41 @@ setup() {
   docker() { echo "PATH=/usr/bin"; }                      # HTTP_PROXY not baked
   run _check_existing_cluster_proxy
   [[ "$output" == *"missing: HTTP_PROXY"* ]]
+}
+
+# ── _check_existing_cluster_dataset_mount (backend#743) ─────────────────────
+@test "_check_existing_cluster_dataset_mount: HOST_DATASET_DIR unset -> no-op" {
+  unset HOST_DATASET_DIR
+  docker() { echo "/should-not-be-read"; }
+  run _check_existing_cluster_dataset_mount
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "_check_existing_cluster_dataset_mount: /tracebloc-data mount present -> silent pass" {
+  HOST_DATASET_DIR=/mnt/nfs/datasets
+  docker() { printf '%s\n' /tracebloc /tracebloc-data; }
+  run _check_existing_cluster_dataset_mount
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "_check_existing_cluster_dataset_mount: mount ABSENT -> fail fast (no ephemeral datasets)" {
+  HOST_DATASET_DIR=/mnt/nfs/datasets
+  docker() { printf '%s\n' /tracebloc; }                  # no /tracebloc-data bind
+  run _check_existing_cluster_dataset_mount
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no /tracebloc-data bind mount"* ]]
+  [[ "$output" == *"ephemeral"* ]]
+  [[ "$output" == *"k3d cluster delete"* ]]
+}
+
+@test "_check_existing_cluster_dataset_mount: inspect fails -> silent no-op" {
+  HOST_DATASET_DIR=/mnt/nfs/datasets
+  docker() { return 1; }
+  run _check_existing_cluster_dataset_mount
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 }
 
 # ── ensure_cluster_autostart (reboot persistence) ───────────────────────────

--- a/scripts/tests/common.bats
+++ b/scripts/tests/common.bats
@@ -40,6 +40,47 @@ setup() {
   [[ "$output" == *"HOST_DATA_DIR"* ]]
 }
 
+# ── validate_config: HOST_DATASET_DIR (backend#743) ──────────────────────────
+# Resolve HOME to its physical path so the HOST_DATA_DIR under-$HOME check (which
+# uses cd -P) is not tripped by macOS's /var -> /private/var symlink (Linux/CI
+# has none). The dataset dir itself MAY live outside $HOME — that's the point.
+@test "validate_config: HOST_DATASET_DIR outside HOME but existing+writable -> passes" {
+  HOME="$(cd -P "$BATS_TEST_TMPDIR" && pwd)"; USER=tester
+  CLUSTER_NAME=ok; SERVERS=1; AGENTS=1; HOST_DATA_DIR="$HOME/.tracebloc"
+  HOST_DATASET_DIR="$HOME/dataset-mount"; mkdir -p "$HOST_DATASET_DIR"
+  run validate_config
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_config: HOST_DATASET_DIR does not exist -> error (never mkdir a share root)" {
+  HOME="$(cd -P "$BATS_TEST_TMPDIR" && pwd)"; USER=tester
+  CLUSTER_NAME=ok; SERVERS=1; AGENTS=1; HOST_DATA_DIR="$HOME/.tracebloc"
+  HOST_DATASET_DIR="$HOME/nope-$$"
+  run validate_config
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "validate_config: HOST_DATASET_DIR not writable -> error" {
+  [[ "$(id -u)" -eq 0 ]] && skip "root bypasses filesystem permission bits"
+  HOME="$(cd -P "$BATS_TEST_TMPDIR" && pwd)"; USER=tester
+  CLUSTER_NAME=ok; SERVERS=1; AGENTS=1; HOST_DATA_DIR="$HOME/.tracebloc"
+  HOST_DATASET_DIR="$HOME/ro-mount"; mkdir -p "$HOST_DATASET_DIR"; chmod 555 "$HOST_DATASET_DIR"
+  run validate_config
+  chmod 755 "$HOST_DATASET_DIR"   # restore so bats can clean up the tmpdir
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not writable"* ]]
+}
+
+@test "validate_config: HOST_DATA_DIR still rejected outside HOME when dataset dir is set" {
+  HOME="$(cd -P "$BATS_TEST_TMPDIR" && pwd)"; USER=tester
+  CLUSTER_NAME=ok; SERVERS=1; AGENTS=1; HOST_DATA_DIR="/tmp/not-under-home-$$"
+  HOST_DATASET_DIR="$HOME/dataset-mount"; mkdir -p "$HOST_DATASET_DIR"
+  run validate_config
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"HOST_DATA_DIR"* ]]
+}
+
 # ── install_cleanup: the CLIENT_STATE guard (#716) ─────────────────────────
 @test "install_cleanup: exit 0 -> silent" {
   out="$( ( exit 0 ); install_cleanup 2>&1 )"

--- a/scripts/tests/e2e-proxy.sh
+++ b/scripts/tests/e2e-proxy.sh
@@ -124,7 +124,10 @@ kubectl get pods -o wide
 # ── 3. prove the node's image pull actually traversed the AUTHED proxy ───────
 echo "── squid access log: the node's authenticated image-pull traffic ──"
 plog="$(docker exec "$SQUID_NAME" cat /var/log/squid/access.log 2>/dev/null || true)"
-echo "$plog" | grep -E 'CONNECT' | grep "$PROXY_USER" | grep -E 'docker' | tail -8 | sed 's/^/    /'
+# Diagnostic preview only. `|| true` is load-bearing: with no matching lines the
+# first grep exits 1 and, under `set -euo pipefail`, would kill the script HERE —
+# before the real assertion just below could report the actual reason.
+echo "$plog" | grep -E 'CONNECT' | grep "$PROXY_USER" | grep -E 'docker' | tail -8 | sed 's/^/    /' || true
 # auth.docker.io is fetched only by a real image pull (the node getting a pull
 # token) — never by the readiness probe to /v2/, which stops at the 401. So an
 # authenticated CONNECT to it proves the NODE pulled through the proxy (not just
@@ -151,10 +154,26 @@ fi
 #     ingestion Job);
 #   * with that env unset the same call bypasses the squid / dials direct (the
 #     pre-fix Job — in a real proxy-only network like Charité that direct dial is
-#     refused with [Errno 111]; here the node has direct egress, so we assert the
-#     *absence* of a proxied CONNECT).
+#     refused with [Errno 111]; here the env-unset call simply reaches the backend
+#     stand-in directly, and we assert the *absence* of a proxied CONNECT).
+#
+# HERMETIC (no external network I/O): the "backend" both calls target is a
+# reserved-TLD stand-in host — backend.tracebloc-e2e.test (RFC 6761 .test, which
+# is guaranteed never to resolve on the public internet). We alias it, via
+# /etc/hosts on BOTH the squid pod and the app pod, to the cluster's OWN
+# kube-apiserver ClusterIP — a guaranteed, always-up in-cluster HTTPS:443 listener.
+# So the squid's CONNECT tunnel terminates against a real in-cluster TLS endpoint
+# and the test never dials the production backend. The previous revision curled the
+# real https://api.tracebloc.io/ through the in-cluster squid, whose egress to that
+# host depends on the CI runner's internet at test time — the intermittent flake
+# that randomly red-X'd this required check on develop (e.g. run 27765964135).
+echo "── reading the in-cluster kube-apiserver ClusterIP (the backend stand-in) ──"
+APISERVER_IP="$(kubectl get svc kubernetes -n default -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)"
+[[ -n "$APISERVER_IP" ]] || error "Could not read the kube-apiserver ClusterIP for the in-cluster backend stand-in."
+BACKEND_HOST="backend.tracebloc-e2e.test"
+
 echo "── deploying an in-cluster squid the test pods can reach by Service DNS ──"
-kubectl apply -f - <<'YAML'
+kubectl apply -f - <<YAML
 apiVersion: v1
 kind: ConfigMap
 metadata: { name: tb-egress-squid }
@@ -175,6 +194,11 @@ spec:
   template:
     metadata: { labels: { app: tb-egress-squid } }
     spec:
+      # Resolve the stand-in backend host to the in-cluster kube-apiserver so the
+      # CONNECT tunnel terminates locally (squid honours /etc/hosts by default).
+      hostAliases:
+        - ip: "${APISERVER_IP}"
+          hostnames: ["${BACKEND_HOST}"]
       containers:
         - name: squid
           image: ubuntu/squid:latest
@@ -200,6 +224,8 @@ YAML
 kubectl rollout status deploy/tb-egress-squid --timeout=180s
 
 # Mirrors _EGRESS_NO_PROXY / the chart's cluster-safe NO_PROXY: in-cluster direct.
+# The stand-in backend host is deliberately OUTSIDE this list (not a .svc / RFC1918
+# entry), so WITH the env set curl routes it through the proxy.
 APP_PROXY_URL="http://tb-egress-squid.default.svc.cluster.local:3128"
 APP_NO_PROXY="localhost,127.0.0.1,mysql-client,requests-proxy-service,.svc,.svc.cluster.local,.cluster.local,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
 
@@ -209,17 +235,39 @@ APP_NO_PROXY="localhost,127.0.0.1,mysql-client,requests-proxy-service,.svc,.svc.
 # calls to the SAME backend: (A) with the proxy env it must traverse the squid via
 # a CONNECT tunnel; (B) with the proxy env unset it must dial direct. A single pod
 # keeps this deterministic — no multi-pod scheduling / log-flush race to flake on.
+# The same stand-in→apiserver /etc/hosts alias lets the (B) direct call reach a
+# real in-cluster TLS endpoint instead of failing DNS. `-k`: the apiserver presents
+# the cluster-CA cert (untrusted here) — we assert proxy ROUTING, not TLS trust, so
+# verification is skipped and both calls complete to a real 401.
 echo "── one app pod: WITH the ingestion proxy env it must tunnel via the squid; with it unset it must dial direct ──"
-kubectl run egress-app --image=curlimages/curl:latest --restart=Never \
-  --env="HTTP_PROXY=${APP_PROXY_URL}"  --env="HTTPS_PROXY=${APP_PROXY_URL}" \
-  --env="http_proxy=${APP_PROXY_URL}"  --env="https_proxy=${APP_PROXY_URL}" \
-  --env="NO_PROXY=${APP_NO_PROXY}"     --env="no_proxy=${APP_NO_PROXY}" \
-  --command -- sh -c '
-    echo ">>>>> SECTION_A_WITH_PROXY_ENV";
-    curl -v -sS -m 20 -o /dev/null https://api.tracebloc.io/ 2>&1;
-    echo ">>>>> SECTION_B_PROXY_ENV_UNSET";
-    env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy -u NO_PROXY -u no_proxy curl -v -sS -m 20 -o /dev/null https://api.tracebloc.io/ 2>&1;
-    echo ">>>>> SECTION_END"'
+kubectl apply -f - <<YAML
+apiVersion: v1
+kind: Pod
+metadata: { name: egress-app }
+spec:
+  restartPolicy: Never
+  hostAliases:
+    - ip: "${APISERVER_IP}"
+      hostnames: ["${BACKEND_HOST}"]
+  containers:
+    - name: app
+      image: curlimages/curl:latest
+      env:
+        - { name: HTTP_PROXY,  value: "${APP_PROXY_URL}" }
+        - { name: HTTPS_PROXY, value: "${APP_PROXY_URL}" }
+        - { name: http_proxy,  value: "${APP_PROXY_URL}" }
+        - { name: https_proxy, value: "${APP_PROXY_URL}" }
+        - { name: NO_PROXY,    value: "${APP_NO_PROXY}" }
+        - { name: no_proxy,    value: "${APP_NO_PROXY}" }
+      command: ["sh", "-c"]
+      args:
+        - |
+          echo ">>>>> SECTION_A_WITH_PROXY_ENV"
+          curl -k -v -sS -m 20 -o /dev/null https://${BACKEND_HOST}/ 2>&1
+          echo ">>>>> SECTION_B_PROXY_ENV_UNSET"
+          env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy -u NO_PROXY -u no_proxy curl -k -v -sS -m 20 -o /dev/null https://${BACKEND_HOST}/ 2>&1
+          echo ">>>>> SECTION_END"
+YAML
 
 # Wait for the pod to finish, then read its single log once.
 for _ in $(seq 1 90); do
@@ -232,11 +280,16 @@ a_section="$(printf '%s\n' "$applog" | awk '/SECTION_A_WITH_PROXY_ENV/{f=1;next}
 b_section="$(printf '%s\n' "$applog" | awk '/SECTION_B_PROXY_ENV_UNSET/{f=1;next} /SECTION_END/{f=0} f')"
 
 # Proof is CLIENT-side from `curl -v` — deterministic, unlike squid's access log
-# which the log daemon buffers and may not have flushed when we read it.
-printf '%s\n' "$a_section" | grep -iE 'Establish HTTP proxy tunnel|CONNECT tunnel established|< HTTP/1.1 200' | sed 's/^/    A WITH proxy env:  /'
-printf '%s\n' "$b_section" | grep -iE 'Trying|Connected to|< HTTP/1.1 200'                                   | sed 's/^/    B env unset:       /'
+# which the log daemon buffers and may not have flushed when we read it. These two
+# lines are DIAGNOSTIC ONLY; the trailing `|| true` is load-bearing: when a section
+# is empty (the failure case) `grep` exits 1 and, under `set -euo pipefail`, the
+# pipeline would kill the whole script HERE — before the real assertions below can
+# print WHY (the CI log then shows only "exit code 1" with no reason). `|| true`
+# keeps the diagnostics non-fatal so the assertions get to run and report.
+printf '%s\n' "$a_section" | grep -iE 'Establish HTTP proxy tunnel|CONNECT tunnel established|< HTTP/' | sed 's/^/    A WITH proxy env:  /' || true
+printf '%s\n' "$b_section" | grep -iE 'Trying|Connected to|< HTTP/|Could not resolve'                 | sed 's/^/    B env unset:       /' || true
 # (A) WITH the ingestion proxy env, the backend call MUST traverse the squid.
-if ! printf '%s' "$a_section" | grep -qiE 'Establish HTTP proxy tunnel to api\.tracebloc\.io|CONNECT tunnel established'; then
+if ! printf '%s' "$a_section" | grep -qiE 'Establish HTTP proxy tunnel to backend\.tracebloc-e2e\.test|CONNECT tunnel established'; then
   error "App pod WITH the ingestion proxy env did NOT tunnel through the squid — ingestion-style backend egress is not proxied (the #119 bug)."
 fi
 # (B) With the env unset, the SAME call MUST NOT use a proxy (it dials direct).
@@ -246,4 +299,4 @@ fi
 success "App-pod egress verified: WITH the ingestion proxy env the backend call tunnelled through the in-cluster squid; with it unset the same call dialled direct."
 
 echo ""
-echo "E2E PASS: cluster came up via an AUTHENTICATED proxy, pulled a workload through it, and an ingestion-style app pod egressed to the backend through a proxy (a no-proxy pod bypassed it)."
+echo "E2E PASS: cluster came up via an AUTHENTICATED proxy, pulled a workload through it, and an ingestion-style app pod tunnelled to an in-cluster backend stand-in through a proxy (with the proxy env unset the same call dialled direct)."

--- a/scripts/tests/e2e-proxy.sh
+++ b/scripts/tests/e2e-proxy.sh
@@ -133,5 +133,117 @@ if ! echo "$plog" | grep -E 'CONNECT .*auth\.docker\.io' | grep -q "$PROXY_USER"
   error "No authenticated auth.docker.io CONNECT in the proxy log — the node's image pull did not traverse the proxy."
 fi
 
+# ── 4. APPLICATION-pod egress through a proxy (client-runtime#119) ────────────
+# §1-3 prove NODE egress (image pulls) through the AUTHENTICATED host squid. But
+# the ingestion Job and training pods are application pods that POST to the
+# backend via requests/urllib3 — they only traverse a proxy if their POD env
+# carries HTTP(S)_PROXY (build_job_spec / jobs_manager._add_environment_variables).
+# That layer is what client-runtime#119 was about, and §3 never touches it.
+#
+# A pod cannot reach the host squid via host.k3d.internal (that alias is for k3d
+# NODES, not pod DNS), so we stand up an in-cluster squid the pods reach by
+# Service DNS — a closer model of a real corporate proxy reachable by name. Auth
+# survival is already covered by §1-3; this section is about proxy-env ROUTING.
+# One pod carries the ingestion-style proxy env and makes two calls to the SAME
+# backend (one pod / two calls = deterministic; no multi-pod scheduling or
+# log-flush race to flake on):
+#   * WITH the proxy env it reaches the backend THROUGH the squid (the fixed
+#     ingestion Job);
+#   * with that env unset the same call bypasses the squid / dials direct (the
+#     pre-fix Job — in a real proxy-only network like Charité that direct dial is
+#     refused with [Errno 111]; here the node has direct egress, so we assert the
+#     *absence* of a proxied CONNECT).
+echo "── deploying an in-cluster squid the test pods can reach by Service DNS ──"
+kubectl apply -f - <<'YAML'
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: tb-egress-squid }
+data:
+  squid.conf: |
+    acl SSL_ports port 443
+    acl CONNECT method CONNECT
+    http_access deny CONNECT !SSL_ports
+    http_access allow all
+    http_port 3128
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: tb-egress-squid, labels: { app: tb-egress-squid } }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: tb-egress-squid } }
+  template:
+    metadata: { labels: { app: tb-egress-squid } }
+    spec:
+      containers:
+        - name: squid
+          image: ubuntu/squid:latest
+          ports: [{ containerPort: 3128 }]
+          # Gate rollout on squid actually LISTENING, so the probe pods below
+          # don't race a not-yet-bound port (the "connect refused after 1ms").
+          readinessProbe:
+            tcpSocket: { port: 3128 }
+            initialDelaySeconds: 2
+            periodSeconds: 2
+          volumeMounts:
+            - { name: conf, mountPath: /etc/squid/squid.conf, subPath: squid.conf }
+      volumes:
+        - { name: conf, configMap: { name: tb-egress-squid } }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: tb-egress-squid }
+spec:
+  selector: { app: tb-egress-squid }
+  ports: [{ port: 3128, targetPort: 3128 }]
+YAML
+kubectl rollout status deploy/tb-egress-squid --timeout=180s
+
+# Mirrors _EGRESS_NO_PROXY / the chart's cluster-safe NO_PROXY: in-cluster direct.
+APP_PROXY_URL="http://tb-egress-squid.default.svc.cluster.local:3128"
+APP_NO_PROXY="localhost,127.0.0.1,mysql-client,requests-proxy-service,.svc,.svc.cluster.local,.cluster.local,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+
+# ONE pod carrying the ingestion-style proxy env (BOTH cases — curl honours the
+# lower-case `https_proxy` for HTTPS; the real ingestion env emits both, so the
+# probe must too or it silently dials direct and the test is a lie). It makes two
+# calls to the SAME backend: (A) with the proxy env it must traverse the squid via
+# a CONNECT tunnel; (B) with the proxy env unset it must dial direct. A single pod
+# keeps this deterministic — no multi-pod scheduling / log-flush race to flake on.
+echo "── one app pod: WITH the ingestion proxy env it must tunnel via the squid; with it unset it must dial direct ──"
+kubectl run egress-app --image=curlimages/curl:latest --restart=Never \
+  --env="HTTP_PROXY=${APP_PROXY_URL}"  --env="HTTPS_PROXY=${APP_PROXY_URL}" \
+  --env="http_proxy=${APP_PROXY_URL}"  --env="https_proxy=${APP_PROXY_URL}" \
+  --env="NO_PROXY=${APP_NO_PROXY}"     --env="no_proxy=${APP_NO_PROXY}" \
+  --command -- sh -c '
+    echo ">>>>> SECTION_A_WITH_PROXY_ENV";
+    curl -v -sS -m 20 -o /dev/null https://api.tracebloc.io/ 2>&1;
+    echo ">>>>> SECTION_B_PROXY_ENV_UNSET";
+    env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy -u NO_PROXY -u no_proxy curl -v -sS -m 20 -o /dev/null https://api.tracebloc.io/ 2>&1;
+    echo ">>>>> SECTION_END"'
+
+# Wait for the pod to finish, then read its single log once.
+for _ in $(seq 1 90); do
+  phase="$(kubectl get pod egress-app -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+  [[ "$phase" == "Succeeded" || "$phase" == "Failed" ]] && break
+  sleep 2
+done
+applog="$(kubectl logs egress-app 2>/dev/null || true)"
+a_section="$(printf '%s\n' "$applog" | awk '/SECTION_A_WITH_PROXY_ENV/{f=1;next} /SECTION_B_PROXY_ENV_UNSET/{f=0} f')"
+b_section="$(printf '%s\n' "$applog" | awk '/SECTION_B_PROXY_ENV_UNSET/{f=1;next} /SECTION_END/{f=0} f')"
+
+# Proof is CLIENT-side from `curl -v` — deterministic, unlike squid's access log
+# which the log daemon buffers and may not have flushed when we read it.
+printf '%s\n' "$a_section" | grep -iE 'Establish HTTP proxy tunnel|CONNECT tunnel established|< HTTP/1.1 200' | sed 's/^/    A WITH proxy env:  /'
+printf '%s\n' "$b_section" | grep -iE 'Trying|Connected to|< HTTP/1.1 200'                                   | sed 's/^/    B env unset:       /'
+# (A) WITH the ingestion proxy env, the backend call MUST traverse the squid.
+if ! printf '%s' "$a_section" | grep -qiE 'Establish HTTP proxy tunnel to api\.tracebloc\.io|CONNECT tunnel established'; then
+  error "App pod WITH the ingestion proxy env did NOT tunnel through the squid — ingestion-style backend egress is not proxied (the #119 bug)."
+fi
+# (B) With the env unset, the SAME call MUST NOT use a proxy (it dials direct).
+if printf '%s' "$b_section" | grep -qiE 'proxy tunnel|CONNECT tunnel established'; then
+  error "App pod with the proxy env unset still used a proxy — unexpected; that path should dial direct."
+fi
+success "App-pod egress verified: WITH the ingestion proxy env the backend call tunnelled through the in-cluster squid; with it unset the same call dialled direct."
+
 echo ""
-echo "E2E PASS: cluster came up via an AUTHENTICATED proxy and pulled a workload through it."
+echo "E2E PASS: cluster came up via an AUTHENTICATED proxy, pulled a workload through it, and an ingestion-style app pod egressed to the backend through a proxy (a no-proxy pod bypassed it)."

--- a/scripts/tests/install-client-helm.bats
+++ b/scripts/tests/install-client-helm.bats
@@ -173,6 +173,38 @@ setup() {
   ! grep -q 'HOST_UID:' "$HOST_DATA_DIR/values.yaml"
 }
 
+@test "install_client_helm: TRACEBLOC_CLIENT_* env -> non-interactive (no prompt), writes values.yaml + helm" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  verify_credentials() { printf valid; }
+  export TRACEBLOC_CLIENT_ID=envid TRACEBLOC_CLIENT_PASSWORD=envpw
+  run install_client_helm </dev/null    # no stdin: must not prompt
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Credentials verified"* ]]
+  [[ "$output" != *"Client ID:"* ]]
+  grep -q 'clientId: "envid"' "$HOST_DATA_DIR/values.yaml"
+  grep -q "clientPassword: 'envpw'" "$HOST_DATA_DIR/values.yaml"
+  mock_calls | grep -q "helm upgrade --install tracebloc"
+}
+
+@test "install_client_helm: TRACEBLOC_CLIENT_* with rejected creds -> errors, no helm" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  verify_credentials() { printf invalid; }
+  export TRACEBLOC_CLIENT_ID=envid TRACEBLOC_CLIENT_PASSWORD=envpw
+  run install_client_helm </dev/null
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"rejected"* ]]
+  run mock_calls
+  [[ "$output" != *"helm upgrade"* ]]
+}
+
 @test "install_client_helm: points kubeconfig at the client namespace (so the CLI needs no -n)" {
   HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
   _ensure_tracebloc_dirs() { :; }

--- a/scripts/tests/install-client-helm.bats
+++ b/scripts/tests/install-client-helm.bats
@@ -141,6 +141,38 @@ setup() {
   mock_calls | grep -q "helm upgrade --install tracebloc"
 }
 
+# backend#743: when a dataset mount is provided, the generated values must point
+# the dataset PV at /tracebloc-data and pass the host uid/gid so jobs-manager
+# runs spawned ingestion pods as the owning user (NFS writes).
+@test "install_client_helm: HOST_DATASET_DIR set -> values carry datasetPath + host uid/gid" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  HOST_DATASET_DIR="$BATS_TEST_TMPDIR/ds"; mkdir -p "$HOST_DATASET_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  verify_credentials() { printf valid; }
+  run install_client_helm <<< $'myid\nmypw'
+  [ "$status" -eq 0 ]
+  grep -q 'datasetPath: /tracebloc-data' "$HOST_DATA_DIR/values.yaml"
+  grep -qE 'HOST_UID: "[0-9]+"' "$HOST_DATA_DIR/values.yaml"
+  grep -qE 'HOST_GID: "[0-9]+"' "$HOST_DATA_DIR/values.yaml"
+}
+
+@test "install_client_helm: HOST_DATASET_DIR unset -> no datasetPath / host uid (unchanged)" {
+  unset HOST_DATASET_DIR
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  helm() { record "helm $*"; return 0; }
+  verify_credentials() { printf valid; }
+  run install_client_helm <<< $'myid\nmypw'
+  [ "$status" -eq 0 ]
+  ! grep -q 'datasetPath:' "$HOST_DATA_DIR/values.yaml"
+  ! grep -q 'HOST_UID:' "$HOST_DATA_DIR/values.yaml"
+}
+
 @test "install_client_helm: points kubeconfig at the client namespace (so the CLI needs no -n)" {
   HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
   _ensure_tracebloc_dirs() { :; }

--- a/scripts/tests/install-k8s.Tests.ps1
+++ b/scripts/tests/install-k8s.Tests.ps1
@@ -462,8 +462,9 @@ Describe "Test-Preflight" {
     Mock Err { throw "preflight-failed" }      # Err exits; make it throwable to assert
     Mock Get-PfCpu { 4 }; Mock Get-PfMemGb { 8 }; Mock Get-PfFreeGb { 50 }
     Mock Get-WindowsArch { "amd64" }
+    Mock Get-PfFsType { "local" }
   }
-  AfterEach { $env:TRACEBLOC_SKIP_PREFLIGHT = $null; $env:TRACEBLOC_ALLOW_ARM64 = $null }
+  AfterEach { $env:TRACEBLOC_SKIP_PREFLIGHT = $null; $env:TRACEBLOC_ALLOW_ARM64 = $null; $env:TRACEBLOC_ALLOW_NETWORK_FS = $null }
 
   It "healthy environment -> does not throw" {
     Mock Test-PfUrl { "ok" }
@@ -492,6 +493,36 @@ Describe "Test-Preflight" {
     Mock Test-PfUrl { "ok" }; Mock Get-PfMemGb { 3 }; $env:PF_MIN_MEM_GB = "2"
     { Test-Preflight } | Should -Not -Throw
     $env:PF_MIN_MEM_GB = $null
+  }
+  It "network filesystem (HOST_DATA_DIR on NFS/UNC) -> fails (Err throws)" {
+    Mock Test-PfUrl { "ok" }; Mock Get-PfFsType { "network" }
+    { Test-Preflight } | Should -Throw
+  }
+  It "network filesystem + TRACEBLOC_ALLOW_NETWORK_FS -> does not throw" {
+    Mock Test-PfUrl { "ok" }; Mock Get-PfFsType { "network" }
+    $env:TRACEBLOC_ALLOW_NETWORK_FS = "1"
+    { Test-Preflight } | Should -Not -Throw
+  }
+  It "undetermined filesystem type -> does not throw (assume local)" {
+    Mock Test-PfUrl { "ok" }; Mock Get-PfFsType { $null }
+    { Test-Preflight } | Should -Not -Throw
+  }
+}
+
+Describe "Get-PfFsType" -Skip:(-not $IsWindows) {
+  It "UNC path -> network" {
+    $HOST_DATA_DIR = "\\nas\share\tracebloc"
+    Get-PfFsType | Should -Be "network"
+  }
+  It "mapped network drive (DriveType 4) -> network" {
+    $HOST_DATA_DIR = "Z:\tracebloc"
+    Mock Get-CimInstance { [pscustomobject]@{ DriveType = 4 } }
+    Get-PfFsType | Should -Be "network"
+  }
+  It "local fixed disk (DriveType 3) -> local" {
+    $HOST_DATA_DIR = "C:\tracebloc"
+    Mock Get-CimInstance { [pscustomobject]@{ DriveType = 3 } }
+    Get-PfFsType | Should -Be "local"
   }
 }
 

--- a/scripts/tests/preflight.bats
+++ b/scripts/tests/preflight.bats
@@ -12,6 +12,7 @@ setup() {
   # Default-safe stubs (a healthy amd64 box); individual tests override.
   _pf_probe_url() { echo ok; }
   _pf_free_kb() { echo $((50 * 1024 * 1024)); }       # 50 GB
+  _pf_fstype() { echo ext4; }                          # local disk (storage check passes)
   _pf_total_mem_kb() { echo $((8 * 1024 * 1024)); }   # 8 GB
   _pf_ncpu() { echo 4; }
   _pf_runtime_mem_kb() { echo ""; }   # daemon "down" in tests → selectors/src use host
@@ -281,4 +282,70 @@ setup() {
   run _pf_connectivity
   [[ "$output" == *"Skipping connectivity"* ]]
   PF_HARD_FAIL=0; _pf_connectivity >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+# ── _pf_storage_type (network-FS guard for HOST_DATA_DIR) ────────────────────
+# _pf_fstype is stubbed per-test; the storage check must reject network FSes but
+# pass anything local — including overlay/tmpfs, which is what CI runners use.
+@test "_pf_storage_type: local ext4 -> success, no hard fail" {
+  _pf_fstype() { echo ext4; }
+  run _pf_storage_type; [[ "$output" == *"ext4"* ]]
+  PF_HARD_FAIL=0; _pf_storage_type >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_storage_type: overlay (CI/containers) -> success, never blocked" {
+  _pf_fstype() { echo overlay; }
+  PF_HARD_FAIL=0; _pf_storage_type >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+@test "_pf_storage_type: NFS -> hard fail naming the cause + local-path hint" {
+  _pf_fstype() { echo nfs; }
+  run _pf_storage_type
+  [[ "$output" == *"network filesystem (nfs)"* ]]
+  [[ "$output" == *"HOST_DATA_DIR"* ]]
+  PF_HARD_FAIL=0; _pf_storage_type >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 1 ]
+}
+
+@test "_pf_storage_type: NFS4 -> hard fail" {
+  _pf_fstype() { echo nfs4; }
+  PF_HARD_FAIL=0; _pf_storage_type >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 1 ]
+}
+
+@test "_pf_storage_type: CIFS -> hard fail" {
+  _pf_fstype() { echo cifs; }
+  PF_HARD_FAIL=0; _pf_storage_type >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 1 ]
+}
+
+@test "_pf_storage_type: fuse.sshfs -> hard fail (covers fuse.* network mounts)" {
+  _pf_fstype() { echo fuse.sshfs; }
+  PF_HARD_FAIL=0; _pf_storage_type >/dev/null 2>&1; [ "$PF_HARD_FAIL" -eq 1 ]
+}
+
+@test "_pf_storage_type: NFS + TRACEBLOC_ALLOW_NETWORK_FS -> warn, no hard fail" {
+  _pf_fstype() { echo nfs; }; export TRACEBLOC_ALLOW_NETWORK_FS=1
+  run _pf_storage_type; [[ "$output" == *"proceeding"* ]]
+  PF_HARD_FAIL=0; _pf_storage_type >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+  unset TRACEBLOC_ALLOW_NETWORK_FS
+}
+
+@test "_pf_storage_type: undetermined fstype -> no hard fail (assume local)" {
+  _pf_fstype() { echo ""; }
+  PF_HARD_FAIL=0; _pf_storage_type >/dev/null; [ "$PF_HARD_FAIL" -eq 0 ]
+}
+
+# ── _pf_fstype reader (re-source for the real function) ──────────────────────
+@test "_pf_fstype: lower-cases output and walks to the nearest existing parent" {
+  source "${BATS_TEST_DIRNAME}/../lib/preflight.sh"
+  has() { [[ "$1" == "findmnt" ]]; }   # only findmnt 'present'
+  findmnt() { echo NFS4; }             # upper-case, ignores args
+  run _pf_fstype "${BATS_TEST_TMPDIR}/does/not/exist/yet"
+  [ "$output" = "nfs4" ]
+}
+
+@test "_pf_fstype: real reader on this host -> a token or empty, never crashes" {
+  source "${BATS_TEST_DIRNAME}/../lib/preflight.sh"
+  OS="$(uname -s)"
+  run _pf_fstype /
+  [ "$status" -eq 0 ]
+  [[ -z "$output" || "$output" =~ ^[a-z0-9._/]+$ ]]
 }


### PR DESCRIPTION
Release **chart v1.8.0** to `main`. Promotes the 9 commits merged to `develop` since v1.7.1 (2026-06-15) plus the version bump (#272).

## Contents (`main` 1.7.1 → `develop` 1.8.0)
**Chart (renders on the fleet):**
- **#262 datasets on a network mount while MySQL stays local** — parameterizes the dataset PV hostPath via a new `hostPath.datasetPath` key (helper `tracebloc.clientDataHostPath`). Renders **byte-identical** with default/stored values (`/tracebloc/<release>/data`); nil-guarded for `--reuse-values`. The network path (`/tracebloc-data`) is set by the installer only on a fresh install given `HOST_DATASET_DIR`. mysql + logs PVs untouched.
- **#270 in-cluster backend-reachability `helm test`** (cli#90, WS3) — a `helm.sh/hook: test` Job; dormant on install/upgrade, runs only on explicit `helm test`.
- **#260 job resource-defaults fix** (#745).

**Installer (host-side; new installs only, not auto-upgrade):**
- **#266** non-interactive credentials + softer connect copy (#834).
- **#261** fail fast when `HOST_DATA_DIR` is on a network filesystem.

**Repo-only (CI / security / e2e tests — not shipped in the chart):**
- **#265** chart-CI concurrency cancellation + job timeouts.
- **#263** public-repo PII gate caller.
- **#264 / #269** application-pod egress e2e test ([redacted]) + deflake.

## Release type
**Minor** — adds a new capability/values key (`hostPath.datasetPath`) and a new test hook. **Inert on auto-upgrade**: existing clusters render byte-identical (helper defaults `datasetPath` to `/tracebloc`, nil-guarded for `--reuse-values`); #270 is a `helm test` hook that never runs on upgrade. Operational change lands only on fresh installs that pass `HOST_DATASET_DIR`.

## After merge
Publish GitHub Release **v1.8.0** tagged on `main` → release workflow packages the chart to gh-pages → fleet auto-upgrades at `:23`.

Closes #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Minor chart bump is mostly inert on auto-upgrade, but v1.8.0 still changes fleet templates and install-time storage/proxy behavior; misconfigured `HOST_DATASET_DIR` or dataset PV paths could misroute data on fresh installs.
> 
> **Overview**
> Promotes **chart v1.8.0** and the develop-side installer/CI work bundled in this sync to `main`.
> 
> **Chart (fleet-facing):** Adds **`hostPath.datasetPath`** so only the dataset (`shared-images`) PV base can move off local disk (default `/tracebloc` keeps renders **byte-identical** on upgrade/`--reuse-values`); mysql and logs hostPaths stay local. Adds an **`egressReachabilityCheck`** `helm test` Job (non-training pod → tracebloc API, proxy-aware) that does not run on install/upgrade. Helm unit tests cover dataset PV wiring, mysql/logs isolation, spawned-job **`RESOURCE_REQUESTS`/`RESOURCE_LIMITS`** defaults (#745), and the new reachability hook.
> 
> **Installers:** **`HOST_DATASET_DIR`** bind-mounts `/tracebloc-data`, emits `datasetPath` + **`HOST_UID`/`HOST_GID`** for NFS ingestion writes, and **refuses** reusing a k3d cluster missing that mount. Preflight **blocks `HOST_DATA_DIR` on network filesystems** (override `TRACEBLOC_ALLOW_NETWORK_FS`); **`TRACEBLOC_CLIENT_ID` / `TRACEBLOC_CLIENT_PASSWORD`** enable non-interactive Helm install.
> 
> **CI / repo:** PR **concurrency cancel** and **job timeouts** on heavy workflows; new **public PII gate** caller; **`e2e-proxy`** extended to assert **application-pod** proxy routing via an in-cluster hermetic backend stand-in (deflake vs real `api.tracebloc.io`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001ef47542f78dbc5e464acbf39eaa9dda01037d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->