### PR TITLE
chore(chart): roll ingestor tag 0.6 → 0.7, bump chart 1.9.2 → 1.9.3

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.2
-appVersion: "1.9.2"
+version: 1.9.3
+appVersion: "1.9.3"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -122,7 +122,7 @@ spec:
         - name: INGESTOR_IMAGE_REPOSITORY
           value: {{ (default dict .Values.images.ingestor).repository | default "ghcr.io/tracebloc/ingestor" | quote }}
         - name: INGESTOR_IMAGE_TAG
-          value: {{ (default dict .Values.images.ingestor).tag | default "0.6" | quote }}
+          value: {{ (default dict .Values.images.ingestor).tag | default "0.7" | quote }}
         - name: INGESTOR_IMAGE_DIGEST
           value: {{ (default dict .Values.images.ingestor).digest | default "" | quote }}
         - name: REQUESTS_PROXY_URL

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -107,7 +107,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: INGESTOR_IMAGE_TAG
-            value: "0.6"
+            value: "0.7"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -318,21 +318,22 @@ images:
     repository: "ghcr.io/tracebloc/ingestor"
     # Floating tag spawned by default (imagePullPolicy=Always). The team's
     # ghcr.io publishing convention uses semver-style float tags — `0` tracks
-    # the latest 0.x, `0.5` tracks the latest 0.5.x patch. `0.5` (patch-only
-    # auto-track) is the default: a future 0.6 release will NOT be picked up
-    # until this is moved to `0.6` (or set to `0` for minor auto-track too).
+    # the latest 0.x, `0.7` tracks the latest 0.7.x patch. `0.7` (patch-only
+    # auto-track) is the default: a future 0.8 release will NOT be picked up
+    # until this is moved to `0.8` (or set to `0` for minor auto-track too).
     # `latest` is rejected by the schema.
     #
-    # Pinned to the 0.6 line so the spawned ingestor carries the current
-    # ingestion correctness fixes — case/whitespace label-column resolution
-    # (data-ingestors#340) and UTF-8 BOM header handling (#338) — and still
-    # supports the full task catalogue jobs-manager validates at submit time
-    # (sentence_pair_classification and embeddings shipped in v0.5.6). Keep
-    # this tracking the current line: leaving it on an older line while
-    # client-runtime's ingest schema tracks newer categories re-opens the
-    # submit-vs-run drift bug (categories accepted at submit that the spawned
-    # image can't process). See client-runtime#162 discussion.
-    tag: "0.6"
+    # Pinned to the 0.7 line so the spawned ingestor carries the current
+    # ingestion correctness fixes and task catalogue — case/whitespace
+    # label-column resolution (data-ingestors#340) and UTF-8 BOM header
+    # handling (#338) from the 0.6 line, plus 0.7's tabular schema-inference
+    # rules (#349), the semantic-segmentation mask_id contract (#358), and the
+    # minimum-image-size floor (#348). Keep this tracking the current line:
+    # leaving it on an older line while client-runtime's ingest schema tracks
+    # newer categories re-opens the submit-vs-run drift bug (categories
+    # accepted at submit that the spawned image can't process). See
+    # client-runtime#162 discussion.
+    tag: "0.7"
     # Opt-in pin. Empty (default) = spawn by the floating `tag` above. Set to
     # a canonical multi-arch digest to lock all ingestion Jobs to one exact
     # image (see the comment block above). Last known-good baseline, for easy


### PR DESCRIPTION
Closes #330.

Rolls the spawned-ingestor pin to the **0.7** line now that data-ingestors **0.7.0** is released (multi-arch ghcr `:0.7`, PyPI, [GitHub Release v0.7.0](https://github.com/tracebloc/data-ingestors/releases/tag/v0.7.0)). Until this merges + syncs to `main`, prod keeps spawning `:0.6`.

0.7.0 brings tabular schema-inference rules (data-ingestors#349), the semantic-segmentation mask_id contract (#358), and the minimum-image-size floor (#348, incl. the min_size config-validation hardening). **TSC #359 was deliberately deferred** — it's not in 0.7.0.

### The standard 3-spot bump
| Spot | Change |
|---|---|
| `client/values.yaml` `images.ingestor.tag` | `0.6` → `0.7` (+ rationale comment refresh) |
| `client/templates/jobs-manager-deployment.yaml` `INGESTOR_IMAGE_TAG` default | `0.6` → `0.7` — so a `helm upgrade --reuse-values` can't revert prod to the stale line |
| `client/tests/jobs_manager_test.yaml` default-tag golden | `0.6` → `0.7` (the `0.4` override-test assertion is untouched) |

`digest` stays `""` (floating mode) → auto-rolls on the next ingestion submit, `imagePullPolicy=Always`.

### Verification
- `:0.7` confirmed **multi-arch** (linux/amd64 + linux/arm64) → `ingestor-multiarch` CI passes.
- `helm unittest client`: **267/267 pass**.
- No other ingestor `0.6` pin anywhere in the chart / env value files.

Chore PR to `develop` (no chart-version bump). **Prod ships via the subsequent Sync develop → main PR.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm default/tag wiring only; ingestion behavior changes are intentional with data-ingestors 0.7.0 and do not touch auth or core control-plane paths.
> 
> **Overview**
> **Bumps the default spawned ingestor image from the `0.6` to the `0.7` floating tag** so jobs-manager creates ingestion Jobs against `ghcr.io/tracebloc/ingestor:0.7` (digest still empty → `imagePullPolicy=Always`).
> 
> The change is applied in the usual three places: `images.ingestor.tag` in **values**, the **`INGESTOR_IMAGE_TAG` template default** (so `--reuse-values` cannot fall back to `0.6`), and the **helm unittest** expectation for the default-tag case. **values** comments are refreshed to document why the chart tracks the 0.7 line (submit-vs-run catalogue alignment).
> 
> The chart **version/appVersion** move **1.9.2 → 1.9.3** in `Chart.yaml` is included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36ee216560a1cf47309434a5e0ce7c22b9eafef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->