### PR TITLE
chore(chart): roll ingestor tag 0.5 → 0.6, bump chart 1.9.0 → 1.9.1

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.0
-appVersion: "1.9.0"
+version: 1.9.1
+appVersion: "1.9.1"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -122,7 +122,7 @@ spec:
         - name: INGESTOR_IMAGE_REPOSITORY
           value: {{ (default dict .Values.images.ingestor).repository | default "ghcr.io/tracebloc/ingestor" | quote }}
         - name: INGESTOR_IMAGE_TAG
-          value: {{ (default dict .Values.images.ingestor).tag | default "0.5" | quote }}
+          value: {{ (default dict .Values.images.ingestor).tag | default "0.6" | quote }}
         - name: INGESTOR_IMAGE_DIGEST
           value: {{ (default dict .Values.images.ingestor).digest | default "" | quote }}
         - name: REQUESTS_PROXY_URL

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -107,7 +107,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: INGESTOR_IMAGE_TAG
-            value: "0.5"
+            value: "0.6"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -323,14 +323,16 @@ images:
     # until this is moved to `0.6` (or set to `0` for minor auto-track too).
     # `latest` is rejected by the schema.
     #
-    # Pinned to the 0.5 line so the spawned ingestor supports the full task
-    # catalogue jobs-manager now validates at submit time — sentence_pair_
-    # classification and embeddings first ship in v0.5.6. The 0.3 line only
-    # supported 11 categories; leaving this at 0.3 while client-runtime's
-    # ingest schema tracks the newer categories re-opens the submit-vs-run
-    # drift bug (categories accepted at submit that the spawned image can't
-    # process). See client-runtime#162 discussion.
-    tag: "0.5"
+    # Pinned to the 0.6 line so the spawned ingestor carries the current
+    # ingestion correctness fixes — case/whitespace label-column resolution
+    # (data-ingestors#340) and UTF-8 BOM header handling (#338) — and still
+    # supports the full task catalogue jobs-manager validates at submit time
+    # (sentence_pair_classification and embeddings shipped in v0.5.6). Keep
+    # this tracking the current line: leaving it on an older line while
+    # client-runtime's ingest schema tracks newer categories re-opens the
+    # submit-vs-run drift bug (categories accepted at submit that the spawned
+    # image can't process). See client-runtime#162 discussion.
+    tag: "0.6"
     # Opt-in pin. Empty (default) = spawn by the floating `tag` above. Set to
     # a canonical multi-arch digest to lock all ingestion Jobs to one exact
     # image (see the comment block above). Last known-good baseline, for easy


### PR DESCRIPTION
## Summary

Moves `images.ingestor.tag` `"0.5"` → `"0.6"` so prod ingestion picks up the data-ingestors **0.6.0** release. `digest` stays empty (floating mode), so jobs-manager auto-rolls on the next ingestion submit — no digest pin, no CronJob, revert-proof against `helm upgrade`.

The 0.6 image is published, multi-arch, and signed:
- `ghcr.io/tracebloc/ingestor:0.6` → `sha256:be42a384904ec3372d24f66894acf91562bc65d2960bb96d56756e69bdf055e8`
- platforms: linux/amd64 + linux/arm64 (satisfies the `ingestor-multiarch` guard / #186)

## Related

Closes tracebloc/client#322. Consumes data-ingestors 0.6.0 (#338 BOM, #340 label-column, #347 layout contract).

## Type of change
- [x] Tech-debt / chore (image rollout)

## Test plan
- Verified `:0.6` resolves to the v0.6.0 release digest and is a multi-arch index (amd64+arm64) before bumping.
- Values-only default change; jobs-manager builds the ref from `repository`/`tag`/`digest` (empty digest → spawn by tag).

## Deployment notes
Ships to prod via the next `develop → main` chart sync. A MINOR line move is intentional — future 0.6.x patches auto-track; a later 0.7 will again require moving this tag (or set `0` for minor auto-track).

## Checklist
- [x] No secrets / credentials in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart version and default ingestor tag only; floating-tag spawn behavior is unchanged and there is no auth or data-path logic in the diff.
> 
> **Overview**
> Bumps the Helm chart to **1.9.1** and moves the default spawned ingestor image from the **`0.5`** to the **`0.6`** floating tag (`images.ingestor.tag` and the `INGESTOR_IMAGE_TAG` fallback in jobs-manager). **`digest` stays empty**, so ingestion jobs still resolve the current published image at submit time with `imagePullPolicy=Always`—no digest pin or extra rollout step.
> 
> The values comments now call out why the line moved: **0.6** picks up ingestion fixes (label-column resolution, UTF-8 BOM headers) while keeping parity with the task catalogue jobs-manager validates at submit. The jobs-manager Helm test default tag expectation is updated to **`0.6`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c2b409e9b981631c3c4c3c6dda288f48d2c8ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->