### PR TITLE
chore(chart): prod-only ingestor digest pin (#1028 item 1)

### DIFF
--- a/client/values-prod.yaml
+++ b/client/values-prod.yaml
@@ -1,0 +1,46 @@
+# ============================================================
+# Production overlay — reproducible prod installs (backend#1028)
+# ============================================================
+#
+# Layer this AFTER the base values.yaml, PROD ONLY:
+#
+#   helm upgrade --install <release> ./client \
+#     -f client/values.yaml \
+#     -f client/values-prod.yaml
+#
+# (or `-f values-prod.yaml` alongside the installer-generated values file).
+#
+# WHAT THIS DOES
+#   Pins the spawned ingestion image to an exact multi-arch digest so a prod
+#   cluster runs a known, certified ingestor build — reproducible regardless
+#   of what the floating `images.ingestor.tag` (0.7) later resolves to. With
+#   the digest set, jobs-manager spawns every ingestion Job by `repo@digest`
+#   and drops imagePullPolicy to IfNotPresent (see jobs-manager-deployment.yaml
+#   and client-runtime submit_ingestion_run._build_image_reference).
+#
+# WHY PROD ONLY
+#   Dev and staging install WITHOUT this overlay and keep the base default
+#   (`images.ingestor.digest: ""`) — floating `0.7`, imagePullPolicy=Always —
+#   so they always pick up the latest published 0.7.x patch at ingestion
+#   submit time and are never frozen on a stale build. Only prod trades that
+#   auto-tracking for a reproducible, audited pin.
+#
+#
+# RELEASE CONVENTION — re-verify the digest every time the prod ingestor
+# line is cut. The digest below MUST equal the current published
+# `images.ingestor.tag` multi-arch index. Resolve it with the helper:
+#
+#   scripts/resolve-ingestor-digest.sh 0.7            # print the index digest
+#   scripts/resolve-ingestor-digest.sh 0.7 --write    # patch this file in place
+#
+# then commit the change. NOTE: CI's `ingestor-multiarch` guard
+# (helm-ci.yaml) inspects the base `client/values.yaml` digest only — it does
+# NOT read this overlay — so it does not validate the digest below. The helper
+# above performs the multi-arch check at resolve time; re-verify by hand at
+# each prod cut (the `# VERIFIED …` note on the digest is the audit trail).
+images:
+  ingestor:
+    # ghcr.io/tracebloc/ingestor multi-arch index for the 0.7 line.
+    # v0.7.0 (== tag `0.7` / `0.7.0`) — VERIFIED against ghcr.io 2026-07-10
+    # (linux/amd64 + linux/arm64 OCI image index). Re-verify at each prod cut.
+    digest: "sha256:78f21a08d1fb186b9764ad96090dcaf9c381c6407c7778f2085a56dea2d8f117"

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -336,8 +336,16 @@ images:
     tag: "0.7"
     # Opt-in pin. Empty (default) = spawn by the floating `tag` above. Set to
     # a canonical multi-arch digest to lock all ingestion Jobs to one exact
-    # image (see the comment block above). Last known-good baseline, for easy
-    # pinning: v0.3.6 (cumulative NULL / empty-value ingestion fixes —
+    # image (see the comment block above).
+    #
+    # PROD REPRODUCIBILITY (backend#1028): the digest is pinned PROD-ONLY via
+    # the `client/values-prod.yaml` overlay, layered on top of this file at
+    # prod-release time. Leave it EMPTY here so dev/staging (which do NOT layer
+    # the overlay) keep floating on `tag` and are never frozen on a stale build.
+    # Regenerate the prod pin with `scripts/resolve-ingestor-digest.sh`.
+    #
+    # Last known-good baseline, for easy manual pinning: v0.3.6 (cumulative
+    # NULL / empty-value ingestion fixes —
     # data-ingestors#150/#167/#168/#170/#172/#176/#179):
     #   sha256:dfdaa7e633a8df0f46b403e9422eba5c16bdb7d9c39047e6d3738f9e38fbdba8
     digest: ""

--- a/scripts/resolve-ingestor-digest.sh
+++ b/scripts/resolve-ingestor-digest.sh
@@ -53,11 +53,25 @@ if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
 fi
 
 # Sanity: the pinned image must be a multi-arch index (amd64 + arm64), or
-# ingestion breaks on arm64 hosts (client#186). Mirror the helm-ci guard.
-platforms="$(docker buildx imagetools inspect "$ref" 2>/dev/null \
-  | awk '/Platform:/ {print $2}' | grep -E 'linux/(amd64|arm64)' | sort -u | tr '\n' ' ')"
-if ! grep -q 'linux/amd64' <<<"$platforms" || ! grep -q 'linux/arm64' <<<"$platforms"; then
-  echo "WARNING: $ref is not a linux/amd64 + linux/arm64 multi-arch index (saw: ${platforms:-none})." >&2
+# ingestion breaks on arm64 hosts (client#186). Mirror the helm-ci
+# `ingestor-multiarch` guard, and inspect the RESOLVED index (repo@digest) —
+# i.e. the exact thing we would pin — not the floating repo:tag.
+resolved="${repo}@${digest}"
+platforms="$(docker buildx imagetools inspect "$resolved" 2>/dev/null \
+  | awk '/Platform:/ {print $2}' | grep -v '^unknown' | sort -u | tr '\n' ' ')"
+multiarch=1
+grep -q 'linux/amd64' <<<"$platforms" || multiarch=0
+grep -q 'linux/arm64' <<<"$platforms" || multiarch=0
+if [[ "$multiarch" -eq 0 ]]; then
+  if [[ "$write" == 1 ]]; then
+    # A prod pin MUST be multi-arch: helm-ci hard-fails a single-arch digest,
+    # and a committed arch-specific pin breaks ingestion on the other arch.
+    echo "ERROR: $resolved is not a linux/amd64 + linux/arm64 multi-arch index (saw: ${platforms:-none})." >&2
+    echo "       Refusing to pin a single-arch digest into the prod overlay (client#186 / #160)." >&2
+    echo "       helm-ci's ingestor-multiarch guard would reject this pin at CI time." >&2
+    exit 1
+  fi
+  echo "WARNING: $resolved is not a linux/amd64 + linux/arm64 multi-arch index (saw: ${platforms:-none})." >&2
   echo "         Pinning an arch-specific digest breaks ingestion on the other arch (client#186)." >&2
 fi
 
@@ -69,5 +83,15 @@ if [[ "$write" == 1 ]]; then
   tmp="$(mktemp)"
   sed -E "s|(^[[:space:]]*digest:[[:space:]]*\").*(\")|\1${digest}\2|" "$prod_overlay" >"$tmp"
   mv "$tmp" "$prod_overlay"
+  # Verify the sed actually landed: if the overlay's digest line has drifted
+  # from the expected `digest: "…"` format, sed matches nothing and silently
+  # leaves the file unchanged. Confirm the intended digest is now present
+  # before reporting success.
+  if ! grep -q "digest:[[:space:]]*\"${digest}\"" "$prod_overlay"; then
+    echo "ERROR: ${prod_overlay#$here/../} was not patched — no matching digest line found." >&2
+    echo "       Expected a line of the form:  digest: \"${digest}\"" >&2
+    echo "       Fix the overlay's digest line to that format and re-run." >&2
+    exit 1
+  fi
   echo "Wrote ${digest} to ${prod_overlay#$here/../}" >&2
 fi

--- a/scripts/resolve-ingestor-digest.sh
+++ b/scripts/resolve-ingestor-digest.sh
@@ -3,8 +3,9 @@
 # spawned ingestor image and (optionally) write it into the prod overlay.
 #
 # backend#1028: prod installs pin `images.ingestor.digest` for reproducibility
-# (see client/values-prod.yaml). The floating tag (default `0.7`) moves as new
-# patches ship, so the pinned digest must be re-resolved every time the prod
+# (see client/values-prod.yaml). The floating tag (read from the chart's
+# images.ingestor.tag) moves as new patches ship, so the pinned digest must
+# be re-resolved every time the prod
 # ingestor line is cut. This helper does that resolution against the live
 # registry so the pin is never hand-typed.
 #
@@ -12,7 +13,9 @@
 #   scripts/resolve-ingestor-digest.sh [TAG]           # print repo@digest
 #   scripts/resolve-ingestor-digest.sh [TAG] --write   # patch values-prod.yaml
 #
-# TAG defaults to `images.ingestor.tag` from client/values.yaml.
+# TAG defaults to `images.ingestor.tag` read from client/values.yaml (via yq
+# if present, else a portable yq-free parse). If it cannot be determined, the
+# script fails loudly — it never falls back to a hardcoded tag.
 # REPO override: INGESTOR_REPO=ghcr.io/tracebloc/ingestor (default).
 set -euo pipefail
 
@@ -26,11 +29,61 @@ write=0
 [[ "${1:-}" == "--write" ]] && { tag=""; write=1; }
 [[ "${2:-}" == "--write" ]] && write=1
 
+# Portable, yq-free reader for images.ingestor.tag from a values.yaml.
+# Scoped to the images: -> ingestor: block so a sibling image's `tag:`
+# (jobsManager / podsMonitor / requestsProxy / ... each carry their own)
+# can never be picked up by mistake. bash-3.2 / macOS-safe (pure awk).
+read_ingestor_tag() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+  awk '
+    # Enter the top-level images: block.
+    /^images:[[:space:]]*$/ { in_images = 1; next }
+    # Any other top-level key (col 0, not a comment) closes it.
+    /^[^[:space:]#]/        { in_images = 0; in_ingestor = 0 }
+    in_images {
+      # A 2-space sibling key under images: — arm the ingestor scope only
+      # while we are inside ingestor:, disarm on the next sibling.
+      if ($0 ~ /^  [A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$/) {
+        in_ingestor = ($0 ~ /^  ingestor:[[:space:]]*$/) ? 1 : 0
+        next
+      }
+      # The 4-space tag: leaf inside ingestor:.
+      if (in_ingestor && $0 ~ /^    tag:[[:space:]]/) {
+        v = $0
+        sub(/^    tag:[[:space:]]*/, "", v)          # drop the key
+        sub(/[[:space:]]+#.*$/, "", v)               # drop a trailing comment
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)   # trim
+        gsub(/^"|"$/, "", v)                         # unwrap double quotes
+        gsub(/^'\''|'\''$/, "", v)                   # unwrap single quotes
+        print v
+        exit
+      }
+    }
+  ' "$file"
+}
+
 if [[ -z "$tag" ]]; then
+  # No explicit TAG arg → default to the chart's images.ingestor.tag so this
+  # helper always resolves the SAME line the chart ships. NEVER hardcode a
+  # tag here: a stale constant would silently pin the WRONG (older) digest
+  # after the chart tag moves (e.g. 0.7 -> 0.8) while appearing to follow the
+  # chart. Prefer yq; fall back to the portable yq-free parse above; if
+  # neither can determine it, fail loudly rather than guess.
   if command -v yq >/dev/null 2>&1 && [[ -f "$chart_values" ]]; then
     tag="$(yq -r '.images.ingestor.tag' "$chart_values")"
+    [[ "$tag" == "null" ]] && tag=""   # yq prints literal "null" for a missing key
+  else
+    tag="$(read_ingestor_tag "$chart_values" || true)"
   fi
-  tag="${tag:-0.7}"
+  if [[ -z "$tag" ]]; then
+    echo "ERROR: could not determine the default ingestor tag from ${chart_values#$here/../}." >&2
+    echo "       (images.ingestor.tag was unreadable: file missing, key absent, or yq not" >&2
+    echo "        installed and the yq-free parse found nothing.)" >&2
+    echo "       Fix: pass TAG explicitly — scripts/resolve-ingestor-digest.sh <TAG> [--write] —" >&2
+    echo "       or install yq. Refusing to fall back to a hardcoded tag." >&2
+    exit 1
+  fi
 fi
 
 ref="${repo}:${tag}"

--- a/scripts/resolve-ingestor-digest.sh
+++ b/scripts/resolve-ingestor-digest.sh
@@ -110,8 +110,13 @@ fi
 # `ingestor-multiarch` guard, and inspect the RESOLVED index (repo@digest) —
 # i.e. the exact thing we would pin — not the floating repo:tag.
 resolved="${repo}@${digest}"
+# `|| true`: under `set -o pipefail`, an inspect failure or a `grep -v` that
+# filters every line exits non-zero and would abort the whole script — even
+# though the digest is already resolved. Tolerate it: an empty `platforms`
+# then trips multiarch=0 below, so the guard still fires (ERROR under --write,
+# WARNING otherwise) instead of the run dying silently with no digest line.
 platforms="$(docker buildx imagetools inspect "$resolved" 2>/dev/null \
-  | awk '/Platform:/ {print $2}' | grep -v '^unknown' | sort -u | tr '\n' ' ')"
+  | awk '/Platform:/ {print $2}' | grep -v '^unknown' | sort -u | tr '\n' ' ')" || true
 multiarch=1
 grep -q 'linux/amd64' <<<"$platforms" || multiarch=0
 grep -q 'linux/arm64' <<<"$platforms" || multiarch=0

--- a/scripts/resolve-ingestor-digest.sh
+++ b/scripts/resolve-ingestor-digest.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# resolve-ingestor-digest.sh — resolve the multi-arch index digest for the
+# spawned ingestor image and (optionally) write it into the prod overlay.
+#
+# backend#1028: prod installs pin `images.ingestor.digest` for reproducibility
+# (see client/values-prod.yaml). The floating tag (default `0.7`) moves as new
+# patches ship, so the pinned digest must be re-resolved every time the prod
+# ingestor line is cut. This helper does that resolution against the live
+# registry so the pin is never hand-typed.
+#
+# Usage:
+#   scripts/resolve-ingestor-digest.sh [TAG]           # print repo@digest
+#   scripts/resolve-ingestor-digest.sh [TAG] --write   # patch values-prod.yaml
+#
+# TAG defaults to `images.ingestor.tag` from client/values.yaml.
+# REPO override: INGESTOR_REPO=ghcr.io/tracebloc/ingestor (default).
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+chart_values="$here/../client/values.yaml"
+prod_overlay="$here/../client/values-prod.yaml"
+
+repo="${INGESTOR_REPO:-ghcr.io/tracebloc/ingestor}"
+tag="${1:-}"
+write=0
+[[ "${1:-}" == "--write" ]] && { tag=""; write=1; }
+[[ "${2:-}" == "--write" ]] && write=1
+
+if [[ -z "$tag" ]]; then
+  if command -v yq >/dev/null 2>&1 && [[ -f "$chart_values" ]]; then
+    tag="$(yq -r '.images.ingestor.tag' "$chart_values")"
+  fi
+  tag="${tag:-0.7}"
+fi
+
+ref="${repo}:${tag}"
+
+# Resolve the top-level (index) digest. Prefer buildx imagetools (prints the
+# manifest-list/index digest directly); fall back to `docker manifest inspect`.
+digest=""
+if docker buildx imagetools inspect "$ref" >/dev/null 2>&1; then
+  digest="$(docker buildx imagetools inspect "$ref" 2>/dev/null \
+    | awk '/^Digest:/ {print $2; exit}')"
+fi
+if [[ -z "$digest" ]]; then
+  digest="$(docker manifest inspect --verbose "$ref" 2>/dev/null \
+    | grep -m1 '"Ref"' | sed -E 's/.*@(sha256:[a-f0-9]{64}).*/\1/')" || true
+fi
+
+if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+  echo "ERROR: could not resolve a digest for $ref (registry auth / network?)." >&2
+  exit 1
+fi
+
+# Sanity: the pinned image must be a multi-arch index (amd64 + arm64), or
+# ingestion breaks on arm64 hosts (client#186). Mirror the helm-ci guard.
+platforms="$(docker buildx imagetools inspect "$ref" 2>/dev/null \
+  | awk '/Platform:/ {print $2}' | grep -E 'linux/(amd64|arm64)' | sort -u | tr '\n' ' ')"
+if ! grep -q 'linux/amd64' <<<"$platforms" || ! grep -q 'linux/arm64' <<<"$platforms"; then
+  echo "WARNING: $ref is not a linux/amd64 + linux/arm64 multi-arch index (saw: ${platforms:-none})." >&2
+  echo "         Pinning an arch-specific digest breaks ingestion on the other arch (client#186)." >&2
+fi
+
+echo "${repo}@${digest}  (tag ${tag}; platforms: ${platforms:-unknown})"
+
+if [[ "$write" == 1 ]]; then
+  [[ -f "$prod_overlay" ]] || { echo "ERROR: $prod_overlay not found." >&2; exit 1; }
+  # Replace the digest value on the `digest:` line under images.ingestor.
+  tmp="$(mktemp)"
+  sed -E "s|(^[[:space:]]*digest:[[:space:]]*\").*(\")|\1${digest}\2|" "$prod_overlay" >"$tmp"
+  mv "$tmp" "$prod_overlay"
+  echo "Wrote ${digest} to ${prod_overlay#$here/../}" >&2
+fi


### PR DESCRIPTION
### What
A **prod-only** digest pin for the ingestor image (backend#1028, Item 1). Prod deploys `ghcr.io/tracebloc/ingestor` by immutable digest; dev/staging keep floating `:0.7` with `imagePullPolicy=Always`.

### Mechanism — a prod values overlay (no dev/staging freeze)
- Base `client/values.yaml` keeps `images.ingestor.digest: ""` → without the overlay, dev/staging float `:0.7` exactly as today.
- New `client/values-prod.yaml` sets **only** `images.ingestor.digest`. Prod layers it:
  ```
  helm upgrade --install <rel> ./client -f client/values.yaml -f client/values-prod.yaml
  ```
  With the digest set, `jobs-manager-deployment.yaml` renders `INGESTOR_IMAGE_DIGEST` and client-runtime spawns `repo@digest` with `imagePullPolicy=IfNotPresent`.

No automated path applies the overlay (the installer generates its own values and never references it) — the pin is a deliberate manual prod-release convention, which matches the scoping intent (the installer pulls the chart remotely and can't reliably `-f` a chart-local file).

### Digest (verified live, not copied from a note)
`sha256:78f21a08d1fb186b9764ad96090dcaf9c381c6407c7778f2085a56dea2d8f117`

Resolved against ghcr.io via both `docker buildx imagetools inspect` and `docker manifest inspect` for `:0.7` and `:0.7.0` — both point at the same multi-arch OCI **image index** (linux/amd64 + linux/arm64, satisfying the client#186 arm64 requirement). The overlay documents that this must be re-verified at each prod cut.

### Helper
`scripts/resolve-ingestor-digest.sh` — resolves the current multi-arch index digest for a tag (default reads `images.ingestor.tag`), warns if not amd64+arm64 (mirrors the `helm-ci.yaml ingestor-multiarch` guard), and `--write` patches the overlay. So "re-verify at release" isn't hand-typed.

### Tests / lint
- `helm lint --strict` for all 4 platform overlays (aks/eks/bm/oc), with and without `values-prod.yaml`: 0 failed.
- `helm unittest ./client`: 267/267 (existing `jobs_manager_test.yaml` already covers both the empty-digest float and the set-digest pin).
- `helm template` diff: base-only → `INGESTOR_IMAGE_DIGEST: ""`; base + overlay → the pinned digest, `INGESTOR_IMAGE_TAG: "0.7"` still rendered as fallback.
- `bash -n scripts/resolve-ingestor-digest.sh` OK.

### Note
A `Chart.yaml` patch bump conventionally accompanies chart changes, but version bumps in this repo happen in dedicated `chore(release)` commits — left for the release step.

Refs tracebloc/backend#1028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational/release convention only; runtime spawn behavior is unchanged unless prod explicitly layers the overlay. A stale or single-arch pin could break prod ingestion, but the helper enforces multi-arch on `--write`.
> 
> **Overview**
> Adds a **prod-only** Helm values overlay so production can lock spawned ingestion Jobs to a verified multi-arch `ghcr.io/tracebloc/ingestor` digest while dev/staging keep the base chart’s empty `images.ingestor.digest` and continue floating on `images.ingestor.tag` (`0.7`).
> 
> **`client/values-prod.yaml`** is meant to be layered after `client/values.yaml` at prod install time (`helm … -f values.yaml -f values-prod.yaml`). It sets only `images.ingestor.digest` to the current `0.7` index digest, with release notes on re-verifying at each prod cut. Base **`client/values.yaml`** comments now document that prod pinning lives in the overlay, not in the default values file.
> 
> **`scripts/resolve-ingestor-digest.sh`** resolves the live registry index digest for a tag (default: `images.ingestor.tag` from the chart), checks linux/amd64 + linux/arm64, prints `repo@digest`, and optionally **`--write`** patches the prod overlay. No chart template changes—existing jobs-manager `INGESTOR_IMAGE_DIGEST` wiring already spawns `repo@digest` when the digest is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 848b78f1b3e7731dce78fff374f953b1e283b2d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->