### PR TITLE
Sync develop → main for v1.8.1 chart release (egress-enforcement-check standard-mode CNI fix)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.8.0
-appVersion: "1.8.0"
+version: 1.8.1
+appVersion: "1.8.1"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/egress-enforcement-check.yaml
+++ b/client/templates/egress-enforcement-check.yaml
@@ -56,40 +56,66 @@ spec:
             - -c
             - |
               HOST={{ $host | quote }}
-              echo "[egress-enforcement-check] probing direct TCP egress to ${HOST}:443 (must be BLOCKED when the lockdown is enforced)..."
+              TIMEOUT={{ dig "enforcementProbeTimeoutSeconds" 60 .Values.networkPolicy.training }}
+              echo "[egress-enforcement-check] probing direct TCP egress to ${HOST}:443; it must be BLOCKED once the CNI reconciles the training-egress NetworkPolicy (retrying up to ${TIMEOUT}s)..."
               # We only care whether a TCP connection to :443 can be ESTABLISHED — the
               # TLS/HTTP outcome is irrelevant. -k disables cert verification so probing an
               # IP (or any host whose cert doesn't match) is NOT misread as a block, and the
               # verdict is keyed on curl's EXIT CODE, not the HTTP status: a blocked egress
               # yields a timeout (28) or connect failure (7); a DNS failure (6) is inconclusive;
               # any other outcome (incl. a TLS/cert error) means the TCP connect already succeeded.
-              curl --noproxy '*' -k -sS -m 5 -o /dev/null "https://$HOST"; rc=$?
-              case "$rc" in
-                7|28)
-                  # connect refused (7) / timed out (28): the TCP handshake never completed => egress blocked.
-                  echo "OK  egress lockdown verified: TCP to ${HOST}:443 could not be established (curl exit $rc) — egress is blocked."
+              #
+              # Why retry: standard-mode CNIs — notably AWS VPC CNI with
+              # NETWORK_POLICY_ENFORCING_MODE=standard — allow a brand-new pod ALL traffic
+              # until its per-pod policy is reconciled (a few-second startup window). A single
+              # immediate probe races that window and can see a false connect, reporting "not
+              # enforced" on a cluster that DOES enforce. Real training pods start far slower
+              # than this window (image pull, dataset load, framework init) so user code never
+              # runs un-policed; this loop measures that steady state, not the startup race.
+              # PASS as soon as egress is blocked; FAIL only if it stays reachable for TIMEOUT.
+              deadline=$(( $(date +%s) + $TIMEOUT ))
+              rc=0
+              attempt=0
+              reached=0
+              while :; do
+                attempt=$(( attempt + 1 ))
+                curl --noproxy '*' -k -sS -m 5 -o /dev/null "https://$HOST"; rc=$?
+                if [ "$rc" = 7 ] || [ "$rc" = 28 ]; then
+                  # connect refused (7) / timed out (28): the TCP handshake never completed => blocked.
+                  echo "OK  egress lockdown verified after ${attempt} attempt(s): TCP to ${HOST}:443 could not be established (curl exit ${rc}) — egress is blocked."
                   exit 0
-                  ;;
-                6)
-                  # DNS resolution failed: no TCP connection was attempted, so enforcement can't be judged.
-                  echo "WARNING  egress enforcement INCONCLUSIVE: could not resolve host '${HOST}' (curl exit 6)."
-                  echo "WARNING  No TCP connection was attempted, so the lockdown was NOT verified. Point"
-                  echo "WARNING  networkPolicy.training.enforcementProbeHost at an external IP (e.g. 1.1.1.1)"
-                  echo "WARNING  or fix in-cluster DNS, then re-run 'helm test'."
-                  exit 1
-                  ;;
-              esac
-              # Any other outcome (0 success, or a TLS-/HTTP-layer error such as 35/52/56/60 — all of
-              # which require the TCP connect to have already succeeded) => the host was reached.
+                fi
+                # Not blocked. Anything other than a DNS failure (6) means the TCP connect
+                # succeeded => egress was observed REACHABLE. Latch it so a later DNS blip can't
+                # downgrade a definitive "reachable" verdict to "inconclusive" after the loop.
+                [ "$rc" != 6 ] && reached=1
+                [ "$(date +%s)" -ge "$deadline" ] && break
+                echo "...  attempt ${attempt}: ${HOST}:443 not yet blocked (curl exit ${rc}); egress not yet enforced — retrying in 3s."
+                sleep 3
+              done
+              if [ "$reached" != 1 ]; then
+                # Never established a TCP connection — every attempt failed DNS (curl exit 6),
+                # so egress enforcement could not be judged either way.
+                echo "WARNING  egress enforcement INCONCLUSIVE: could not resolve host '${HOST}' (curl exit 6) within ${TIMEOUT}s."
+                echo "WARNING  No TCP connection ever succeeded, so the lockdown was NOT verified. Point"
+                echo "WARNING  networkPolicy.training.enforcementProbeHost at an external IP (e.g. 1.1.1.1)"
+                echo "WARNING  or fix in-cluster DNS, then re-run 'helm test'."
+                exit 1
+              fi
+              # Egress was observed REACHABLE on at least one attempt (TCP connect succeeded;
+              # rc=0 or a TLS-/HTTP-layer error such as 35/52/56/60) and never became blocked
+              # within TIMEOUT — regardless of the final attempt's code, so a late DNS blip
+              # cannot mask a connect we already saw.
               echo "WARNING ================================================================"
               echo "WARNING  EGRESS LOCKDOWN NOT ENFORCED on this cluster."
-              echo "WARNING  A tracebloc.io/workload=training pod reached ${HOST}:443 directly"
-              echo "WARNING  (curl exit $rc; the TCP connect succeeded). networkPolicy.training."
+              echo "WARNING  A tracebloc.io/workload=training pod established a direct TCP connection"
+              echo "WARNING  to ${HOST}:443 within ${TIMEOUT}s and egress never became blocked. networkPolicy.training."
               echo "WARNING  allowExternalHttps is false, but the CNI is NOT enforcing egress"
               echo "WARNING  NetworkPolicy, so the SECURITY §8.2 lockdown is INACTIVE and"
               echo "WARNING  training pods can still reach the open internet."
-              echo "WARNING  Fix: enable egress NetworkPolicy on the CNI (Calico/Cilium, or"
-              echo "WARNING  EKS VPC-CNI enableNetworkPolicy=true), then re-run 'helm test'."
+              echo "WARNING  Fix: ensure the CNI enforces egress NetworkPolicy — Calico/Cilium, or"
+              echo "WARNING  AWS VPC CNI with enableNetworkPolicy=true (enforced after a brief reconcile"
+              echo "WARNING  in 'standard' mode). Then re-run 'helm test'."
               echo "WARNING ================================================================"
               exit 1
           resources:

--- a/client/tests/egress_enforcement_check_test.yaml
+++ b/client/tests/egress_enforcement_check_test.yaml
@@ -118,3 +118,38 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: "^docker\\.io/curlimages/curl@sha256:[a-f0-9]{64}$"
+
+  - it: retries until egress is blocked, tolerating the standard-mode CNI reconciliation window
+    set:
+      networkPolicy:
+        training:
+          allowExternalHttps: false
+          enforcementProbeTimeoutSeconds: 45
+    asserts:
+      # probes in a loop until blocked or the deadline, rather than a single immediate shot
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "while :; do"
+      # honours the configurable timeout...
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "TIMEOUT=45"
+      # ...via a wall-clock deadline
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'date \+%s'
+      # a TCP connect seen on ANY attempt latches a definitive "reachable" verdict, so a
+      # later DNS failure cannot downgrade it to "inconclusive" (bugbot, PR #276)
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "reached=1"
+
+  - it: defaults the enforcement-probe timeout to 60s
+    set:
+      networkPolicy:
+        training:
+          allowExternalHttps: false
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "TIMEOUT=60"

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -167,7 +167,10 @@ namespace:
 # egress to DNS + external HTTPS only (blocks pod-to-pod, MySQL, K8s API).
 # Requires a CNI that enforces NetworkPolicy:
 #   AKS:   needs "Azure NPM" (--network-policy azure) or Calico at cluster create
-#   EKS:   needs Calico or Cilium add-on (AWS VPC CNI alone does NOT enforce)
+#   EKS:   AWS VPC CNI with enableNetworkPolicy=true (the network-policy agent), or
+#          a Calico / Cilium add-on. Plain AWS VPC CNI without the agent does NOT
+#          enforce. In "standard" mode enforcement applies after a brief per-pod
+#          reconcile (see enforcementProbeTimeoutSeconds).
 #   bm:    needs Calico / Cilium / kube-router (Flannel alone does NOT enforce)
 #   OC:    OVN-Kubernetes enforces by default
 # Leave `enabled: false` on clusters without an enforcing CNI — silently
@@ -184,11 +187,18 @@ networkPolicy:
     # predating it keeps the old behaviour (rule present).
     allowExternalHttps: true
     # client-runtime#104: enforcement check, run via `helm test <release>` after
-    # flipping the lockdown (allowExternalHttps=false). The test opens a direct TCP
-    # connection to this host's :443 from a training-labelled pod; if it connects =>
-    # the CNI isn't enforcing egress => the test FAILS (a test hook never affects
-    # install/upgrade). Set "" to disable (e.g. air-gapped clusters).
+    # flipping the lockdown (allowExternalHttps=false). A training-labelled pod opens a
+    # direct TCP connection to this host's :443 and RETRIES until it is blocked (PASS) or
+    # enforcementProbeTimeoutSeconds elapses while still reachable (FAIL — the CNI isn't
+    # enforcing egress). The retry tolerates standard-mode CNIs that enforce only after a
+    # brief per-pod reconcile. A test hook never affects install/upgrade. Set "" to
+    # disable (e.g. air-gapped clusters).
     enforcementProbeHost: "1.1.1.1"
+    # Max seconds the enforcement check waits for egress to become blocked before it
+    # gives up and FAILS. Covers the standard-mode CNI reconciliation window (AWS VPC CNI
+    # NETWORK_POLICY_ENFORCING_MODE=standard allows a new pod all traffic until its policy
+    # is programmed). 60s suits AWS VPC CNI / Calico / Cilium; raise it on slow nodes.
+    enforcementProbeTimeoutSeconds: 60
     dnsNamespace: kube-system
     # CoreDNS pod selector — varies per platform. Override in ci/<platform>-values.yaml.
     # When empty, the template falls back to {k8s-app: kube-dns}, which works


### PR DESCRIPTION
## What
Syncs `develop → main` for the **v1.8.1** chart release.

## What 1.8.1 ships
`develop` is exactly two commits ahead of `main`:
- **#277** — chart version bump `1.8.0 → 1.8.1` (version + appVersion).
- **#276** — `egress-enforcement-check` standard-mode CNI fix (the substantive change).

The §8.2 egress-lockdown `helm test` gate was false-failing on CNIs that enforce egress NetworkPolicy in **`standard` mode** (notably AWS VPC CNI with `NETWORK_POLICY_ENFORCING_MODE=standard` — both the dev and prod fleets). The probe ran instantly on pod startup, inside the per-pod policy reconciliation window, connected, and reported `EGRESS LOCKDOWN NOT ENFORCED`. #276 makes the probe **retry until egress is observed blocked** (bounded by `enforcementProbeTimeoutSeconds`, default 60s), so it measures steady-state enforcement. This is the gate used to verify each fleet during the [client-runtime#102](https://github.com/tracebloc/client-runtime/issues/102) egress-lockdown rollout, so it must ship before the per-fleet flips can rely on `helm test`.

Closes #275.

## Validation
- helm-unittest: **267/267**.
- **End-to-end on dev** (EKS, AWS VPC CNI `standard` mode): the patched `helm test` goes green where the previous instant-probe failed; a live egress-restriction demo confirmed a training pod's direct external calls are all blocked and only the allowlisted backend is reachable via the squid gateway. Dev rolled back to its original state afterward.

## After merge
Publish the **v1.8.1** GitHub release (tag on `main`) → triggers `release-helm-chart.yaml` to package + publish to the helm repo. Then the [client-runtime#102](https://github.com/tracebloc/client-runtime/issues/102) per-fleet rollout can run with a trustworthy gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the helm test hook script and chart metadata/docs; no runtime training workload or NetworkPolicy rules are modified.
> 
> **Overview**
> Releases **client chart v1.8.1** and fixes false failures in the §8.2 **`helm test` egress-enforcement-check** on CNIs that enforce egress only after a short per-pod reconcile (e.g. AWS VPC CNI `NETWORK_POLICY_ENFORCING_MODE=standard`).
> 
> The probe **retries** `curl` to the canary host until TCP egress is blocked (pass) or **`networkPolicy.training.enforcementProbeTimeoutSeconds`** (default **60s**) elapses while still reachable (fail). A **`reached`** latch records any successful TCP connect so a late DNS failure cannot downgrade a definitive “not enforced” result to inconclusive. **`values.yaml`** documents the new knob and updated EKS VPC CNI guidance; **helm-unittest** asserts the loop, timeout wiring, and default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f223987301ec640b5e6b76d43134712526b5873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->