### PR TITLE
test(drift): pin the CLI-assumed chart contract in check-drift.sh

### DIFF
--- a/scripts/tests/check-drift.sh
+++ b/scripts/tests/check-drift.sh
@@ -14,6 +14,10 @@
 #    2. The workload objects summary.sh (readiness wait) and diagnose.sh (support
 #       bundle) reference BY NAME are actually rendered by the chart. A chart
 #       rename would silently break readiness detection and the --diagnose bundle.
+#    3. The chart names/shapes the tracebloc CLI hardcodes (tracebloc/cli#290) —
+#       Service, PVC + mount, ingestion-authz ConfigMap, ingestor SA, digest env,
+#       submit path — so a chart rename fails HERE, at the source, not in the
+#       field after both repos shipped green.
 #
 #  Exit 0 = no drift; non-zero = drift (every divergence is printed).
 #  Overrides: DRIFT_ROOT (repo root), TB_RELEASE, TB_NAMESPACE.
@@ -85,11 +89,109 @@ _drift_workload_names() {
   done
 }
 
+# ── Check 3: CLI-assumed chart contract (tracebloc/cli#290) ──────────────────
+# The tracebloc CLI hardcodes these names/shapes to discover the release, run
+# `cluster doctor`, and ingest datasets (cli: internal/cluster/discover.go,
+# internal/cluster/pvc.go, internal/submit/client.go). Check 2 already pins the
+# two Deployment names; this pins the REST of the CLI contract. The cli repo
+# runs the mirror gate against a pinned chart ref (cli .github/workflows/
+# chart-drift.yml + scripts/.client-ref); this side fails the renaming chart PR
+# itself.
+
+# _render_doc <kind> <name-regex>: print the rendered doc(s) (stdin) whose
+# top-level kind and metadata.name match. Line-oriented on helm output: docs
+# split on ^---, kind/metadata are unindented, metadata.name is the first
+# 2-space `name:` inside the metadata block (chart names render unquoted).
+_render_doc() {
+  awk -v K="$1" -v NRE="$2" '
+    function flush() { if (kind == K && name ~ NRE) printf "%s", buf; buf=""; kind=""; name=""; inmeta=0 }
+    /^---/ { flush(); next }
+    { buf = buf $0 "\n" }
+    /^kind:/     { kind=$2 }
+    /^metadata:/ { inmeta=1; next }
+    /^[^ ]/      { inmeta=0 }
+    inmeta && name=="" && /^  name:/ { name=$2 }
+    END { flush() }
+  '
+}
+
+_drift_cli_contract() {
+  echo "▸ CLI-assumed chart contract (tracebloc/cli#290) vs the chart render"
+  if ! command -v helm >/dev/null 2>&1; then
+    echo "  (helm not installed — skipping chart render; CI runs this half)"; return 0
+  fi
+  local vals; vals="$(ls "$DRIFT_ROOT"/client/ci/bm-values.yaml "$DRIFT_ROOT"/client/ci/*-values.yaml 2>/dev/null | head -1)"
+  local rendered
+  if ! rendered="$(helm template "$TB_RELEASE" "$DRIFT_ROOT/client" -n "$TB_NAMESPACE" ${vals:+-f "$vals"} 2>/dev/null)"; then
+    _note "helm template failed — the chart does not render (values: ${vals:-none})"; return 0
+  fi
+  local doc
+
+  # Service jobs-manager on port 8080 — the CLI probes both name forms and
+  # port-forwards to 8080 (discover.go pickJobsManagerService, jobsManagerPort).
+  doc="$(_render_doc Service "^(jobs-manager|${TB_RELEASE}-jobs-manager)\$" <<<"$rendered")"
+  if [[ -n "$doc" ]] && grep -qE '^[[:space:]]*port:[[:space:]]*8080([[:space:]]|$)' <<<"$doc"; then
+    _ok "Service jobs-manager rendered with port 8080 (CLI port-forward + POST target)"
+  else
+    _note "the CLI expects a Service named 'jobs-manager' (or '${TB_RELEASE}-jobs-manager') with port 8080 — not rendered"
+  fi
+
+  # Shared-data PVC + its mount — the CLI pins the claim name 'client-pvc' and
+  # the '/data/shared' mount for stage/ingestor pods (pvc.go SharedPVCClaimName,
+  # SharedPVCMountPath).
+  if [[ -n "$(_render_doc PersistentVolumeClaim '^client-pvc$' <<<"$rendered")" ]]; then
+    _ok "PVC client-pvc rendered"
+  else
+    _note "the CLI expects a PVC named 'client-pvc' — not rendered"
+  fi
+  doc="$(_render_doc Deployment "^${TB_RELEASE}-jobs-manager\$" <<<"$rendered")"
+  if grep -qF 'mountPath: "/data/shared"' <<<"$doc" && grep -qE '^[[:space:]]*claimName:[[:space:]]*client-pvc([[:space:]]|$)' <<<"$doc"; then
+    _ok "jobs-manager mounts client-pvc at /data/shared"
+  else
+    _note "the CLI expects jobs-manager to mount claim 'client-pvc' at '/data/shared' — mount or claim missing from the render"
+  fi
+
+  # Ingestion authz — the CLI reads ConfigMap '<release>-ingestion-authz', key
+  # 'ingestion-authz.yaml', and falls back to the SA name 'ingestor' when the
+  # ConfigMap is unreadable (discover.go discoverIngestorSAName, IngestorSAName).
+  doc="$(_render_doc ConfigMap "^${TB_RELEASE}-ingestion-authz\$" <<<"$rendered")"
+  if [[ -n "$doc" ]] && grep -qE '^[[:space:]]*ingestion-authz\.yaml:' <<<"$doc"; then
+    _ok "ConfigMap ${TB_RELEASE}-ingestion-authz rendered with key ingestion-authz.yaml"
+  else
+    _note "the CLI expects ConfigMap '${TB_RELEASE}-ingestion-authz' with key 'ingestion-authz.yaml' — not rendered"
+  fi
+  if [[ -n "$(_render_doc ServiceAccount '^ingestor$' <<<"$rendered")" ]]; then
+    _ok "ServiceAccount ingestor rendered (the CLI's hardcoded fallback SA)"
+  else
+    _note "the CLI's fallback ingestor SA name is 'ingestor' — no such ServiceAccount rendered (update discover.go IngestorSAName together with any rename)"
+  fi
+
+  # Ingestor digest pin — the CLI reads INGESTOR_IMAGE_DIGEST off jobs-manager's
+  # first container (discover.go).
+  doc="$(_render_doc Deployment "^${TB_RELEASE}-jobs-manager\$" <<<"$rendered")"
+  if grep -qE '^[[:space:]]*-?[[:space:]]*name:[[:space:]]*INGESTOR_IMAGE_DIGEST([[:space:]]|$)' <<<"$doc"; then
+    _ok "jobs-manager carries the INGESTOR_IMAGE_DIGEST env"
+  else
+    _note "the CLI expects env INGESTOR_IMAGE_DIGEST on jobs-manager — not rendered"
+  fi
+
+  # Submit endpoint — the CLI POSTs /internal/submit-ingestion-run to port 8080
+  # (submit/client.go SubmitPath). The path lives in rendered comments; a
+  # client-runtime endpoint move updates those in the same change, and this
+  # makes it confront the CLI's constant too.
+  if grep -qF '/internal/submit-ingestion-run' <<<"$rendered"; then
+    _ok "chart still references POST /internal/submit-ingestion-run (CLI SubmitPath)"
+  else
+    _note "the render no longer references '/internal/submit-ingestion-run' — if the endpoint moved, the CLI's SubmitPath must move with it"
+  fi
+}
+
 main() {
   set -uo pipefail
   echo "── source-of-truth drift checks ─────────────────────────────"
   _drift_backend_hosts
   _drift_workload_names
+  _drift_cli_contract
   echo "─────────────────────────────────────────────────────────────"
   if [[ "$_drift" -gt 0 ]]; then
     echo "DRIFT: $_drift divergence(s) above. Update both sides (or the contract in check-drift.sh) and re-run." >&2


### PR DESCRIPTION
## Summary
Extends `scripts/tests/check-drift.sh` with a Check 3 that pins the chart names/shapes the tracebloc CLI hardcodes (discovery, `cluster doctor`, dataset ingest) — so a chart PR renaming any of them fails **here, at the source**, instead of shipping green in both repos and breaking in the field. Check 2 already pins the two Deployment names; this covers the rest of the CLI contract: Service `jobs-manager`:8080, PVC `client-pvc` mounted at `/data/shared` (claim-backed), ConfigMap `<release>-ingestion-authz` with key `ingestion-authz.yaml`, ServiceAccount `ingestor` (the CLI's hardcoded fallback), the `INGESTOR_IMAGE_DIGEST` env on jobs-manager, and the `POST /internal/submit-ingestion-run` reference.

The cli repo runs the mirror gate against a **pinned** chart ref (tracebloc/cli#311: `scripts/.client-ref` + `chart-drift.yml`); this side is the pre-merge guard on chart PRs themselves. Follows the existing script style (`_ok`/`_note`, render-half skipped when helm is absent); the one structural addition is a small awk `_render_doc` helper so each name is asserted against the right *kind*, not just any `name:` line.

## Related
Part of tracebloc/backend#1106 (cli#290) · sibling PR: tracebloc/cli#311

## Type of change
- [ ] Feature
- [ ] Bug fix
- [x] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
Ran locally (all green):
- `bash scripts/tests/check-drift.sh` against the real chart — all Check 3 assertions pass (helm v4.1.1 locally; CI uses its pinned v3.15.4).
- Negative paths: mutated the chart (jobs-manager Service port 8080→9090; `client-pvc` renamed in `_helpers.tpl`) — each mutation trips the matching Check 3 line and exits non-zero; chart restored after.
- `bats scripts/tests/check-drift.bats` — all 8 existing tests still pass (the script stays side-effect-safe to source).
- `bash -n` + `shellcheck --severity=error --shell=bash` (the CI gate) — clean, no warnings at `--severity=warning` either.

Not run locally: the `drift-checks.yaml` CI job itself — but it invokes exactly the command above and runs on this PR (paths include `scripts/**`).

## Checklist
- [x] Tests added / updated and passing locally
- [x] Docs updated if behavior or config changed (script header lists the new check)
- [x] No secrets / credentials in the diff
- [x] For security-sensitive paths: appropriate reviewer requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only drift guard on scripts/tests/check-drift.sh; no runtime chart or application behavior changes.
> 
> **Overview**
> Adds **Check 3** to `scripts/tests/check-drift.sh` so chart PRs that rename or reshape resources the tracebloc CLI hardcodes fail CI on this repo before both sides ship green.
> 
> After `helm template`, the new `_drift_cli_contract` path asserts the render still matches the CLI contract: **jobs-manager** Service on **8080**, PVC **`client-pvc`** with **`/data/shared`** on jobs-manager, **`{release}-ingestion-authz`** ConfigMap and **`ingestor`** ServiceAccount, **`INGESTOR_IMAGE_DIGEST`** on jobs-manager, and a reference to **`/internal/submit-ingestion-run`**. A small **`_render_doc`** awk helper matches assertions by Kubernetes **kind** and **metadata.name** instead of grepping any `name:` line.
> 
> The script header documents Check 3; **`main`** invokes it alongside the existing host and workload-name checks. Behavior matches Check 2 when **helm** is missing (skip render half locally).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 751ecfe90604c0e39cbadd6d625bad5b75febbaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->