### PR TITLE
fix(egress-reachability-check): fail closed on TLS/transport errors, not just connect failures

### DIFF
--- a/client/templates/egress-reachability-check.yaml
+++ b/client/templates/egress-reachability-check.yaml
@@ -73,21 +73,25 @@ spec:
                 *)   HOST="api.tracebloc.io" ;;
               esac
               echo "[egress-reachability-check] CLIENT_ENV=$CLIENT_ENV -> probing backend reachability to https://${HOST}/ (through the proxy if one is configured)..."
-              # Key the verdict on curl's EXIT CODE, not the HTTP status: we only
-              # care whether the TCP+TLS connection to the backend can be made.
-              # No-egress yields connect-refused (7) or timeout (28); a DNS/proxy
-              # resolution failure (6/5) means the host can't be found. Any other
-              # outcome (0, or a TLS/HTTP-layer code) means the connection already
-              # succeeded => the backend is reachable.
+              # Key the verdict on curl's EXIT CODE, not the HTTP status. With no
+              # --fail, curl exits 0 for ANY HTTP response (200/401/404/5xx), so a
+              # 0 exit is the only outcome that proves a full TCP+TLS+HTTP round
+              # trip — the backend is genuinely reachable AND usable. Every
+              # non-zero code is a transport/TLS failure, so we fail closed on it:
+              # connect-refused (7) / timeout (28) = egress blocked; DNS/proxy
+              # resolve (6/5) = host can't be found; a TLS handshake/cert error
+              # (35/51/60/…) = reached the host but TLS is broken (commonly a proxy
+              # intercepting TLS with an untrusted CA), so the API is unusable.
               curl -sS -m 10 -o /dev/null "https://${HOST}/"; rc=$?
               case "$rc" in
+                0)  echo "OK  backend reachable: completed an HTTPS request to ${HOST}:443 (curl exit 0) — the cluster can reach the tracebloc backend."; exit 0 ;;
                 5)  echo "FAIL  could not resolve the configured proxy (curl exit 5) — check HTTP_PROXY settings."; exit 1 ;;
                 6)  echo "FAIL  could not resolve ${HOST} (curl exit 6) — in-cluster DNS or egress is broken."; exit 1 ;;
                 7)  echo "FAIL  connection to ${HOST}:443 refused (curl exit 7) — no egress route to the tracebloc backend."; exit 1 ;;
                 28) echo "FAIL  connection to ${HOST}:443 timed out (curl exit 28) — egress blocked by a firewall/proxy/NetworkPolicy. Experiments can't start without backend egress."; exit 1 ;;
+                35|51|53|58|59|60|66|77|83|91) echo "FAIL  reached ${HOST}:443 but the TLS handshake/certificate check failed (curl exit $rc) — commonly a corporate proxy intercepting TLS with a CA the cluster doesn't trust. The backend API is unusable until that CA is trusted; experiments can't authenticate."; exit 1 ;;
+                *)  echo "FAIL  could not complete an HTTPS request to ${HOST}:443 (curl exit $rc) — backend egress is not working."; exit 1 ;;
               esac
-              echo "OK  backend reachable: connected to ${HOST}:443 (curl exit $rc) — the cluster can reach the tracebloc backend."
-              exit 0
           resources:
             requests:
               cpu: "10m"


### PR DESCRIPTION
Follow-up to #270, flagged by Cursor Bugbot on the v1.8.0 sync PR (#273). Targets `develop` so the fix is in the source of truth; the sync branch will be re-pointed to pick it up (no version bump — v1.8.0 isn't published yet).

## Bug
The backend-reachability `helm test` keyed the verdict on a **denylist** of curl exit codes (5/6/7/28) and treated everything else as success. But the probe runs `curl -sS` without `--fail`, so curl exits `0` for **any** HTTP response — meaning every non-zero exit is actually a transport/TLS failure. A TLS handshake/cert error (e.g. `35`/`51`/`60`, typically a corporate proxy intercepting TLS with a CA the cluster doesn't trust) therefore printed `OK backend reachable` and exited 0 — a **false pass** that defeats the check, since the real client (jobs-manager) would fail the same TLS handshake and experiments would sit Pending.

## Fix
Pass **only** on curl exit `0` (a full TCP+TLS+HTTP round trip proves the backend is reachable *and* usable). Fail closed on everything else:
- `5`/`6` — proxy/host DNS resolution
- `7`/`28` — connection refused / timeout (egress blocked)
- `35|51|53|58|59|60|66|77|83|91` — TLS handshake/certificate failure, with corporate-CA guidance
- `*` — generic catch-all (fail), so no future failure mode silently passes

HTTP 4xx/5xx still pass (exit 0) — we only assert reachability, not auth.

## Validation
`helm unittest ./client` → **265/265** (the companion suite asserts hook/labels/env, nothing on the script body); template renders clean.

Part of #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single helm test Job script logic change; no install/upgrade hooks or runtime client paths affected.
> 
> **Overview**
> The **egress-reachability-check** `helm test` probe no longer treats “not DNS/connect/timeout” as success. It now **passes only when `curl` exits 0** (full TCP+TLS+HTTP round trip without `--fail`, so 4xx/5xx still count as reachable).
> 
> **Fail-closed** handling adds explicit failures for TLS/cert handshake codes (`35|51|53|58|59|60|66|77|83|91`) with proxy/CA guidance, and a `*` catch-all so unknown transport errors cannot silently pass. This fixes false **OK** results when TLS is broken (e.g. untrusted corporate proxy CA) while connect-oriented errors keep the same messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2516a5c65b6ea95195e64a5659a0dda40bd51d9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->