### PR TITLE
chore(chart): bump client 1.8.5 → 1.9.0 (version + appVersion)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.8.5
-appVersion: "1.8.5"
+version: 1.9.0
+appVersion: "1.9.0"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
Release carrier for the 13 commits on `develop` since v1.8.5. **Minor** bump — ships a new user-facing feature + a default-image behavior change on top of fixes/hardening.

## What's in 1.9.0
- **feat(installer):** first-run UX — interim slice of the v2 spec (#307)
- **fix(chart):** default ingestor tag 0.3 → 0.5 (#314); inject proxyEnv into resource-monitor DaemonSet (#312)
- **fix(installer):** configurable training size at install (#308); harden provision location + client-detect guards (#315)
- **fix(tests):** ×4 (e2e-journey guards/timeouts, path-persist signal, Step-4 data validate); cross-repo fresh-shell E2E harness (#214)
- **ci(helm):** drop redundant schema job; rename colliding test jobs (#280)

## Change
`client/Chart.yaml`: `version` + `appVersion` 1.8.5 → 1.9.0 in lockstep (appVersion feeds the `app.kubernetes.io/version` label cluster-info reads).

## Release flow
develop is already in sync with main → merge this → publish GitHub Release tagged `v1.9.0` on main → release workflow packages from the tag to gh-pages; fleet auto-upgrade flips at :23.

Closes #319

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata bump in Chart.yaml with no runtime manifest or values changes in this diff.
> 
> **Overview**
> **Bumps the client Helm chart release metadata from 1.8.5 to 1.9.0** in `client/Chart.yaml`, updating `version` and `appVersion` together so packaging, GitHub Release tagging, and fleet auto-upgrade align on the same semver.
> 
> This PR is the chart-only carrier for work already on `develop` (installer first-run UX, ingestor default tag and proxy env fixes, installer/training and provision hardening, test/CI updates). No templates or values change here—only the chart’s declared version, which also drives labels such as `app.kubernetes.io/version` used by cluster-info.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22805a8db04e791d57ed0ddd2c6698fe317d3635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->