### PR TITLE
fix(chart): bump default ingestor tag 0.3 → 0.5

### DIFF
--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -122,7 +122,7 @@ spec:
         - name: INGESTOR_IMAGE_REPOSITORY
           value: {{ (default dict .Values.images.ingestor).repository | default "ghcr.io/tracebloc/ingestor" | quote }}
         - name: INGESTOR_IMAGE_TAG
-          value: {{ (default dict .Values.images.ingestor).tag | default "0.3" | quote }}
+          value: {{ (default dict .Values.images.ingestor).tag | default "0.5" | quote }}
         - name: INGESTOR_IMAGE_DIGEST
           value: {{ (default dict .Values.images.ingestor).digest | default "" | quote }}
         - name: REQUESTS_PROXY_URL

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -107,7 +107,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: INGESTOR_IMAGE_TAG
-            value: "0.3"
+            value: "0.5"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -318,11 +318,19 @@ images:
     repository: "ghcr.io/tracebloc/ingestor"
     # Floating tag spawned by default (imagePullPolicy=Always). The team's
     # ghcr.io publishing convention uses semver-style float tags — `0` tracks
-    # the latest 0.x, `0.3` tracks the latest 0.3.x patch. `0.3` (patch-only
-    # auto-track) is the default: a future 0.4 release will NOT be picked up
-    # until this is moved to `0.4` (or set to `0` for minor auto-track too).
+    # the latest 0.x, `0.5` tracks the latest 0.5.x patch. `0.5` (patch-only
+    # auto-track) is the default: a future 0.6 release will NOT be picked up
+    # until this is moved to `0.6` (or set to `0` for minor auto-track too).
     # `latest` is rejected by the schema.
-    tag: "0.3"
+    #
+    # Pinned to the 0.5 line so the spawned ingestor supports the full task
+    # catalogue jobs-manager now validates at submit time — sentence_pair_
+    # classification and embeddings first ship in v0.5.6. The 0.3 line only
+    # supported 11 categories; leaving this at 0.3 while client-runtime's
+    # ingest schema tracks the newer categories re-opens the submit-vs-run
+    # drift bug (categories accepted at submit that the spawned image can't
+    # process). See client-runtime#162 discussion.
+    tag: "0.5"
     # Opt-in pin. Empty (default) = spawn by the floating `tag` above. Set to
     # a canonical multi-arch digest to lock all ingestion Jobs to one exact
     # image (see the comment block above). Last known-good baseline, for easy


### PR DESCRIPTION
## What

Bumps the default spawned-ingestor float tag `images.ingestor.tag` from `0.3` → `0.5`.

## Why

jobs-manager validates every `ingest.yaml` at submit time against a vendored schema that now tracks data-ingestors' newer task categories — `sentence_pair_classification`, `embeddings`, `seq2seq`, `causal_language_modeling` (client-runtime#162). Those categories first ship in the ingestor **0.5** line (`v0.5.6`); the `0.3` float tag resolves to the latest `0.3.x` (`v0.3.12`), which supports only **11** categories.

Leaving the spawned ingestor on `0.3` while submit-time validation accepts 15 re-opens the submit-vs-run drift bug (the #64 class): a customer submitting one of the new categories passes validation, a Job is minted, and the `0.3` image can't process it. This was found while triaging review comments on client-runtime#161 — dev, **staging**, and prod all pin `0.3`.

## Changes

- `values.yaml` — `images.ingestor.tag` `0.3` → `0.5`, with a rationale comment. `0.5` auto-tracks `0.5.x` patches (`imagePullPolicy=Always`); a future `0.6` needs an explicit bump, same convention as before.
- `templates/jobs-manager-deployment.yaml` — the `--reuse-values` nil-guard fallback `default "0.3"` → `default "0.5"`, so upgrading a release that predates the `images.ingestor` key doesn't silently fall back to the drifting `0.3`.
- `tests/jobs_manager_test.yaml` — default-wiring assertion `0.3` → `0.5`.

## Verification

`helm template` renders `INGESTOR_IMAGE_TAG: "0.5"` on both the default path and the nil-guard (`images.ingestor=null`) path.

## Before merge / deploy — please confirm

- `ghcr.io/tracebloc/ingestor:0.5` exists and is a **multi-arch** index (amd64+arm64). Per `release-image.yml` the `v0.5.x` releases publish the `:0.5` float tag; the chart's `ingestor-multiarch` CI job enforces the multi-arch requirement. (I couldn't list ghcr tags directly — the CLI token lacks `read:packages`.)
- Roll this out **before or with** the client-runtime develop→staging promotion (client-runtime#161), so staging's submit schema never gets ahead of the ingestor it schedules.

## Related

- client-runtime#162 (schema → develop, 15 categories)
- client-runtime#161 (staging promotion; review flagged this drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which container image runs for all default ingestion Jobs; wrong or missing `ghcr.io/tracebloc/ingestor:0.5` would break ingestion fleet-wide, but scope is a version bump aligned with runtime schema—not auth or data-path logic.
> 
> **Overview**
> **Aligns the chart’s default spawned ingestor with jobs-manager validation** by changing `images.ingestor.tag` from `0.3` to `0.5`, with comments explaining that newer task categories (e.g. `sentence_pair_classification`, embeddings) ship on the 0.5 line while 0.3 only covered 11 categories.
> 
> The jobs-manager deployment template’s nil-guard fallback for `INGESTOR_IMAGE_TAG` is updated the same way (`0.3` → `0.5`), so upgrades with `--reuse-values` on releases that lack `images.ingestor` no longer silently schedule the old 0.3 image. The Helm unit test for default ingestor wiring expects `0.5` instead of `0.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7268b24b78775ad7d50b5cbd1465d78240ba729c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->