### PR TITLE
fix(chart): inject proxyEnv into the resource-monitor DaemonSet

### DIFF
--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -91,6 +91,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "tracebloc.secretName" . }}
                   key: CLIENT_PASSWORD
+            {{- /* Corporate egress proxy (client-runtime#154): resource-monitor
+                 was the only backend-calling workload without proxyEnv, so its
+                 auth/heartbeat POSTs dialed direct and failed behind a proxy.
+                 Renders nothing when HTTP_PROXY_HOST is unset. requests honours
+                 the URL-form vars ambiently (trust_env); NO_PROXY carries the
+                 cluster-internal ranges, and the k8s python client ignores
+                 ambient proxy env, so in-cluster calls are unaffected. */ -}}
+            {{- include "tracebloc.proxyEnv" . | nindent 12 }}
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## Summary

resource-monitor is the only backend-calling workload whose pod gets **no proxy env** from the chart — jobs-manager, pods-monitor, requests-proxy, image-refresh, auto-upgrade and the egress-reachability check all include `tracebloc.proxyEnv` already. Behind a corporate egress proxy its `api-token-auth` and `edge-device-heartbeat` POSTs dial direct and fail, so proxied clusters show stale/no node resource data.

One include, appended after the DaemonSet's fixed env list (no `.Values.env` passthrough here, so the jobs-manager-style exclusion dance from #238 does not apply).

## Verified

- `helm template` with `env.HTTP_PROXY_HOST` set renders the URL-form sextet + cluster-safe NO_PROXY, correctly indented, directly after `CLIENT_PASSWORD`.
- Without `HTTP_PROXY_HOST`: renders nothing — non-proxy installs byte-identical.
- `helm lint` clean.
- In-cluster k8s API calls unaffected: NO_PROXY carries the internal ranges, and the kubernetes python client ignores ambient proxy env anyway.

## Companion

Code half: tracebloc/client-runtime#165 (shared ProxyConfig; resource_monitor threads split-key settings). With this include alone, **current** resource-monitor images already work behind a proxy via requests' `trust_env` handling of the URL-form vars — so this chart change is independently shippable and is the half that matters for existing clusters.

Refs tracebloc/client-runtime#154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
