### PR TITLE
ci(helm): drop redundant schema job + fix Lint/Unit tests name collision

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   lint:
     timeout-minutes: 10
-    name: Lint
+    name: Helm lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
 
   unittest:
     timeout-minutes: 10
-    name: Unit tests
+    name: Helm unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -106,28 +106,6 @@ jobs:
 
       - name: Run unit tests
         run: helm unittest ./client
-
-  schema:
-    timeout-minutes: 10
-    name: Schema validation
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [aks, bm, eks, oc]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.15.4
-
-      - name: Validate values against schema — ${{ matrix.platform }}
-        run: |
-          helm template test-${{ matrix.platform }} ./client \
-            -f client/ci/${{ matrix.platform }}-values.yaml \
-            > /dev/null
-          echo "Schema validation passed for ${{ matrix.platform }}"
 
   ingestor-multiarch:
     timeout-minutes: 10


### PR DESCRIPTION
Two cleanups to `helm-ci.yaml`:
- **Drop the `schema` job** — it re-rendered each platform to `/dev/null`, exactly what `template` already does (and `template` also runs kubeconform on the output). 4 matrix jobs of zero extra coverage. Not a required check, so safe to remove.
- **Rename `Lint`/`Unit tests` → `Helm lint`/`Helm unit tests`** — they collided with the same-named **required** checks that `standard-checks.yml` emits unconditionally on every PR. After this, the required contexts come unambiguously from `standard-checks`; branch protection (requires `Lint` + `Unit tests`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)