### PR TITLE
chore(chart): bump client 1.8.4 → 1.8.5 (version + appVersion)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.8.4
-appVersion: "1.8.4"
+version: 1.8.5
+appVersion: "1.8.5"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
Release carrier for the R8 supply-chain hardening now on develop but not yet released:
- #287 — CODEOWNERS R8 trust root + SHA-pinned release-workflow actions
- #299 — R8 Windows installer (`install.ps1` pins to the immutable tag + cosign-verifies against the signed manifest; manifest + release workflow cover the Windows entrypoint)

The client chart **templates are unchanged** since v1.8.4 — this bump exists to version the release that stamps + publishes the hardened `install.sh`/`install.ps1` + signed manifest as release assets. `appVersion` kept in lockstep.

Patch bump (matches v1.8.1, which shipped the R8 *bash* installer as a patch).

Next steps after this merges (the actual release, yours to cut):
1. Promote develop → main (`chore(release): promote develop → main — R8 Windows installer + trust-root hardening (v1.8.5)`).
2. Create GitHub Release `v1.8.5` on main → triggers `release-helm-chart.yaml` (packages chart + stamps/publishes install.sh **and install.ps1** + manifest/sig/cert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only semver bump in `Chart.yaml`; no Kubernetes manifest or runtime behavior changes in this diff.
> 
> **Overview**
> **Release version carrier** for R8 supply-chain hardening (trust-root/CODEOWNERS, SHA-pinned release actions, cosign-verified `install.ps1` + manifest) already on develop—chart **templates are unchanged** since v1.8.4.
> 
> Updates `client/Chart.yaml` only: `version` and `appVersion` **1.8.4 → 1.8.5** so the GitHub release workflow can publish the chart and stamped `install.sh` / `install.ps1` assets under **v1.8.5**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c734453774d260ed6a277b496fa530c92392ae00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->