### PR TITLE
docs(security): update §8.3 — backend tokens now bounded + revocable (#302)

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -465,11 +465,15 @@ By default the NetworkPolicy still allows outbound HTTPS/443 so training pods ca
 
 **Residual:** the pod still holds `BACKEND_TOKEN` (it authenticates to the backend through the gateway). Scoping / short-TTL of that token is tracked under §8.1.
 
-### 8.3 Backend tokens never expire — **backend team**
+### 8.3 Backend token lifetime (SEC-06) — **mitigated for web sessions; residual tracked (backend team)**
 
-The tracebloc backend uses Django REST Framework's `authtoken` with no TTL. A leaked token is valid forever until manually deleted from the DB.
+Previously the tracebloc backend issued Django REST Framework `authtoken` credentials with no TTL, so a leaked token was valid forever until manually deleted from the DB.
 
-**Mitigation plan:** backend adds a revocation endpoint + evaluates switching to `djangorestframework-simplejwt` for TTL-bound tokens. Backend team owns.
+**Mitigated for interactive web sessions (backend#933 + frontend-app#575, shipped via backend#590).** Data-scientist web logins now receive a bounded, revocable **30-day `ClientAccessToken`** (Bearer). It can be revoked via `/auth/revoke`, `/logout/`, a password change, or a Django-admin action; there is no refresh token by design, so re-login simply mints a fresh token. The frontend sends a scheme-aware `Authorization: <token_scheme> <token>` header and centrally handles `401 → re-login`.
+
+**Intentionally unchanged — edge devices and bots.** Non-interactive service credentials (edge devices, bots) deliberately keep the legacy long-lived DRF `Token`: these are machine identities with no interactive re-login path, so a bounded web-session token doesn't apply. This is by design, not an oversight.
+
+**Residual risk (open — backend team).** The web-session token is still stored in JS-readable storage (localStorage + a non-`httpOnly` cookie), so it remains exfiltratable via XSS. Moving it out of script-reachable storage is tracked as the **SEC-06 residual follow-up** in tracebloc/backend (successor to backend#590).
 
 ### 8.4 Legacy training image architecture (G4 partial) — **legacy-migration team**
 


### PR DESCRIPTION
Closes #302.

## Summary
`docs/SECURITY.md` §8.3 still claimed "Backend tokens never expire." That finding has since been mitigated for interactive data-scientist web sessions (tracebloc/backend#590, closed), so this rewrites §8.3 to match reality. **Docs-only, no code change.**

## What changed
Reworked §8.3 (heading now `Backend token lifetime (SEC-06) — mitigated for web sessions; residual tracked`) into three parts:

1. **Mitigated for web sessions** — DS web logins now get a bounded, revocable **30-day `ClientAccessToken`** (Bearer), revocable via `/auth/revoke`, `/logout/`, password change, or a Django-admin action; no refresh token by design (re-login mints a fresh one). Scheme-aware `Authorization` header + central `401 → re-login`. (backend#933, frontend-app#575)
2. **Intentionally unchanged — edge devices & bots** — keep the legacy long-lived DRF `Token` as non-interactive service credentials. Called out as **by design**, so it isn't "re-fixed" later.
3. **Residual risk (open)** — token still in JS-readable storage (localStorage + non-`httpOnly` cookie), tracked as the **SEC-06 residual follow-up** in tracebloc/backend (successor to backend#590).

## Refs
tracebloc/backend#590 (closed) · tracebloc/backend#933 · tracebloc/frontend-app#575

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `docs/SECURITY.md`; no runtime or security behavior changes in this repo.
> 
> **Overview**
> **§8.3** in `docs/SECURITY.md` is updated so it no longer states that backend tokens never expire. The section is retitled around **SEC-06** and **backend token lifetime**, with status **mitigated for web sessions; residual tracked**.
> 
> It now describes **interactive data-scientist web logins** as using a **30-day, revocable `ClientAccessToken` (Bearer)** with revocation via `/auth/revoke`, `/logout/`, password change, or Django admin, plus scheme-aware `Authorization` and central **401 → re-login** (refs backend#933, frontend-app#575, backend#590).
> 
> **Edge devices and bots** are explicitly documented as still using the legacy long-lived DRF `Token` **by design**.
> 
> The remaining **open** item is **XSS-exfiltratable** web-session storage (localStorage and a non-`httpOnly` cookie), tracked as the **SEC-06 residual follow-up** in tracebloc/backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a74fbb747fa787a07e8fae939cb97cbdb64d9051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->