### PR TITLE
security(R8): CODEOWNERS trust root + SHA-pin signing actions (client#282)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,15 @@
 /client/values.schema.json                              @saadqbal
 /client/values.yaml                                     @saadqbal
 /docs/SECURITY.md                                       @saadqbal
+
+# ── R8 signed-installer trust root (RFC-0001 / tracebloc/backend#889, client#282) ──
+# tracebloc.io/i.sh runs the latest signed release's install.sh, which cosign-verifies
+# every sub-script against a signed manifest. The keyless signer identity IS the release
+# workflow — so a change to the workflow, the installer, its sub-scripts, or the manifest
+# generator changes *what gets trusted*, and must be code-owner reviewed.
+/.github/workflows/release-helm-chart.yaml              @saadqbal
+/scripts/install.sh                                     @saadqbal
+/scripts/install-k8s.sh                                 @saadqbal
+/scripts/gen-manifest.sh                                @saadqbal
+/scripts/manifest.sha256                                @saadqbal
+/scripts/lib/                                           @saadqbal

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -27,7 +27,7 @@ jobs:
         # runs (actions/runner#2788, still open). An empty default would cause
         # checkout to fall back to the repo default branch and package the
         # chart from the wrong commit.
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
@@ -130,7 +130,7 @@ jobs:
         # release-triggered runs (actions/runner#2788, still open).
         # Attach BOTH chart tgzs so downloaders pinning a specific release
         # tag can pull either chart's exact bytes from this release page.
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |
@@ -166,13 +166,13 @@ jobs:
       - name: Checkout the released tag
         # Same actions/runner#2788 guard as above — pin to the release tag so the
         # manifest covers exactly the bytes published at this immutable ref.
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
         with:
           cosign-release: 'v2.4.1'   # keep in lockstep with scripts/install.sh COSIGN_VERSION
 
@@ -282,7 +282,7 @@ jobs:
           echo "stamped installer fails closed on a mutable ref (expected)"
 
       - name: Attach installer + signed manifest to the release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |


### PR DESCRIPTION
Closes #282 (the file half). RFC-0001 R8 follow-up (tracebloc/backend#889). Now that `tracebloc.io/i.sh` serves the latest signed release, the trust root is "whatever the release workflow signs" — so the workflow, installer, sub-scripts, and manifest generator must be review-gated, and the signing actions pinned.

## In this PR (files)
- **`.github/CODEOWNERS`** — extended to require code-owner review on the trust-root paths: `release-helm-chart.yaml`, `install.sh`, `install-k8s.sh`, `gen-manifest.sh`, `manifest.sha256`, `scripts/lib/`. (`@saadqbal` matches the existing owner; swap to a platform/security **team** when one exists so review isn't single-person / self-approvable.)
- **SHA-pin the signing-job actions** in `release-helm-chart.yaml` — `actions/checkout`, `sigstore/cosign-installer`, `softprops/action-gh-release` pinned to commit SHAs (`# v4/v3/v2` comments kept), so a compromised action tag can't inject into the sign/publish path.

## Still needs a repo-admin (ticket steps 2 + 3 — can't be done in a PR)
The filer has `maintain`, not `admin`. An admin needs to:
1. **Branch protection** on `develop` **and** `main`: require a PR before merge + **Require review from Code Owners** (so the CODEOWNERS paths above actually gate). Settings → Branches (or a repository ruleset).
2. **Protected tags** rule for **`v*`**: restrict who can create/update release tags (the keyless signer identity is the tag-triggered release workflow). Settings → Tags → New rule → `v*` (or a `tag`-target ruleset with a create/update restriction).

Once those two are set, the R8 trust root is fully locked. (The CODEOWNERS + SHA-pins here are inert for enforcement until the branch protection is enabled — but they're the prerequisite + safe to land now.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release signing/publish workflow and installer trust boundary; changes are hardening (review gates + action pinning) but affect how releases and `curl | bash` installs are produced.
> 
> **Overview**
> **Locks the R8 signed-installer trust root** by requiring code-owner review on paths that define what `tracebloc.io/i.sh` trusts: `release-helm-chart.yaml`, installer scripts (`install.sh`, `install-k8s.sh`), `gen-manifest.sh`, `manifest.sha256`, and `scripts/lib/`. A new CODEOWNERS section documents that the release workflow’s keyless signer identity is the trust boundary.
> 
> **SHA-pins supply-chain-sensitive GitHub Actions** in `release-helm-chart.yaml`: `actions/checkout`, `sigstore/cosign-installer`, and `softprops/action-gh-release` (chart upload, manifest signing checkout, and installer asset attach) now reference immutable commit SHAs with version comments, so a compromised floating tag cannot run in the sign/publish path.
> 
> Enforcement still depends on repo-admin branch protection and protected `v*` tags (called out in the PR); this change is the in-repo prerequisite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28a9230a45f8b0e02b9b37644d0ce673e44e9519. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->