### PR TITLE
chore(chart): bump client 1.8.0 → 1.8.1

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.8.0
-appVersion: "1.8.0"
+version: 1.8.1
+appVersion: "1.8.1"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
## What
Bumps the `client` chart `1.8.0 → 1.8.1` (version + appVersion, in lockstep with the prior bump #272). Readies the **1.8.1 release**.

## What 1.8.1 ships
`develop` is exactly one commit ahead of `main`: the egress-enforcement-check standard-mode CNI fix, **#276** (closes #275).

The §8.2 egress-lockdown `helm test` gate (`egress-enforcement-check`) was false-failing on CNIs that enforce egress NetworkPolicy in **`standard` mode** — notably AWS VPC CNI with `NETWORK_POLICY_ENFORCING_MODE=standard`, which **both the dev and prod fleets use**. The probe ran instantly on pod startup, inside the per-pod policy reconciliation window, connected, and reported `EGRESS LOCKDOWN NOT ENFORCED`. #276 makes the probe **retry until egress is observed blocked** (bounded by `enforcementProbeTimeoutSeconds`, default 60s), so it measures steady-state enforcement instead of the startup race.

This is the gate used to verify each fleet during the [client-runtime#102](https://github.com/tracebloc/client-runtime/issues/102) egress-lockdown rollout, so it needs to ship before the per-fleet flips can rely on `helm test`.

## Validation
- Full helm-unittest suite: **267/267**.
- **End-to-end on dev** (EKS `tb-client-dev-templates`, AWS VPC CNI `standard` mode): applied the lockdown and ran the patched `helm test` → `egress-enforcement-check` **Succeeded** (retried through the reconcile window, observed the block, passed) where the previous instant-probe test failed. Dev was rolled back to its original state afterward.

## Release steps after this merges
1. `develop → main` sync PR (also auto-closes #275).
2. Publish the `v1.8.1` GitHub release → triggers `release-helm-chart.yaml` to package + publish to the helm repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only chart version bump with no template, value, or runtime behavior changes in this diff.
> 
> **Overview**
> Bumps the unified `client` Helm chart release metadata from **1.8.0** to **1.8.1** by updating both `version` and `appVersion` in `Chart.yaml`, keeping them in lockstep for the **1.8.1** publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e15bcc88fd7a343aa3d64738531dcd4aa340d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->