### PR TITLE
Sync develop → main for v1.9.0 chart release (installer first-run UX + ingestor default 0.5 + fixes)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.8.5
-appVersion: "1.8.5"
+version: 1.9.0
+appVersion: "1.9.0"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
Sync `develop` → `main` to cut the **v1.9.0** client chart release.

## What ships in v1.9.0 (since v1.8.5)
- **feat(installer):** first-run UX — interim slice of the v2 spec (#307)
- **fix(chart):** default ingestor tag 0.3 → 0.5 (#314); inject proxyEnv into resource-monitor DaemonSet (#312)
- **fix(installer):** configurable training size at install (#308); harden provision location + client-detect guards (#315)
- **fix(tests):** ×4 (e2e-journey guards/timeouts, path-persist signal, Step-4 data validate); cross-repo fresh-shell E2E harness (#214)
- **ci(helm):** drop redundant schema job; rename colliding test jobs (#280)
- **chore(chart):** bump client 1.8.5 → 1.9.0 (version + appVersion, #320)

## After merge
Publish a GitHub Release tagged `v1.9.0` on `main` → release workflow packages the chart from the tag to gh-pages; fleet auto-upgrade flips at :23.

Tracked by #319.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart metadata version bump only; no runtime or template changes in this diff.
> 
> **Overview**
> Cuts the **v1.9.0** client Helm release by bumping `version` and `appVersion` in `client/Chart.yaml` from **1.8.5** to **1.9.0**.
> 
> No chart templates or values change in this diff—only the release metadata so `main` can be tagged and published for fleet auto-upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec55dd3d1608d17bab2381a7607f74a9c43d73c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->