### PR TITLE
feat(installer): reorder — sign in + provision the client before Helm (#838)

### DIFF
--- a/scripts/install-k8s.sh
+++ b/scripts/install-k8s.sh
@@ -69,6 +69,11 @@ source "${LIB_DIR}/summary.sh"
 source "${LIB_DIR}/diagnose.sh"
 
 trap install_cleanup EXIT
+# Route SIGINT/SIGTERM through a normal exit so the EXIT trap (install_cleanup)
+# always runs — it shreds the transient machine credential (#838). Without these,
+# a Ctrl-C in the brief mint→source window could leave the 0600 secret on disk.
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # ── Main ─────────────────────────────────────────────────────────────────────
 main() {
@@ -83,7 +88,7 @@ main() {
   print_banner
   print_roadmap
 
-  # ── Step 1/4: Check system requirements ──────────────────────────────────
+  # ── Step 1/5: Check system requirements ──────────────────────────────────
   step 1 5 "Checking system requirements"
   run_preflight
   detect_gpu
@@ -97,7 +102,7 @@ main() {
     *)        error "Unsupported OS: $OS" ;;
   esac
 
-  # ── Step 2/4: Set up secure compute environment ──────────────────────────
+  # ── Step 2/5: Set up secure compute environment ──────────────────────────
   step 2 5 "Setting up secure compute environment"
   create_cluster
   deploy_gpu_device_plugin

--- a/scripts/install-k8s.sh
+++ b/scripts/install-k8s.sh
@@ -59,6 +59,12 @@ source "${LIB_DIR}/install-client-helm.sh"
 if [[ -f "${LIB_DIR}/install-cli.sh" ]]; then
   source "${LIB_DIR}/install-cli.sh"
 fi
+# provision.sh (the #838 sign-in + client-create-before-Helm step) likewise may be
+# absent under a stale bootstrap — guard so the installer degrades to the dual-mode
+# credential path rather than aborting under `set -e`.
+if [[ -f "${LIB_DIR}/provision.sh" ]]; then
+  source "${LIB_DIR}/provision.sh"
+fi
 source "${LIB_DIR}/summary.sh"
 source "${LIB_DIR}/diagnose.sh"
 
@@ -97,18 +103,21 @@ main() {
   deploy_gpu_device_plugin
   verify_gpu
 
-  # ── Step 3/5 + 4/5 are handled inside install_client_helm ────────────────
+  # ── Step 3/5: sign in + provision the client (install CLI, login, client
+  #    create) BEFORE Helm, so the minted credential + derived namespace feed the
+  #    chart (#838). On the dual-mode path (TRACEBLOC_VALUES_FILE / pre-supplied
+  #    credentials) this skips sign-in. Guarded so a stale bootstrap that didn't
+  #    fetch provision.sh degrades to the dual-mode credential path rather than
+  #    aborting; in that case the operator must supply credentials/values. ──────
+  if declare -F provision_client >/dev/null 2>&1; then
+    provision_client
+  fi
+
+  # ── Step 4/5 + 5/5 are handled inside install_client_helm ────────────────
   install_client_helm
 
   # ── Verify the client actually came up before reporting anything ─────────
   wait_for_client_ready
-
-  # ── Step 5/5: install the tracebloc CLI. Non-fatal — the client is already
-  #    connected, so a CLI hiccup warns but never fails the run. Guarded on the
-  #    function being defined, in case a stale bootstrap didn't fetch the lib. ─
-  if declare -F install_tracebloc_cli >/dev/null 2>&1; then
-    install_tracebloc_cli
-  fi
 
   print_summary
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,6 +43,7 @@ FILES=(
   "scripts/lib/gpu-plugins.sh"
   "scripts/lib/install-client-helm.sh"
   "scripts/lib/install-cli.sh"
+  "scripts/lib/provision.sh"
   "scripts/lib/summary.sh"
   "scripts/lib/diagnose.sh"
 )

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -323,6 +323,10 @@ PM_UPDATE=""
 install_cleanup() {
   local exit_code=$?
   [[ -n "${SUDO_KEEPALIVE_PID:-}" ]] && kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
+  # Never leave the transient machine credential on disk (#838): provision.sh sets
+  # _PROVISION_CRED_FILE before minting and removes it after sourcing — this is the
+  # backstop for an error/signal between mint and that cleanup.
+  [[ -n "${_PROVISION_CRED_FILE:-}" ]] && rm -f "$_PROVISION_CRED_FILE" 2>/dev/null || true
   if [[ $exit_code -eq 2 ]]; then
     echo ""
     if [[ -n "${TRACEBLOC_DOCKER_FIRST_RUN_EXIT:-}" ]]; then
@@ -369,9 +373,9 @@ print_roadmap() {
   echo -e "  ${DIM}─────${RESET}"
   echo -e "  ${DIM}1. Check system requirements${RESET}"
   echo -e "  ${DIM}2. Set up secure compute environment${RESET}"
-  echo -e "  ${DIM}3. Install tracebloc client${RESET}"
-  echo -e "  ${DIM}4. Connect to tracebloc network${RESET}"
-  echo -e "  ${DIM}5. Install the tracebloc CLI${RESET}"
+  echo -e "  ${DIM}3. Sign in and provision this client${RESET}"
+  echo -e "  ${DIM}4. Install tracebloc client${RESET}"
+  echo -e "  ${DIM}5. Connect to tracebloc network${RESET}"
   echo ""
 }
 

--- a/scripts/lib/install-cli.sh
+++ b/scripts/lib/install-cli.sh
@@ -119,8 +119,9 @@ _verify_tracebloc_cli() {
 }
 
 install_tracebloc_cli() {
-  step 5 5 "Install the tracebloc CLI"
-
+  # No step framing here: this is called from provision_client (Step 3) on the
+  # browser-auth path and, non-fatally, on the dual-mode path — the caller owns
+  # the step heading. (#838 reorder: the CLI installs BEFORE Helm now.)
   if has tracebloc; then
     # Version is cosmetic — never let a failing `tracebloc version` (or SIGPIPE
     # from `head` closing the pipe, under `set -o pipefail`) abort this step.

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -194,8 +194,9 @@ _chart_proxy_env_yaml() {
 }
 
 install_client_helm() {
-  # ── Step 3/4: Install tracebloc client ───────────────────────────────────
-  step 3 5 "Installing tracebloc client"
+  # ── Step 4/5: Install tracebloc client (credential + namespace provisioned
+  #    in Step 3 by provision_client, or supplied via dual-mode) ─────────────
+  step 4 5 "Installing tracebloc client"
 
   _ensure_tracebloc_dirs
   local values_file="${HOST_DATA_DIR}/values.yaml"
@@ -247,8 +248,8 @@ install_client_helm() {
   # Advanced / GitOps setups can override with TB_NAMESPACE=<name>.
   TB_NAMESPACE=$(_sanitize_workspace_name "${TB_NAMESPACE:-tracebloc}")
 
-  # ── Step 4/4: Connect to tracebloc network ──────────────────────────────
-  step 4 5 "Connect to tracebloc network"
+  # ── Step 5/5: Connect to tracebloc network ──────────────────────────────
+  step 5 5 "Connect to tracebloc network"
 
   if [[ "$_noninteractive_creds" == 1 ]]; then
     # Credentials supplied via env — verify once, no prompt, no re-prompt.

--- a/scripts/lib/install-client-helm.sh
+++ b/scripts/lib/install-client-helm.sh
@@ -368,6 +368,19 @@ install_client_helm() {
     error "Refusing to replace the existing client. See the options above."
   fi
 
+  # Same client, but already installed under a DIFFERENT namespace — e.g. a release
+  # from an older installer that used the fixed `tracebloc` namespace, before #838
+  # began deriving the namespace from the minted client slug. Upgrade THAT release
+  # in place rather than installing a second one under the new namespace: the
+  # platform counts each release as separate capacity, so a fork would silently
+  # double-book this host (and orphan the original). Reuse the existing namespace;
+  # an intentional namespace move is a delete-then-reinstall, not a silent fork.
+  if [[ -n "$existing_id" && "$existing_id" == "$TB_CLIENT_ID" && -n "$existing_ns" && "$existing_ns" != "$TB_NAMESPACE" ]]; then
+    log "Client '${existing_id}' already installed in namespace '${existing_ns}'; upgrading it in place instead of creating '${TB_NAMESPACE}'."
+    info "Updating the existing client (namespace '${existing_ns}')."
+    TB_NAMESPACE="$existing_ns"
+  fi
+
   TB_CLIENT_PASSWORD_ESCAPED="${TB_CLIENT_PASSWORD//\'/\'\'}"
 
   # ── GPU limits ──────────────────────────────────────────────────────────

--- a/scripts/lib/provision.sh
+++ b/scripts/lib/provision.sh
@@ -56,12 +56,20 @@ provision_client() {
   # between mint and the explicit removal below — the secret must never linger.
   _PROVISION_CRED_FILE="$cred_file"
   rm -f "$cred_file"
-  if ! tracebloc client create --yes --credential-file "$cred_file" >>"${LOG_FILE:-/dev/null}" 2>&1; then
+  # umask 077 so the credential file lands 0600 even if a future CLI build
+  # regresses on its explicit chmod — defense in depth (cli#104 already sets 0600).
+  if ! ( umask 077; tracebloc client create --yes --credential-file "$cred_file" ) >>"${LOG_FILE:-/dev/null}" 2>&1; then
     rm -f "$cred_file"   # remove any partial the failed create may have written
     error "Provisioning the client failed — see ${LOG_FILE:-the install log}. Re-run to retry."
   fi
   [[ -f "$cred_file" ]] || error "client create did not write the credential file ($cred_file)."
 
+  # The credential file is the sole source of truth for what was provisioned.
+  # Clear any pre-existing values from the environment first: the mint case does
+  # NOT write TRACEBLOC_CLIENT_ADOPTED, so a stale ADOPTED=1 left in the env would
+  # otherwise misroute a fresh mint into the adopt branch and drop the just-minted
+  # credential. Same reasoning for id/password/namespace — only the file wins.
+  unset TRACEBLOC_CLIENT_ID TRACEBLOC_CLIENT_PASSWORD TB_NAMESPACE TRACEBLOC_CLIENT_ADOPTED
   # shellcheck disable=SC1090
   source "$cred_file"
   rm -f "$cred_file"

--- a/scripts/lib/provision.sh
+++ b/scripts/lib/provision.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  provision.sh — RFC-0001 #838: provision the client BEFORE Helm.
+#
+#  In the browser-auth path this installs the tracebloc CLI (FATAL — it mints the
+#  credential), signs in (`tracebloc login`, the device flow), and `tracebloc
+#  client create`s to mint the machine credential + derive the namespace. The
+#  credential is written to a 0600 file by `--credential-file` and sourced here
+#  (never printed), then handed to the Helm step via the SAME env contract
+#  install_client_helm already consumes:
+#      TRACEBLOC_CLIENT_ID + TRACEBLOC_CLIENT_PASSWORD + TB_NAMESPACE
+#
+#  DUAL-MODE (unchanged, one deprecation cycle): when the operator pre-supplies a
+#  values file (TRACEBLOC_VALUES_FILE) or credentials (TRACEBLOC_CLIENT_ID +
+#  TRACEBLOC_CLIENT_PASSWORD), browser sign-in is skipped and those paths feed
+#  Helm as before. Unattended installs use dual-mode — the device-flow `login` is
+#  interactive; a non-interactive enroll-token login is a CLI follow-up.
+# =============================================================================
+
+# _provisioning_preset: true when the operator already supplied a values file or
+# credentials, so browser sign-in is skipped and install_client_helm uses them.
+_provisioning_preset() {
+  [[ -n "${TRACEBLOC_VALUES_FILE:-}" ]] && return 0
+  [[ -n "${TRACEBLOC_CLIENT_ID:-}" && -n "${TRACEBLOC_CLIENT_PASSWORD:-}" ]] && return 0
+  return 1
+}
+
+provision_client() {
+  step 3 5 "Sign in and provision this client"
+
+  if _provisioning_preset; then
+    info "Using the credentials you supplied — skipping browser sign-in."
+    # Still install the CLI (non-fatal) so the operator has it for `data ingest`.
+    install_tracebloc_cli
+    return 0
+  fi
+
+  # Browser-auth path. The CLI is REQUIRED here (it mints the credential), so the
+  # install is effectively FATAL — unlike the old post-Helm, non-fatal Step 5.
+  install_tracebloc_cli
+  # The CLI installer may drop the binary in ~/.local/bin (not yet on this
+  # process's PATH); make it resolvable so the login/create calls below work.
+  export PATH="${HOME}/.local/bin:${PATH}"
+  has tracebloc || error "The tracebloc CLI is required to provision this client but isn't available after install. Install it (curl -fsSL ${TRACEBLOC_CLI_INSTALL_URL} | sh), open a new shell, and re-run."
+
+  # Sign in (device flow — approve in a browser). Unattended installs use the
+  # dual-mode credential path above.
+  info "Sign in to tracebloc — approve this machine in your browser when prompted…"
+  tracebloc login || error "Sign-in didn't complete — re-run the installer to try again."
+
+  # Mint the client + derive the namespace. --credential-file writes the secret to
+  # a 0600 file (never printed); we source it, hand it to Helm, then delete it (the
+  # secret's durable home is the Helm/cluster secret — RFC §7.9).
+  local cred_file="${HOST_DATA_DIR}/client-credential.env"
+  # Register the path so install_cleanup removes it on ANY exit (error/signal)
+  # between mint and the explicit removal below — the secret must never linger.
+  _PROVISION_CRED_FILE="$cred_file"
+  rm -f "$cred_file"
+  if ! tracebloc client create --yes --credential-file "$cred_file" >>"${LOG_FILE:-/dev/null}" 2>&1; then
+    rm -f "$cred_file"   # remove any partial the failed create may have written
+    error "Provisioning the client failed — see ${LOG_FILE:-the install log}. Re-run to retry."
+  fi
+  [[ -f "$cred_file" ]] || error "client create did not write the credential file ($cred_file)."
+
+  # shellcheck disable=SC1090
+  source "$cred_file"
+  rm -f "$cred_file"
+  unset _PROVISION_CRED_FILE
+
+  if [[ "${TRACEBLOC_CLIENT_ADOPTED:-}" == "1" ]]; then
+    # Re-run on an already-registered cluster: no fresh credential was minted (the
+    # existing one stands, write-only on the backend). Drop the partial creds and
+    # let install_client_helm reconcile the existing release from the local
+    # values.yaml (helm upgrade). A rebuilt host with no local values falls through
+    # to its existing credential prompt/error — the R7 orphan-resume is a follow-up.
+    info "This cluster is already registered (client ${TRACEBLOC_CLIENT_ID:-?}) — reconciling the existing install."
+    unset TRACEBLOC_CLIENT_ID TRACEBLOC_CLIENT_PASSWORD
+    export TB_NAMESPACE
+    return 0
+  fi
+
+  # Mint: hand the credential + the provisioned namespace to the Helm step. The
+  # namespace MUST be the created client's slug (Q2: it equals the heartbeat-
+  # reported namespace), so the minted value wins over any TB_NAMESPACE default.
+  export TRACEBLOC_CLIENT_ID TRACEBLOC_CLIENT_PASSWORD TB_NAMESPACE
+  info "Provisioned — credential handed to the install (not shown)."
+}

--- a/scripts/lib/provision.sh
+++ b/scripts/lib/provision.sh
@@ -25,6 +25,17 @@ _provisioning_preset() {
   return 1
 }
 
+# _cli_supports_provisioning: does the installed CLI ship the browser-auth mint
+# commands (`tracebloc login` + `tracebloc client create`)? install_tracebloc_cli
+# pulls the latest RELEASE, which can lag this installer until the cli#104 release
+# ships — so probe before committing to the path. `--help` is side-effect-free and
+# cobra exits non-zero on an unknown command, so this cleanly tells old from new.
+_cli_supports_provisioning() {
+  tracebloc login --help >/dev/null 2>&1 || return 1
+  tracebloc client create --help >/dev/null 2>&1 || return 1
+  return 0
+}
+
 provision_client() {
   step 3 5 "Sign in and provision this client"
 
@@ -42,6 +53,20 @@ provision_client() {
   # process's PATH); make it resolvable so the login/create calls below work.
   export PATH="${HOME}/.local/bin:${PATH}"
   has tracebloc || error "The tracebloc CLI is required to provision this client but isn't available after install. Install it (curl -fsSL ${TRACEBLOC_CLI_INSTALL_URL} | sh), open a new shell, and re-run."
+
+  # The browser-auth mint path needs a CLI new enough to ship `login` + `client
+  # create` (cli#104). The installed CLI comes from the latest RELEASE, which may
+  # predate this installer — so if it's too old, fall back to the proven manual-
+  # credential path (install_client_helm prompts for an existing client's
+  # credentials, exactly as before #838) instead of hard-failing on an unknown
+  # `tracebloc login`. Once the CLI release lands, the probe passes and the
+  # one-step browser flow takes over automatically.
+  if ! _cli_supports_provisioning; then
+    warn "This tracebloc CLI is too old to provision a client from the installer — falling back to manual sign-in."
+    hint "Connect an existing client below, or upgrade the CLI later for one-step browser sign-in:"
+    hint "  curl -fsSL ${TRACEBLOC_CLI_INSTALL_URL} | sh"
+    return 0
+  fi
 
   # Sign in (device flow — approve in a browser). Unattended installs use the
   # dual-mode credential path above.

--- a/scripts/tests/install-client-helm.bats
+++ b/scripts/tests/install-client-helm.bats
@@ -344,6 +344,28 @@ setup() {
   [[ "$output" == *"helm upgrade --install tracebloc"* ]]
 }
 
+@test "install_client_helm: same client in a different namespace -> upgrades in place, no duplicate" {
+  HOST_DATA_DIR="$BATS_TEST_TMPDIR/data"; mkdir -p "$HOST_DATA_DIR"
+  _ensure_tracebloc_dirs() { :; }
+  _ensure_release_dirs() { :; }
+  _ensure_helm_runnable() { :; }
+  # The minted/adopted namespace (client slug) differs from where this same client
+  # is already installed (the old fixed `tracebloc` namespace). Must upgrade the
+  # existing release in place, NOT fork a second one under 'acme-corp'.
+  export TB_NAMESPACE=acme-corp
+  helm() {
+    if [ "$1" = list ]; then echo '[{"name":"tracebloc","namespace":"tracebloc","chart":"client-1.4.3"}]'; return 0; fi
+    if [ "$1" = get ] && [ "$2" = values ]; then echo 'clientId: "sameid"'; return 0; fi
+    record "helm $*"; return 0
+  }
+  verify_credentials() { printf valid; }
+  run install_client_helm <<< $'sameid\nmypw'
+  [ "$status" -eq 0 ]
+  run mock_calls
+  [[ "$output" == *"helm upgrade --install tracebloc"* ]]   # reused existing namespace
+  [[ "$output" != *"acme-corp"* ]]                          # no second release forked
+}
+
 # ── _chart_proxy_env_yaml (#242: host proxy -> split chart keys) ─────────────
 @test "_chart_proxy_env_yaml: no proxy on host -> empty" {
   run _chart_proxy_env_yaml

--- a/scripts/tests/provision.bats
+++ b/scripts/tests/provision.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# Tests for provision.sh (RFC-0001 #838): sign in + `client create` BEFORE Helm,
+# handing the minted credential + namespace to install_client_helm via env.
+#
+# The load-bearing properties: dual-mode (pre-supplied creds/values) skips
+# sign-in; the browser-auth path is FATAL on a missing CLI / failed login /
+# missing credential file; a mint hands all three env vars to Helm; an adopt
+# hands only the namespace (no password) and lets Helm reconcile.
+
+load test_helper
+
+setup() {
+  load_lib install-cli.sh             # common.sh + install-cli.sh (URL, the real fn)
+  # shellcheck source=/dev/null
+  source "${LIB_DIR}/provision.sh"
+  step() { :; }
+  info() { echo "INFO: $*"; }
+  warn() { echo "WARN: $*"; }
+  hint() { echo "HINT: $*"; }
+  # error() is the real common.sh one (prints + exit 1) — fatal tests assert status.
+  has() { return 0; }                 # default: CLI present after install
+  install_tracebloc_cli() { :; }      # stubbed — covered by install-cli.bats
+  LOG_FILE="$(mktemp)"
+  HOST_DATA_DIR="$(mktemp -d)"
+  unset TRACEBLOC_VALUES_FILE TRACEBLOC_CLIENT_ID TRACEBLOC_CLIENT_PASSWORD \
+        TB_NAMESPACE TRACEBLOC_CLIENT_ADOPTED
+}
+
+# A `tracebloc` stub: `login` succeeds; `client create` writes the given
+# --credential-file with the env lines in $CRED_LINES.
+_stub_tracebloc() {
+  CRED_LINES="$1"
+  tracebloc() {
+    [ "$1" = "login" ] && return 0
+    local f="" prev=""
+    for a in "$@"; do [ "$prev" = "--credential-file" ] && f="$a"; prev="$a"; done
+    [ -n "$f" ] && printf '%b' "$CRED_LINES" > "$f"
+    return 0
+  }
+}
+
+@test "provision_client: dual-mode (credentials) skips browser sign-in" {
+  export TRACEBLOC_CLIENT_ID=abc TRACEBLOC_CLIENT_PASSWORD=xyz
+  tracebloc() { echo "TRACEBLOC $*"; }   # must NOT be called for login/create
+  run provision_client
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipping browser sign-in"* ]]
+  [[ "$output" != *"TRACEBLOC login"* ]]
+}
+
+@test "provision_client: dual-mode (values file) skips browser sign-in" {
+  export TRACEBLOC_VALUES_FILE=/tmp/values.yaml
+  tracebloc() { echo "TRACEBLOC $*"; }
+  run provision_client
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipping browser sign-in"* ]]
+}
+
+@test "provision_client: mint hands id+password+namespace to Helm" {
+  _stub_tracebloc 'TRACEBLOC_CLIENT_ID=5\nTRACEBLOC_CLIENT_PASSWORD=pw9\nTB_NAMESPACE=my-ns\n'
+  provision_client                       # called directly so exports persist
+  [ "$TRACEBLOC_CLIENT_ID" = "5" ]
+  [ "$TRACEBLOC_CLIENT_PASSWORD" = "pw9" ]
+  [ "$TB_NAMESPACE" = "my-ns" ]
+  # the credential file is transient — removed after sourcing
+  [ ! -f "${HOST_DATA_DIR}/client-credential.env" ]
+}
+
+@test "provision_client: adopt hands only the namespace (no password)" {
+  _stub_tracebloc 'TRACEBLOC_CLIENT_ID=8\nTB_NAMESPACE=ex-ns\nTRACEBLOC_CLIENT_ADOPTED=1\n'
+  provision_client
+  [ "$TB_NAMESPACE" = "ex-ns" ]
+  [ -z "${TRACEBLOC_CLIENT_PASSWORD:-}" ]   # no fresh credential on adopt
+  [ -z "${TRACEBLOC_CLIENT_ID:-}" ]         # partial creds cleared → Helm uses values.yaml
+}
+
+@test "provision_client: missing CLI after install is fatal" {
+  has() { return 1; }                    # CLI not resolvable after install
+  tracebloc() { return 0; }
+  run provision_client
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"tracebloc CLI is required"* ]]
+}
+
+@test "provision_client: failed sign-in is fatal" {
+  tracebloc() { [ "$1" = "login" ] && return 1; return 0; }
+  run provision_client
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Sign-in didn't complete"* ]]
+}
+
+@test "provision_client: client create writing no credential file is fatal" {
+  tracebloc() { return 0; }              # login OK, create "succeeds" but writes nothing
+  run provision_client
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"did not write the credential file"* ]]
+}
+
+@test "provision_client: a failed client create leaves no credential file behind" {
+  tracebloc() {
+    [ "$1" = "login" ] && return 0
+    # create writes a PARTIAL (secret-bearing) file, then fails — must be cleaned up.
+    local f="" prev=""
+    for a in "$@"; do [ "$prev" = "--credential-file" ] && f="$a"; prev="$a"; done
+    [ -n "$f" ] && printf 'TRACEBLOC_CLIENT_ID=5\nTRACEBLOC_CLIENT_PASSWORD=leak\n' >"$f"
+    return 1
+  }
+  run provision_client
+  [ "$status" -ne 0 ]
+  [ ! -f "${HOST_DATA_DIR}/client-credential.env" ]
+}

--- a/scripts/tests/provision.bats
+++ b/scripts/tests/provision.bats
@@ -66,6 +66,16 @@ _stub_tracebloc() {
   [ ! -f "${HOST_DATA_DIR}/client-credential.env" ]
 }
 
+@test "provision_client: a stale TRACEBLOC_CLIENT_ADOPTED in the env does not misroute a mint" {
+  export TRACEBLOC_CLIENT_ADOPTED=1      # leftover in the environment, NOT from the mint file
+  _stub_tracebloc 'TRACEBLOC_CLIENT_ID=7\nTRACEBLOC_CLIENT_PASSWORD=pw\nTB_NAMESPACE=mns\n'  # mint: no ADOPTED line
+  provision_client
+  # mint path must win: the credential is handed to Helm, not dropped as if adopted
+  [ "$TRACEBLOC_CLIENT_ID" = "7" ]
+  [ "$TRACEBLOC_CLIENT_PASSWORD" = "pw" ]
+  [ "$TB_NAMESPACE" = "mns" ]
+}
+
 @test "provision_client: adopt hands only the namespace (no password)" {
   _stub_tracebloc 'TRACEBLOC_CLIENT_ID=8\nTB_NAMESPACE=ex-ns\nTRACEBLOC_CLIENT_ADOPTED=1\n'
   provision_client

--- a/scripts/tests/provision.bats
+++ b/scripts/tests/provision.bats
@@ -56,6 +56,17 @@ _stub_tracebloc() {
   [[ "$output" == *"skipping browser sign-in"* ]]
 }
 
+@test "provision_client: a CLI too old to provision falls back to manual sign-in (not fatal)" {
+  # Old CLI: `login` / `client create` are unknown commands, so the --help probe
+  # exits non-zero. provision_client must fall back (return 0) and let
+  # install_client_helm collect credentials, NOT hard-fail on `tracebloc login`.
+  tracebloc() { case "$1" in login|client) return 1 ;; *) return 0 ;; esac; }
+  run provision_client
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"falling back to manual sign-in"* ]]
+  [[ "$output" != *"approve this machine in your browser"* ]]   # never entered the login flow
+}
+
 @test "provision_client: mint hands id+password+namespace to Helm" {
   _stub_tracebloc 'TRACEBLOC_CLIENT_ID=5\nTRACEBLOC_CLIENT_PASSWORD=pw9\nTB_NAMESPACE=my-ns\n'
   provision_client                       # called directly so exports persist
@@ -93,7 +104,9 @@ _stub_tracebloc() {
 }
 
 @test "provision_client: failed sign-in is fatal" {
-  tracebloc() { [ "$1" = "login" ] && return 1; return 0; }
+  # Provisioning-capable CLI (the --help capability probe passes), but the actual
+  # sign-in fails — that must still be fatal, not a silent fall-through.
+  tracebloc() { [[ "$*" == *--help ]] && return 0; [ "$1" = "login" ] && return 1; return 0; }
   run provision_client
   [ "$status" -ne 0 ]
   [[ "$output" == *"Sign-in didn't complete"* ]]
@@ -108,6 +121,7 @@ _stub_tracebloc() {
 
 @test "provision_client: a failed client create leaves no credential file behind" {
   tracebloc() {
+    [[ "$*" == *--help ]] && return 0      # capability probe: CLI supports provisioning
     [ "$1" = "login" ] && return 0
     # create writes a PARTIAL (secret-bearing) file, then fails — must be cleaned up.
     local f="" prev=""


### PR DESCRIPTION
## What

RFC-0001 **#838** ([epic backend#830](https://github.com/tracebloc/backend/issues/830)): reorder the installer so the client is **provisioned before Helm** — the minted credential + derived namespace feed the chart.

New flow in `install-k8s.sh`:
```
create_cluster → provision_client (Step 3) → install_client_helm (Step 4/5)
```

## `provision.sh` (new) — `provision_client`

- **Browser-auth path:** install the CLI **(now FATAL** — it mints the credential, vs the old non-fatal post-Helm Step 5) → `tracebloc login` (device flow) → `tracebloc client create --credential-file <f>` → **source the 0600 file** → export `TRACEBLOC_CLIENT_ID` + `TRACEBLOC_CLIENT_PASSWORD` + `TB_NAMESPACE` into `install_client_helm`'s **existing** non-interactive env contract. The credential is **never printed**; the transient file is removed after sourcing **and on any error/signal** (a failed mint never leaves a secret-bearing file behind).
- **Adopt (re-run):** no fresh credential (the existing one stands) — hands only `TB_NAMESPACE` and lets `install_client_helm` reconcile from the local `values.yaml`.
- **Dual-mode preserved:** `TRACEBLOC_VALUES_FILE` or pre-supplied `TRACEBLOC_CLIENT_ID`+`PASSWORD` **skip sign-in** entirely (still install the CLI, non-fatal) — exactly the prior behavior. Unattended installs use this path.

Also: `install.sh` fetches `provision.sh`; `common.sh` `print_roadmap` renumbered to match (3 sign-in/provision · 4 install · 5 connect) and `install_cleanup` shreds the transient credential on exit; the step headers + the trailing CLI install were updated/removed.

## Tests

`scripts/tests/provision.bats` (8): dual-mode skip (creds + values), mint hands all three env vars, adopt hands only the namespace, **fatal** on missing CLI / failed login / no credential file, and **a failed `create` leaves no credential file behind**. The `install-cli`, `install-client-helm`, and `common` (`install_cleanup`) suites stay green; `shellcheck` clean on `provision.sh`. (The 2 suite failures — `validate_config: valid config passes` and `_extract_yaml '' escape` — are **pre-existing on develop**, unrelated to this change.)

## Gate + deferred

- **Runs end-to-end once the CLI release ships `login` + `create` + `--credential-file`** (cli#104 merged; `install-cli.sh` fetches `releases/latest`).
- Adversarially reviewed (reorder/dual-mode safety, credential-handoff security, bats+integration); the should-fix items (cred-file cleanup on error, stale roadmap) are folded in.
- **Deferred** (noted, follow-ups): a non-interactive **enroll-token login** for fully unattended browser-auth installs; the **R7 orphan-resume** edge (adopt on a rebuilt host with no local `values.yaml` → it currently falls through to the existing credential prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
