### PR TITLE
fix(tests): install-journey guard() asserted nothing + CI-config gaps (#310)

### DIFF
--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -17,6 +17,10 @@ on:
       - 'scripts/**'
       - '.github/workflows/installer-tests.yaml'
   pull_request:
+    # `labeled` is required so adding the `e2e` label to an open PR starts the
+    # e2e-journey job immediately — with the default types it would only fire on
+    # the next push, making the label gate feel broken.
+    types: [opened, synchronize, reopened, labeled]
     branches: [main, develop, openshift]
     paths:
       - 'scripts/**'
@@ -204,6 +208,7 @@ jobs:
         run: bash scripts/tests/e2e-proxy.sh
 
   path-persist:
+    timeout-minutes: 20
     # Fresh-shell PATH-persistence guard for the tracebloc CLI — the cheap, wide
     # leg. Installs cli/install.sh in a plain container per distro, then opens a
     # BRAND-NEW login AND non-login shell for each of bash/zsh/fish and asserts
@@ -249,6 +254,7 @@ jobs:
             sh -c 'command -v bash >/dev/null 2>&1 || apk add --no-cache bash >/dev/null 2>&1; exec bash scripts/tests/path-persist.sh'
 
   e2e-journey:
+    timeout-minutes: 30
     # Leg 2 — the full last-mile journey on a real cluster: create_cluster() →
     # install the CLI via cli/install.sh → apply a CREDENTIAL-FREE stub the CLI
     # discovers (a *-jobs-manager Deployment with the chart's labels + an

--- a/scripts/tests/e2e-journey.sh
+++ b/scripts/tests/e2e-journey.sh
@@ -83,18 +83,32 @@ guard() { # guard <seconds> <label> -- <command...>
   local secs="$1" label="$2"; shift 2
   [[ "${1:-}" == "--" ]] && shift
   if has timeout; then
-    if ! timeout --kill-after=15s "$secs" "$@"; then
-      local rc=$?
-      if [[ $rc -eq 124 ]]; then
-        error "step '${label}' exceeded ${secs}s — treating the hang as a failure."
-      fi
-      return $rc
+    # Capture the real exit status. `if ! timeout ...; then rc=$?` would read the
+    # NEGATED status ($? is always 0 inside that branch), so a failed or hung step
+    # returned 0 and the whole journey passed vacuously — see the negative-control
+    # self-test below. Run the command, stash its status via `|| rc=$?`, act on it.
+    local rc=0
+    timeout --kill-after=15s "$secs" "$@" || rc=$?
+    if [[ $rc -eq 124 ]]; then
+      error "step '${label}' exceeded ${secs}s — treating the hang as a failure."
     fi
+    return $rc
   else
     warn "'timeout' not found — running '${label}' without a watchdog."
     "$@"
   fi
 }
+
+# ── Negative control: prove the watchdog can actually fail ───────────────────
+# This whole harness once shipped with a guard() that returned 0 for a failed or
+# hung step, so `E2E JOURNEY PASS` was printed vacuously. Before we run any real
+# assertion, confirm guard() propagates a non-zero exit — otherwise a green run
+# means nothing. Run in a subshell so this script's `set -e` doesn't abort on the
+# intentional failure.
+if ( guard 5 "watchdog self-test" -- sh -c 'exit 7' ) >/dev/null 2>&1; then
+  error "watchdog self-test FAILED: guard() returned 0 for a command that exited non-zero — every assertion below would pass vacuously. Refusing to run."
+fi
+success "watchdog self-test: guard() propagates failures (a red step stays red)."
 
 echo "═══════════════════════════════════════════════════════════════════════"
 echo "  E2E last-mile journey   arch: $(uname -m)   kernel: $(uname -r)"


### PR DESCRIPTION
Follow-up to #214 (post-merge review by @aptracebloc). Fixes the findings that are solidly correct and locally reasoned; the path-persist signal rework is scoped separately on #310 (needs CI validation across the distro matrix).

## 🔴 Critical — `guard()` swallowed every failure (Leg 2 asserted nothing)
`scripts/tests/e2e-journey.sh` captured `local rc=$?` inside the `then` branch of `if ! timeout ...`. In bash, `$?` there is the **negated** status — always `0`. Since every assertion (`cluster info`, `dataset push --dry-run`) runs under `guard`, `set -e` never tripped and the job printed `E2E JOURNEY PASS` even when steps failed or hung.

Reproduced before the fix — a step exiting 3 and a 124 hang both made `guard` return `0`.

- Rewrote to `rc=0; timeout ... || rc=$?; return $rc` — a failed step now propagates and a 124 hang is a hard failure.
- Added a **negative-control self-test** at startup: `guard` must return non-zero for a command that exits non-zero, else the script refuses to run. `bash -n` and shellcheck both passed on the buggy version, so this locks the class.

## 🟡 Medium — CI config
- Added `timeout-minutes` to `path-persist` (20) and `e2e-journey` (30). Every other job in the file had one; these two rode to the 6h ceiling on a hang.
- Added `labeled` to the `pull_request` trigger types so adding the `e2e` label starts an `e2e-journey` run immediately instead of only on the next push.

## Deferred to #310 — 🟠 path-persist has no red/green signal
Not in this PR: it's a real rewrite, not a one-liner. The cli `install.sh` persists PATH to **one** rc file keyed off `$SHELL` (Linux bash→`.bashrc`, zsh→`.zshrc`, fish→config.fish, else `.profile`), and only when the prefix is under `$HOME`/off-PATH. As root the test installs to `/usr/local/bin` (already on PATH → persistence never exercised), and the `login × nonlogin` matrix doesn't match the installer's model (`bash -c` reads no rc files at all). Making it actually distinguish a pre-fix vs fixed installer means forcing `INSTALL_PREFIX=$HOME/.local/bin`, installing once per `$SHELL`, and asserting an *interactive* shell of that kind — which can only be validated in CI. Tracked on #310.

## Test plan
- Reproduced the `guard()` bug and verified the fix: self-test detects a non-zero exit; a failing guarded step aborts with its true exit code (SHOULD-NOT-PRINT line absent).
- `bash -n scripts/tests/e2e-journey.sh` — parses.
- `shellcheck --severity=error` (the CI gate) and `--severity=warning` (advisory) on the script + libs — both clean.
- `actionlint .github/workflows/installer-tests.yaml` — clean.

Refs #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The guard fix restores real failure semantics for the labeled e2e journey job; CI-only changes with no production runtime impact, but a previously green e2e job may now correctly fail when steps break.
> 
> **Overview**
> Fixes a **critical bug** in `e2e-journey.sh` where `guard()` always returned success: capturing `$?` inside `if ! timeout ...` read the negated status, so every guarded step (`cluster info`, `dataset push --dry-run`, etc.) could fail or hang while the job still printed **E2E JOURNEY PASS**. The watchdog now records the real exit via `timeout ... || rc=$?` and returns it; exit **124** still fails hard on timeout.
> 
> Adds a **negative-control self-test** at startup that refuses to run if `guard` does not propagate a non-zero exit from a deliberate failure.
> 
> In **installer-tests.yaml**: `timeout-minutes` for `path-persist` (20) and `e2e-journey` (30); `pull_request` trigger includes **`labeled`** so adding the `e2e` label starts the journey job without waiting for another push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1652770e7159778f1a97da18ec6ae125119b089d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->