### PR TITLE
fix(tests): give path-persist a real red/green signal (off-PATH prefix + interactive per-shell) (#310)

### DIFF
--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -210,15 +210,17 @@ jobs:
   path-persist:
     timeout-minutes: 20
     # Fresh-shell PATH-persistence guard for the tracebloc CLI — the cheap, wide
-    # leg. Installs cli/install.sh in a plain container per distro, then opens a
-    # BRAND-NEW login AND non-login shell for each of bash/zsh/fish and asserts
-    # `tracebloc` resolves + `tracebloc version` runs. This is the cell that goes
-    # RED on the pre-fix installer and GREEN on the fixed one (a fresh non-login
-    # bash reads ~/.bashrc, not ~/.profile) — the regression guard for the whole
-    # PATH class that distro-prereqs / e2e-cluster can't see (they assert in the
-    # same shell that ran the installer). No cluster, no Docker-in-Docker, no
-    # creds. The script iterates shell × mode INSIDE the container; distro is the
-    # matrix axis (it installs zsh/fish in-container where a package exists).
+    # leg. Installs cli/install.sh into an OFF-PATH prefix (~/.local/bin) in a
+    # plain container per distro, once per shell (SHELL=bash/zsh/fish so the
+    # installer persists to that shell's rc), then opens a BRAND-NEW INTERACTIVE
+    # shell of that kind and asserts `tracebloc` resolves + `tracebloc version`
+    # runs. Forcing an off-PATH prefix is what gives the test a real signal: it
+    # goes RED on an installer that doesn't persist PATH to the rc and GREEN on
+    # the fixed one — the regression guard for the whole PATH class that
+    # distro-prereqs / e2e-cluster can't see (they assert in the same shell that
+    # ran the installer). No cluster, no Docker-in-Docker, no creds. The script
+    # iterates shells INSIDE the container; distro is the matrix axis (it installs
+    # zsh/fish in-container where a package exists). See client#310.
     name: PATH persist — ${{ matrix.distro }}
     runs-on: ubuntu-latest
     strategy:

--- a/scripts/tests/path-persist.sh
+++ b/scripts/tests/path-persist.sh
@@ -3,25 +3,41 @@
 #  path-persist.sh — fresh-shell PATH-persistence guard for the tracebloc CLI
 # -----------------------------------------------------------------------------
 #  Runs INSIDE a plain distro container. Installs the tracebloc CLI via the
-#  cli repo's own install.sh, then — for every shell present among bash/zsh/fish
-#  — spawns a BRAND-NEW login shell AND a BRAND-NEW non-login shell and asserts:
+#  cli repo's own install.sh into a USER-LOCAL, OFF-PATH prefix, then — for each
+#  shell present among bash/zsh/fish — opens a BRAND-NEW INTERACTIVE shell (the
+#  kind a customer gets when they open a new terminal) and asserts:
 #
-#      command -v tracebloc      resolves
-#      tracebloc version         runs (exit 0)
+#      tracebloc      resolves on PATH
+#      tracebloc version   runs (exit 0)
 #
 #  Why this is the crux (and why no existing job catches it):
 #    distro-prereqs.sh and e2e-cluster.sh both run their assertions in the SAME
 #    shell process that ran the installer, so a CLI that only edits the *current*
 #    PATH (or writes to the wrong rc file) still looks green to them. The real
-#    customer opens a NEW terminal and types the documented next command. A fresh
-#    NON-LOGIN bash sources ~/.bashrc — NOT ~/.profile / ~/.bash_profile — so an
-#    installer that persists PATH only to ~/.profile passes "login" but FAILS
-#    "non-login". That asymmetry is exactly the class this script exists to lock
-#    down (it goes red on the pre-fix installer and green on the fixed one).
+#    customer opens a NEW terminal and types the documented next command.
+#
+#  Two things are load-bearing for this to actually produce a red/green signal
+#  (both were missing in the first cut of this test — see client#310):
+#
+#    1. OFF-PATH PREFIX. install.sh only PERSISTS a PATH entry when the binary
+#       lands somewhere that isn't already on PATH. As root it defaults to
+#       /usr/local/bin, which is on every PATH — so no rc is ever written and
+#       every shell resolves it trivially, even on a BROKEN installer. We pin
+#       INSTALL_PREFIX to ~/.local/bin (a $HOME dir the installer always
+#       persists, and which is not on any supported distro's default root PATH),
+#       so a fresh shell can ONLY find the binary if the installer persisted it.
+#
+#    2. INTERACTIVE, PER-SHELL. install.sh persists to a SINGLE rc file chosen
+#       from $SHELL (zsh→~/.zshrc, Linux bash→~/.bashrc, fish→config.fish). So we
+#       run the installer once per shell with SHELL=<that shell>, then assert a
+#       fresh INTERACTIVE shell of that kind — the one that reads that rc. A
+#       non-interactive `bash -c` reads NO rc, and a *login* bash reads
+#       ~/.profile (NOT the ~/.bashrc the installer writes on Linux); both
+#       mis-model "open a new terminal", which on Linux is interactive non-login.
 #
 #  No cluster, no Docker, no credentials — pure install.sh behaviour. Cheap and
 #  wide, so CI fans it out across the distro matrix (one container per distro;
-#  this script iterates shells × modes inside the container).
+#  this script iterates shells inside the container).
 #
 #  Configuration (env):
 #    TRACEBLOC_CLI_REF   How to obtain cli/install.sh. Either:
@@ -29,9 +45,8 @@
 #                          • a path to a local install.sh   → run directly.
 #                        The local-path form lets the cli repo point this guard
 #                        at the install.sh of the PR under test (cross-repo
-#                        pre-merge gate). Default: see TODO below.
-#    TRACEBLOC_CLI_VERSION  Optional. Passed to install.sh as `--version <tag>`
-#                        (handy to pin a tag when testing a URL installer).
+#                        pre-merge gate). Default: see DEFAULT_CLI_REF below.
+#    TRACEBLOC_CLI_VERSION  Optional. Passed to install.sh as `--version <tag>`.
 #
 #  Usage (inside a container, as root):
 #    bash scripts/tests/path-persist.sh
@@ -47,19 +62,19 @@ LIB="$HERE/../lib"
 # shellcheck source=/dev/null
 source "$LIB/common.sh"   # colours, has(), info/success/warn/error helpers
 
-# common.sh sets umask 077; a 077 binary under /usr/local/bin is still
+# common.sh sets umask 077; a 077 binary under the prefix is still
 # owner-executable, but relax to 022 so the install + any rc files it writes
 # look like a real host (the installer itself relaxes to 022 around tool installs).
 umask 022
 
 # ── Where to get cli/install.sh ──────────────────────────────────────────────
 # Default to the public release installer. cli#61's PATH-persist fix shipped in
-# cli v0.3.1 and is in every release since (verified: the served install.sh
-# persists PREFIX to ~/.bashrc / ~/.zshrc / fish config), so `releases/latest`
-# now exercises the FIXED installer — this guard stays green on a good release
-# and would go red if a future release regressed the PATH class. A cli-side
-# caller overrides TRACEBLOC_CLI_REF with a local path to a PR's own install.sh
-# for pre-merge cross-repo coverage (see cli install-path-persist.yml).
+# cli v0.3.1 and is in every release since (the served install.sh persists PREFIX
+# to ~/.bashrc / ~/.zshrc / fish config), so `releases/latest` exercises the
+# FIXED installer — this guard stays green on a good release and would go red if
+# a future release regressed the PATH class. A cli-side caller overrides
+# TRACEBLOC_CLI_REF with a local path to a PR's own install.sh for pre-merge
+# cross-repo coverage (see cli install-path-persist.yml).
 DEFAULT_CLI_REF="https://github.com/tracebloc/cli/releases/latest/download/install.sh"
 CLI_REF="${TRACEBLOC_CLI_REF:-$DEFAULT_CLI_REF}"
 CLI_VERSION="${TRACEBLOC_CLI_VERSION:-}"
@@ -91,6 +106,11 @@ _pm_install ca-certificates >/dev/null 2>&1 || true
 has zsh  || _pm_install zsh  >/dev/null 2>&1 || true
 has fish || _pm_install fish >/dev/null 2>&1 || true
 
+# ── Force a user-local, OFF-PATH prefix so persistence is actually exercised ──
+# See the header (point 1): without this the test would pass on a broken
+# installer. ~/.local/bin is a $HOME dir the installer ALWAYS persists.
+export INSTALL_PREFIX="$HOME/.local/bin"
+
 # ── Context banner ───────────────────────────────────────────────────────────
 PRETTY="$( . /etc/os-release 2>/dev/null && echo "${PRETTY_NAME:-unknown}" )"
 echo ""
@@ -99,107 +119,116 @@ echo "  path-persist (fresh-shell CLI guard)"
 echo "  distro : ${PRETTY}"
 echo "  arch   : $(uname -m)"
 echo "  cli ref: ${CLI_REF}"
+echo "  prefix : ${INSTALL_PREFIX} (off the default PATH — persistence required)"
 echo "═══════════════════════════════════════════════════════════════════════"
 
-# ── Run cli/install.sh ───────────────────────────────────────────────────────
-# We deliberately do NOT use `set -e` here: install.sh runs under its own
-# `set -eu`, and we want to capture its exit status explicitly so a failed
-# install reports as a clean FAIL line rather than aborting the banner/summary.
-echo ""
-echo "── installing the tracebloc CLI via cli/install.sh ─────────────────────"
+# Precondition: the prefix must NOT already be on this image's PATH, or a fresh
+# shell could resolve the binary WITHOUT any rc persistence and a green result
+# would prove nothing (the vacuous-pass trap client#310 called out). Bail loudly.
+case ":${PATH}:" in
+  *":$INSTALL_PREFIX:"*)
+    echo "RESULT: FAIL — $INSTALL_PREFIX is already on PATH in this image; the test can't attribute a pass to rc persistence."
+    exit 1 ;;
+esac
+
+# ── Resolve install.sh to a local file ONCE ──────────────────────────────────
+# install.sh re-fetches the binary per invocation, but we needn't re-download the
+# SCRIPT for every shell.
+INSTALLER=""
+IS_TEMP_INSTALLER=0
+case "$CLI_REF" in
+  http://*|https://*)
+    INSTALLER="$(mktemp)"; IS_TEMP_INSTALLER=1
+    if ! curl -fsSL "$CLI_REF" -o "$INSTALLER"; then
+      echo "RESULT: FAIL — could not download install.sh from ${CLI_REF}"; exit 1
+    fi ;;
+  *)
+    if [[ ! -f "$CLI_REF" ]]; then
+      echo "RESULT: FAIL — TRACEBLOC_CLI_REF is neither a URL nor an existing file: ${CLI_REF}"; exit 1
+    fi
+    INSTALLER="$CLI_REF" ;;
+esac
+cleanup() { [[ "$IS_TEMP_INSTALLER" == 1 && -n "$INSTALLER" ]] && rm -f "$INSTALLER"; }
+trap cleanup EXIT
 
 install_args=()
 [[ -n "$CLI_VERSION" ]] && install_args+=(--version "$CLI_VERSION")
 
-install_rc=0
-case "$CLI_REF" in
-  http://*|https://*)
-    # Download to a temp file then run, mirroring how the client installer
-    # invokes the CLI installer (download → run), rather than `curl | sh`
-    # (which hides curl's exit code behind sh's under pipefail).
-    installer="$(mktemp)"
-    if curl -fsSL "$CLI_REF" -o "$installer"; then
-      sh "$installer" "${install_args[@]}" || install_rc=$?
-    else
-      echo "  ✖ could not download install.sh from ${CLI_REF}"
-      install_rc=1
-    fi
-    rm -f "$installer"
-    ;;
-  *)
-    # Treat as a local path (the cross-repo caller mounts the PR's install.sh).
-    if [[ -f "$CLI_REF" ]]; then
-      sh "$CLI_REF" "${install_args[@]}" || install_rc=$?
-    else
-      echo "  ✖ TRACEBLOC_CLI_REF is neither a URL nor an existing file: ${CLI_REF}"
-      install_rc=1
-    fi
-    ;;
-esac
-
-if [[ $install_rc -ne 0 ]]; then
-  echo ""
-  echo "RESULT: FAIL — cli/install.sh exited ${install_rc} on ${PRETTY} (install itself failed)"
-  exit 1
-fi
-success "install.sh completed (exit 0)"
-
-# Sanity: the installer may have placed the binary in ~/.local/bin (the fallback
-# when /usr/local/bin isn't writable). That's a legitimate install — the WHOLE
-# point of this test is that the installer must make it reachable from a fresh
-# shell regardless of where it landed. We do NOT add anything to PATH ourselves:
-# discovering it from a pristine shell is the assertion.
-
-# ── The fresh-shell assertion (the mechanism) ────────────────────────────────
-# For one shell + mode, spawn a brand-new shell of that kind and check that BOTH
-# `command -v tracebloc` resolves AND `tracebloc version` runs. Returns 0/1 and
-# prints a single PASS/FAIL cell line. Crucially, each invocation is a fresh
-# process: it reads only the rc files that shell+mode actually reads on startup,
-# so it faithfully reproduces "customer opens a new terminal".
-assert_cell() {
-  local sh="$1" mode="$2"
-  local found="" ver_rc=0
-
-  case "$sh:$mode" in
-    bash:login)    found="$(bash -lc 'command -v tracebloc' 2>/dev/null)"; bash -lc 'tracebloc version >/dev/null 2>&1' || ver_rc=$? ;;
-    bash:nonlogin) found="$(bash  -c 'command -v tracebloc' 2>/dev/null)"; bash  -c 'tracebloc version >/dev/null 2>&1' || ver_rc=$? ;;
-    zsh:login)     found="$(zsh  -lc 'command -v tracebloc' 2>/dev/null)"; zsh  -lc 'tracebloc version >/dev/null 2>&1' || ver_rc=$? ;;
-    zsh:nonlogin)  found="$(zsh   -c 'command -v tracebloc' 2>/dev/null)"; zsh   -c 'tracebloc version >/dev/null 2>&1' || ver_rc=$? ;;
-    # fish reads ~/.config/fish/config.fish for BOTH login and non-login
-    # interactive shells, but a fresh non-interactive `fish -c` still sources it,
-    # so the login/non-login split is meaningful for parity with bash/zsh. fish's
-    # `command -v` and `command -s` both work; use -v for portability.
-    fish:login)    found="$(fish -lc 'command -v tracebloc' 2>/dev/null)"; fish -lc 'tracebloc version >/dev/null 2>&1' || ver_rc=$? ;;
-    fish:nonlogin) found="$(fish  -c 'command -v tracebloc' 2>/dev/null)"; fish  -c 'tracebloc version >/dev/null 2>&1' || ver_rc=$? ;;
-    *) echo "  ✖ ${sh} (${mode}): unknown shell/mode"; return 1 ;;
-  esac
-
-  if [[ -z "$found" ]]; then
-    printf '  ✖ %-5s %-9s tracebloc NOT on PATH in a fresh shell\n' "$sh" "($mode)"
-    return 1
-  fi
-  if [[ $ver_rc -ne 0 ]]; then
-    printf '  ✖ %-5s %-9s found at %s but `tracebloc version` exited %s\n' "$sh" "($mode)" "$found" "$ver_rc"
-    return 1
-  fi
-  printf '  ✔ %-5s %-9s %s\n' "$sh" "($mode)" "$found"
-  return 0
+# ── Per-shell mechanics ──────────────────────────────────────────────────────
+# Run the installer with SHELL pointing at the target shell so it persists to
+# THAT shell's rc (see header point 2), capturing its exit status explicitly (no
+# `set -e` here — install.sh runs under its own `set -eu`).
+install_for_shell() { # $1=shell name; sets $install_rc
+  install_rc=0
+  SHELL="$(command -v "$1")" sh "$INSTALLER" "${install_args[@]}" || install_rc=$?
 }
 
+# A brand-new INTERACTIVE shell reads the user rc the installer wrote. `</dev/null`
+# stops it blocking on stdin; stderr is dropped (an interactive shell without a
+# tty emits harmless "no job control" notices).
+resolves_interactive() { # $1=shell
+  case "$1" in
+    bash) bash -ic 'command -v tracebloc >/dev/null 2>&1' </dev/null >/dev/null 2>&1 ;;
+    zsh)  zsh  -ic 'command -v tracebloc >/dev/null 2>&1' </dev/null >/dev/null 2>&1 ;;
+    fish) fish -ic 'type -q tracebloc'                     </dev/null >/dev/null 2>&1 ;;
+  esac
+}
+version_interactive() { # $1=shell
+  case "$1" in
+    bash) bash -ic 'tracebloc version >/dev/null 2>&1' </dev/null >/dev/null 2>&1 ;;
+    zsh)  zsh  -ic 'tracebloc version >/dev/null 2>&1' </dev/null >/dev/null 2>&1 ;;
+    fish) fish -ic 'tracebloc version >/dev/null 2>&1' </dev/null >/dev/null 2>&1 ;;
+  esac
+}
+# A brand-new NON-INTERACTIVE shell reads NO user rc, so it must NOT resolve the
+# binary (which lives only in the off-PATH prefix). If it DOES, the prefix leaked
+# onto the base PATH and the positive assertion would be meaningless — so this is
+# a per-shell negative control. (Skipped for fish: `fish_add_path` writes a
+# universal variable and `fish -c` still sources config.fish, so a fresh
+# non-interactive fish legitimately resolves it; the global precondition above
+# covers fish.)
+resolves_noninteractive() { # $1=shell
+  case "$1" in
+    bash) bash -c 'command -v tracebloc >/dev/null 2>&1' </dev/null >/dev/null 2>&1 ;;
+    zsh)  zsh  -c 'command -v tracebloc >/dev/null 2>&1' </dev/null >/dev/null 2>&1 ;;
+  esac
+}
+
+# ── Install-per-shell → fresh-interactive-shell assertion ────────────────────
 echo ""
-echo "── fresh-shell resolution (login + non-login) ──────────────────────────"
+echo "── install (SHELL=<shell>) → fresh INTERACTIVE shell resolves + runs ────"
 
 fail=0
 tested=0
 for sh in bash zsh fish; do
   if ! has "$sh"; then
-    printf '  · %-5s %-9s skipped (shell not installed on %s)\n' "$sh" "(both)" "${PRETTY}"
+    printf '  · %-5s skipped (shell not installed on %s)\n' "$sh" "${PRETTY}"
     continue
   fi
-  for mode in login nonlogin; do
-    tested=$((tested + 1))
-    assert_cell "$sh" "$mode" || fail=1
-  done
+  tested=$((tested + 1))
+
+  install_for_shell "$sh"
+  if [[ $install_rc -ne 0 ]]; then
+    printf '  ✖ %-5s install.sh (SHELL=%s) exited %s\n' "$sh" "$sh" "$install_rc"
+    fail=1; continue
+  fi
+
+  # Negative control (bash/zsh): a fresh non-interactive shell must NOT find it.
+  if [[ "$sh" != fish ]] && resolves_noninteractive "$sh"; then
+    printf '  ✖ %-5s %s is reachable from a fresh NON-interactive shell — prefix leaked onto the base PATH; a pass would not prove persistence\n' "$sh" "tracebloc"
+    fail=1; continue
+  fi
+
+  # Positive: a fresh INTERACTIVE shell (reads the persisted rc) resolves + runs.
+  if ! resolves_interactive "$sh"; then
+    printf '  ✖ %-5s tracebloc NOT on PATH in a fresh interactive shell (installer did not persist to its rc)\n' "$sh"
+    fail=1; continue
+  fi
+  if ! version_interactive "$sh"; then
+    printf '  ✖ %-5s resolved but `tracebloc version` failed in a fresh interactive shell\n' "$sh"
+    fail=1; continue
+  fi
+  printf '  ✔ %-5s resolves + runs from a fresh interactive shell (rc persistence works)\n' "$sh"
 done
 echo "───────────────────────────────────────────────────────────────────────"
 
@@ -211,9 +240,9 @@ if [[ $tested -eq 0 ]]; then
 fi
 
 if [[ $fail -ne 0 ]]; then
-  echo "RESULT: FAIL — tracebloc was not reachable from a fresh shell on ${PRETTY}"
+  echo "RESULT: FAIL — tracebloc was not reachable from a fresh interactive shell on ${PRETTY}"
   echo "        (the install put the binary somewhere a new terminal doesn't see —"
   echo "         this is the cli#61 PATH-persistence class.)"
   exit 1
 fi
-echo "RESULT: PASS — tracebloc resolves + runs from every fresh shell on ${PRETTY}"
+echo "RESULT: PASS — install.sh persists PATH so tracebloc resolves + runs from a fresh interactive shell on ${PRETTY}"


### PR DESCRIPTION
Completes #310 (the remaining 🟠 item from @aptracebloc's #214 review; the Critical `guard()` bug + CI-config gaps landed in #311). Reworks `path-persist.sh` so it can actually distinguish a fixed installer from a broken one.

## The problem
As merged in #214 the guard passed on a broken installer too:
- Ran as root → cli `install.sh` installed to `/usr/local/bin` (on every PATH). The installer only **persists** a PATH entry for an off-PATH prefix, so no rc was ever written and every shell resolved the binary trivially. **No signal.**
- The `login × non-login` matrix mis-modelled "open a new terminal": a non-interactive `bash -c` reads **no** rc file, and a *login* bash reads `~/.profile` — not the `~/.bashrc` the installer writes on Linux.

## The fix
- **Off-PATH prefix.** Pin `INSTALL_PREFIX=$HOME/.local/bin` (a `$HOME` dir the installer *always* persists, off the default root PATH), and precondition-check it isn't already on PATH — else bail rather than assert nothing.
- **Per-shell install.** `install.sh` persists to a single rc keyed off `$SHELL`, so install once per shell with `SHELL=bash/zsh/fish`, then assert a fresh **interactive** shell of that kind (`bash -ic` / `zsh -ic` / `fish -ic`) — the one that reads that rc. The meaningless `login` dimension is dropped.
- **Per-shell negative control** (bash/zsh): a fresh non-interactive shell must **not** resolve the binary; if it does, the prefix leaked onto the base PATH and a pass would be meaningless. Skipped for fish (`fish_add_path` writes a universal variable and `fish -c` still sources `config.fish`; the global precondition covers fish).

## Test plan
- Validated the resolution mechanics locally with an isolated binary name (the dev host has a real `tracebloc` on PATH): a fresh **non-interactive** shell does **not** resolve it, while a fresh **interactive** shell does and `tracebloc version` runs — i.e. resolution is attributable to rc persistence.
- `bash -n`, `shellcheck --severity=error` (the gate) and `--severity=warning` (advisory), `actionlint` — all clean.
- **CI-only:** the full `distro × shell` matrix (real cli binary download + per-distro zsh/fish installs, interactive-shell behaviour without a tty across 9 base images) runs on GitHub — not claimed to pass locally.

Fixes #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test scripts and workflow documentation; no production installer or runtime behavior is modified.
> 
> **Overview**
> Reworks the **PATH persist** CI guard so it can fail on broken CLI installers instead of vacuously passing.
> 
> **`path-persist.sh`** now pins **`INSTALL_PREFIX=$HOME/.local/bin`** and aborts if that prefix is already on `PATH`, so `install.sh` must write rc persistence for the binary to be found. It downloads **`install.sh` once**, then for each of bash/zsh/fish runs the installer with **`SHELL` set to that shell** and checks a **fresh interactive** shell (`-ic`) resolves `tracebloc` and runs `tracebloc version`. The old **login vs non-login** matrix is removed. **bash/zsh** get a **negative control**: a non-interactive shell must not see the binary (detects prefix leaking onto base `PATH`).
> 
> **`installer-tests.yaml`** comments are updated to describe the off-PATH prefix, per-shell install, and interactive assertion model (references client#310).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5090e0cdd89a0377f27663cb70392d898e2b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->