### PR TITLE
Sync develop → main for v1.9.3 chart release (ingestor 0.7)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.2
-appVersion: "1.9.2"
+version: 1.9.3
+appVersion: "1.9.3"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -122,7 +122,7 @@ spec:
         - name: INGESTOR_IMAGE_REPOSITORY
           value: {{ (default dict .Values.images.ingestor).repository | default "ghcr.io/tracebloc/ingestor" | quote }}
         - name: INGESTOR_IMAGE_TAG
-          value: {{ (default dict .Values.images.ingestor).tag | default "0.6" | quote }}
+          value: {{ (default dict .Values.images.ingestor).tag | default "0.7" | quote }}
         - name: INGESTOR_IMAGE_DIGEST
           value: {{ (default dict .Values.images.ingestor).digest | default "" | quote }}
         - name: REQUESTS_PROXY_URL

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -107,7 +107,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: INGESTOR_IMAGE_TAG
-            value: "0.6"
+            value: "0.7"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -318,21 +318,22 @@ images:
     repository: "ghcr.io/tracebloc/ingestor"
     # Floating tag spawned by default (imagePullPolicy=Always). The team's
     # ghcr.io publishing convention uses semver-style float tags — `0` tracks
-    # the latest 0.x, `0.5` tracks the latest 0.5.x patch. `0.5` (patch-only
-    # auto-track) is the default: a future 0.6 release will NOT be picked up
-    # until this is moved to `0.6` (or set to `0` for minor auto-track too).
+    # the latest 0.x, `0.7` tracks the latest 0.7.x patch. `0.7` (patch-only
+    # auto-track) is the default: a future 0.8 release will NOT be picked up
+    # until this is moved to `0.8` (or set to `0` for minor auto-track too).
     # `latest` is rejected by the schema.
     #
-    # Pinned to the 0.6 line so the spawned ingestor carries the current
-    # ingestion correctness fixes — case/whitespace label-column resolution
-    # (data-ingestors#340) and UTF-8 BOM header handling (#338) — and still
-    # supports the full task catalogue jobs-manager validates at submit time
-    # (sentence_pair_classification and embeddings shipped in v0.5.6). Keep
-    # this tracking the current line: leaving it on an older line while
-    # client-runtime's ingest schema tracks newer categories re-opens the
-    # submit-vs-run drift bug (categories accepted at submit that the spawned
-    # image can't process). See client-runtime#162 discussion.
-    tag: "0.6"
+    # Pinned to the 0.7 line so the spawned ingestor carries the current
+    # ingestion correctness fixes and task catalogue — case/whitespace
+    # label-column resolution (data-ingestors#340) and UTF-8 BOM header
+    # handling (#338) from the 0.6 line, plus 0.7's tabular schema-inference
+    # rules (#349), the semantic-segmentation mask_id contract (#358), and the
+    # minimum-image-size floor (#348). Keep this tracking the current line:
+    # leaving it on an older line while client-runtime's ingest schema tracks
+    # newer categories re-opens the submit-vs-run drift bug (categories
+    # accepted at submit that the spawned image can't process). See
+    # client-runtime#162 discussion.
+    tag: "0.7"
     # Opt-in pin. Empty (default) = spawn by the floating `tag` above. Set to
     # a canonical multi-arch digest to lock all ingestion Jobs to one exact
     # image (see the comment block above). Last known-good baseline, for easy


### PR DESCRIPTION
Promotes `develop` → `main` to ship chart **1.9.3**, which rolls the spawned ingestor to the **0.7** line.

Single commit ahead of main:
- #331 — roll `images.ingestor.tag` 0.6 → 0.7 + bump chart 1.9.2 → 1.9.3 (ticket client#330)

Ships data-ingestors **0.7.0** to prod: tabular schema-inference rules (data-ingestors#349), semseg mask_id contract (#358), minimum-image-size floor (#348). TSC #359 deferred (not in 0.7.0).

**After merge:** cut a GitHub Release for **1.9.3** to trigger `release-helm-chart.yaml` (gh-pages package) → fleet auto-upgrade rolls prod. `:0.7` is multi-arch; `digest` stays floating so ingestion Jobs auto-resolve the current image.

⚠️ Prod-shipping PR — needs a 2nd approver (no self-approve/bypass).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ships a new default ingestor minor line to production ingestion Jobs; behavior changes in data processing paths though the rollout mechanism (floating tag, no digest pin) is unchanged.
> 
> **Overview**
> **Chart 1.9.2 → 1.9.3** (`version` / `appVersion` in `Chart.yaml`) for a production fleet rollout after merge and GitHub release.
> 
> **Default ingestor line 0.6 → 0.7:** `images.ingestor.tag` in `values.yaml`, the `INGESTOR_IMAGE_TAG` fallback in `jobs-manager-deployment.yaml`, and the Helm unit test expectation are aligned so jobs-manager spawns ingestion Jobs on the **0.7** float tag (digest still empty → `Always` pull behavior unchanged). Comments in `values.yaml` are updated to document 0.7 capabilities (tabular schema inference, semseg `mask_id`, minimum image size) and the submit-vs-run drift rationale.
> 
> No new values keys or template logic beyond the version and tag defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 490d9339ba0dd32b77a7f332cd4f02af054c2001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->