### PR TITLE
Sync develop → main for v1.9.1 chart release (ingestor 0.6)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.0
-appVersion: "1.9.0"
+version: 1.9.1
+appVersion: "1.9.1"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -122,7 +122,7 @@ spec:
         - name: INGESTOR_IMAGE_REPOSITORY
           value: {{ (default dict .Values.images.ingestor).repository | default "ghcr.io/tracebloc/ingestor" | quote }}
         - name: INGESTOR_IMAGE_TAG
-          value: {{ (default dict .Values.images.ingestor).tag | default "0.5" | quote }}
+          value: {{ (default dict .Values.images.ingestor).tag | default "0.6" | quote }}
         - name: INGESTOR_IMAGE_DIGEST
           value: {{ (default dict .Values.images.ingestor).digest | default "" | quote }}
         - name: REQUESTS_PROXY_URL

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -107,7 +107,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: INGESTOR_IMAGE_TAG
-            value: "0.5"
+            value: "0.6"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -323,14 +323,16 @@ images:
     # until this is moved to `0.6` (or set to `0` for minor auto-track too).
     # `latest` is rejected by the schema.
     #
-    # Pinned to the 0.5 line so the spawned ingestor supports the full task
-    # catalogue jobs-manager now validates at submit time — sentence_pair_
-    # classification and embeddings first ship in v0.5.6. The 0.3 line only
-    # supported 11 categories; leaving this at 0.3 while client-runtime's
-    # ingest schema tracks the newer categories re-opens the submit-vs-run
-    # drift bug (categories accepted at submit that the spawned image can't
-    # process). See client-runtime#162 discussion.
-    tag: "0.5"
+    # Pinned to the 0.6 line so the spawned ingestor carries the current
+    # ingestion correctness fixes — case/whitespace label-column resolution
+    # (data-ingestors#340) and UTF-8 BOM header handling (#338) — and still
+    # supports the full task catalogue jobs-manager validates at submit time
+    # (sentence_pair_classification and embeddings shipped in v0.5.6). Keep
+    # this tracking the current line: leaving it on an older line while
+    # client-runtime's ingest schema tracks newer categories re-opens the
+    # submit-vs-run drift bug (categories accepted at submit that the spawned
+    # image can't process). See client-runtime#162 discussion.
+    tag: "0.6"
     # Opt-in pin. Empty (default) = spawn by the floating `tag` above. Set to
     # a canonical multi-arch digest to lock all ingestion Jobs to one exact
     # image (see the comment block above). Last known-good baseline, for easy


### PR DESCRIPTION
## Summary

Release sync: ships the chart **1.9.0 → 1.9.1** batch to `main` / prod. Sole content is the ingestor floating-tag roll to the 0.6 line (#323).

**Prod effect:** jobs-manager spawns each ingestion Job by `images.ingestor.tag` (`imagePullPolicy=Always`, empty digest = floating), so once this reaches prod the next ingestion submit auto-rolls to `ghcr.io/tracebloc/ingestor:0.6` (→ `sha256:be42a384…055e8`, multi-arch amd64+arm64).

Brings to prod ingestion: case/whitespace label-column resolution (data-ingestors#340), UTF-8 BOM header handling (#338), and the machine-readable layout contract (#347).

## Related

Contains #323. Closes tracebloc/client#322.

## Type of change
- [x] Release / chart version bump

## Test plan
- Full chart CI green on #323 (Helm lint + unit tests, source-of-truth drift, template renders aks/bm/eks/oc, multi-arch guard).
- `:0.6` verified as a multi-arch index resolving to the v0.6.0 release digest before the tag roll.

## Deployment notes
Floating-tag roll — no digest pin. Future 0.6.x patches auto-track; a later 0.7 will require moving the tag again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which ingestor image runs for every ingestion Job in prod; behavior is intentional but affects data ingestion correctness and compatibility.
> 
> **Overview**
> **Chart release 1.9.0 → 1.9.1** rolls the default spawned ingestor image from the **0.5** to the **0.6** floating tag (`ghcr.io/tracebloc/ingestor:0.6`), with matching template fallbacks and Helm unit test expectations.
> 
> After deploy, jobs-manager still spawns ingestion Jobs with an empty digest and `imagePullPolicy=Always`, so new submits resolve the current **0.6.x** image (including label-column normalization and UTF-8 BOM header fixes noted in values comments). **values.yaml** comments were updated to document the 0.6 line and avoid submit-vs-run task-catalog drift.
> 
> No digest pin — future **0.6.x** patches auto-track until the tag is bumped again for a new minor line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4423f2b1533c7ddd83d12eae8c12d8f7d1a63d7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->