### PR TITLE
chore(chart): bump client 1.9.1 → 1.9.2

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.1
-appVersion: "1.9.1"
+version: 1.9.2
+appVersion: "1.9.2"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
Dedicated version-bump for the **v1.9.2** chart release. Bumps `client/Chart.yaml` `version` **and** `appVersion` in lockstep (1.9.1 → 1.9.2).

### Ships in v1.9.2 (everything unreleased since v1.9.0)
- #323 — ingestor default tag → 0.6 (landed on main as 1.9.1, never published)
- #325 — stop leaking client password on curl's argv (CWE-214)
- #326 — survive `curl|bash`: retry name prompt (customer-reported), read creds from terminal, guard pkg-index refresh

Release tracked in #328. After this merges to develop, a develop → main sync PR + GitHub Release `v1.9.2` follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only chart version bump with no application or template logic changes in this diff.
> 
> **Overview**
> Bumps the **client** Helm chart **`version`** and **`appVersion`** in `Chart.yaml` from **1.9.1** to **1.9.2** so the chart can be published as the v1.9.2 release.
> 
> This PR is only the version metadata change; functional fixes listed for v1.9.2 (ingestor tag, install script hardening, etc.) are already on the branch from earlier merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c16211722f2293f3d93b8085880b436f355b86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->