### PR TITLE
fix: Bugbot finding from promotion PR #284

### DIFF
--- a/scripts/install-k8s.sh
+++ b/scripts/install-k8s.sh
@@ -116,6 +116,12 @@ main() {
   #    aborting; in that case the operator must supply credentials/values. ──────
   if declare -F provision_client >/dev/null 2>&1; then
     provision_client
+  elif declare -F install_tracebloc_cli >/dev/null 2>&1; then
+    # Stale bootstrap: provision.sh wasn't fetched, but install-cli.sh was. Keep
+    # the old post-Helm Step 5 behavior so the CLI still gets installed (non-fatal,
+    # for `tracebloc data ingest`); provisioning then falls through to the dual-mode
+    # credential path inside install_client_helm.
+    install_tracebloc_cli
   fi
 
   # ── Step 4/5 + 5/5 are handled inside install_client_helm ────────────────

--- a/scripts/manifest.sha256
+++ b/scripts/manifest.sha256
@@ -1,4 +1,4 @@
-43046b1047af86c51e805467874184030fbfe5f6de24416bde44a80fdd2ef1c1  scripts/install-k8s.sh
+b946562948a7e6581147ec5a661456d841872464dd49df924236ac7825db70d9  scripts/install-k8s.sh
 5bdcbae06d6fddca16ca616bdbd83ba68d4206361ea5c2e73c09ac492ea2dfa0  scripts/lib/common.sh
 a370fc0c170f34f21d36d67e5434443b4ac8c671fba259826878b9840838b9c4  scripts/lib/preflight.sh
 e14e4dfc43f0ac8648a01b09f597d8c6b9e3d3dfb5a2953b099de7a09b4c29f5  scripts/lib/detect-gpu.sh


### PR DESCRIPTION
Resolves the Cursor Bugbot finding surfaced on the client promotion PR (#284, develop → main).

### Fix
- **Stale bootstrap skips CLI install** — CLI installation now lives only inside `provision_client`, which the orchestrator calls only when `provision.sh` was fetched. A stale bootstrap that fetched `install-cli.sh` but **not** `provision.sh` would finish without ever installing the CLI, unlike the previous post-Helm Step 5. Added an `elif` fallback: when `provision_client` is absent but `install_tracebloc_cli` is defined, call it (non-fatal) so the CLI still gets installed for `tracebloc data ingest`; provisioning then falls through to the dual-mode credential path inside `install_client_helm`. (https://github.com/tracebloc/client/pull/284#discussion_r3481197896)

Lands on `develop`; the promotion PR head picks it up on the next sync and Bugbot re-reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small installer orchestration fallback for edge-case stale bootstrap bundles; no auth or cluster logic changes beyond when the CLI install runs.
> 
> **Overview**
> Fixes a regression where **stale bootstraps** that fetch `install-cli.sh` but not `provision.sh` would complete **without installing the tracebloc CLI**, after CLI install was folded into `provision_client` only.
> 
> `install-k8s.sh` now adds an **`elif`** branch: if `provision_client` is undefined but `install_tracebloc_cli` exists, it calls **`install_tracebloc_cli`** (non-fatal, restoring the old post-Helm Step 5 behavior for `tracebloc data ingest`). Client provisioning still falls through to the **dual-mode credential path** in `install_client_helm`.
> 
> `scripts/manifest.sha256` is updated for the changed `install-k8s.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a0d3101f2a88e17741075206fea471f219d11e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->