### PR TITLE
fix(tests): run create_cluster in a timeout-able bash in e2e-journey

### DIFF
--- a/scripts/tests/e2e-journey.sh
+++ b/scripts/tests/e2e-journey.sh
@@ -124,7 +124,17 @@ install_helm
 
 echo ""
 echo "── Step 1: create_cluster() — the installer's real cluster-bring-up ─────"
-guard 600 "create_cluster" -- create_cluster
+# `timeout` (inside guard) execs an external command in a fresh process, so it
+# cannot see create_cluster — a shell function sourced from cluster.sh (guarding
+# it directly fails with "timeout: failed to run command 'create_cluster': No
+# such file or directory", exit 127). Run it inside a real `bash` (which timeout
+# CAN exec) that re-sources the libs. The exported CLUSTER_NAME /
+# TRACEBLOC_NO_AUTOSTART / USER carry through the env, and the CLI binaries the
+# install_* steps dropped into /usr/local/bin are on the inherited PATH.
+guard 600 "create_cluster" -- bash -c '
+  set -euo pipefail
+  source "$1/common.sh"; source "$1/setup-linux.sh"; source "$1/cluster.sh"
+  create_cluster' _ "$LIB"
 
 echo "── assert: all nodes reach Ready ──"
 guard 200 "wait nodes Ready" -- kubectl wait --for=condition=Ready nodes --all --timeout=180s


### PR DESCRIPTION
## What

`scripts/tests/e2e-journey.sh` step 1 failed on `develop` with:

```
timeout: failed to run command 'create_cluster': No such file or directory
exit code 127
```

The `guard()` watchdog added in #310/#311 wraps each step in `timeout`. `timeout` execs an external command in a fresh process and cannot see shell functions — and `create_cluster` is a function sourced from `scripts/lib/cluster.sh`. So the very first guarded step aborted before the cluster was ever created, failing the **E2E last-mile journey (amd64)** check (e.g. on #309).

## Fix

Run `create_cluster` inside a real `bash` (which `timeout` *can* exec) that re-sources the libs:

```bash
guard 600 "create_cluster" -- bash -c '
  set -euo pipefail
  source "$1/common.sh"; source "$1/setup-linux.sh"; source "$1/cluster.sh"
  create_cluster' _ "$LIB"
```

- Exported `CLUSTER_NAME` / `TRACEBLOC_NO_AUTOSTART` / `USER` carry through the env.
- The CLI binaries `install_*` dropped into `/usr/local/bin` are on the inherited PATH.
- The existing `guard()` negative-control self-test still validates the timeout mechanics (it guards `sh -c 'exit 7'`, a real binary).

Verified locally: script parses (`bash -n`) and `create_cluster` resolves inside the re-sourcing subshell.

Refs #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness-only change; no production installer or cluster logic modified.
> 
> **Overview**
> Fixes **E2E last-mile journey** step 1 failing immediately with `timeout: failed to run command 'create_cluster'` (exit 127) after the `guard()` watchdog started wrapping steps in GNU `timeout`.
> 
> `guard` passes its command to `timeout`, which only runs real executables—not shell functions like `create_cluster` from `cluster.sh`. Step 1 now runs **`bash -c`** that re-sources `common.sh`, `setup-linux.sh`, and `cluster.sh`, then calls `create_cluster`, with `$LIB` passed as `_` so sourcing still works under `timeout`.
> 
> Exported env (`CLUSTER_NAME`, `TRACEBLOC_NO_AUTOSTART`, `USER`) and PATH from prior `install_*` steps are unchanged; inline comments document why the indirection is required. Other guarded steps already use binaries (`kubectl`, `curl`, `sh`, etc.) and are unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 528d8d4e8871f0b637b39facadb2ab767d1774d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->