### PR TITLE
test(e2e-proxy): deflake §4 — retry the squid Service-readiness race

### DIFF
--- a/scripts/tests/e2e-proxy.sh
+++ b/scripts/tests/e2e-proxy.sh
@@ -263,7 +263,14 @@ spec:
       args:
         - |
           echo ">>>>> SECTION_A_WITH_PROXY_ENV"
-          curl -k -v -sS -m 20 -o /dev/null https://${BACKEND_HOST}/ 2>&1
+          # --retry-connrefused survives the window where the squid Deployment is
+          # rolled out (readinessProbe green) but its Service endpoints aren't yet
+          # programmed in kube-proxy, so a brand-new pod's first CONNECT to the
+          # Service ClusterIP is refused. Without it, that transient refusal made
+          # curl give up before attempting the tunnel — no "Establish HTTP proxy
+          # tunnel" line — and §4 flaked red (e.g. run 29255451968). A genuine
+          # #119 regression still fails all retries, so the guard keeps its teeth.
+          curl -k -v -sS -m 30 --retry 5 --retry-connrefused --retry-delay 2 -o /dev/null https://${BACKEND_HOST}/ 2>&1
           echo ">>>>> SECTION_B_PROXY_ENV_UNSET"
           env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy -u NO_PROXY -u no_proxy curl -k -v -sS -m 20 -o /dev/null https://${BACKEND_HOST}/ 2>&1
           echo ">>>>> SECTION_END"
@@ -290,6 +297,14 @@ printf '%s\n' "$a_section" | grep -iE 'Establish HTTP proxy tunnel|CONNECT tunne
 printf '%s\n' "$b_section" | grep -iE 'Trying|Connected to|< HTTP/|Could not resolve'                 | sed 's/^/    B env unset:       /' || true
 # (A) WITH the ingestion proxy env, the backend call MUST traverse the squid.
 if ! printf '%s' "$a_section" | grep -qiE 'Establish HTTP proxy tunnel to backend\.tracebloc-e2e\.test|CONNECT tunnel established'; then
+  # The filtered diagnostics above matched nothing on a novel failure (run
+  # 29255451968 showed only the B line). Dump the RAW pod log + squid/endpoint
+  # state so the cause is visible next time instead of a bare "did NOT tunnel."
+  echo "── DIAGNOSTIC: raw egress-app log (section A showed no proxy tunnel) ──"
+  printf '%s\n' "$applog" | sed 's/^/    app| /'
+  echo "── DIAGNOSTIC: squid pod + service endpoints ──"
+  kubectl get pod -l app=tb-egress-squid -o wide 2>&1 | sed 's/^/    /' || true
+  kubectl get endpoints tb-egress-squid 2>&1 | sed 's/^/    /' || true
   error "App pod WITH the ingestion proxy env did NOT tunnel through the squid — ingestion-style backend egress is not proxied (the #119 bug)."
 fi
 # (B) With the env unset, the SAME call MUST NOT use a proxy (it dials direct).


### PR DESCRIPTION
## What

`scripts/tests/e2e-proxy.sh` §4 (the client-runtime#119 ingestion-egress guard) flaked red on develop — [run 29255451968](https://github.com/tracebloc/client/actions/runs/29255451968). A re-run of the **same commit** (`ca9a3352f`) [passed](https://github.com/tracebloc/client/actions/runs/29340987746), confirming a **transient**, not a regression — and #341 (the commit under test) never touched this file.

## Cause

Section A's app-pod curl reaches the in-cluster squid via its **Service**, but `kubectl rollout status` gates only on the squid **pod** being Ready — not on its Service endpoints being programmed in kube-proxy. In that window a brand-new pod's first CONNECT to the ClusterIP is refused; curl gave up before attempting the tunnel (no `Establish HTTP proxy tunnel` line), so the assertion false-failed. The failure was opaque because the diagnostics only print *filtered* lines — a novel failure showed nothing.

## Fix

- `--retry 5 --retry-connrefused --retry-delay 2` (-m 30) on section A's curl — rides out the transient connection-refused. A genuine #119 regression still fails all retries, so the guard keeps its teeth.
- On the (A) assertion failure, dump the **raw** egress-app log + squid pod/endpoint state, so any future failure is debuggable instead of a bare "did NOT tunnel."

## Test plan
- `bash -n` + `shellcheck` clean. The k3d e2e can't run locally; CI (this workflow) is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to an e2e shell script; no production runtime, auth, or data paths are modified.
> 
> **Overview**
> **Deflakes** the §4 ingestion-egress check in `scripts/tests/e2e-proxy.sh` when section A’s curl hits the in-cluster squid **before** its Service endpoints are ready in kube-proxy (pod Ready ≠ ClusterIP routable).
> 
> Section A’s proxied `curl` now uses **`--retry 5 --retry-connrefused --retry-delay 2`** and a longer **`-m 30`** so a transient connection refused does not abort before the CONNECT tunnel is attempted; a real #119-style regression should still fail after all retries.
> 
> If the tunnel assertion still fails, the script now prints the **raw** `egress-app` log plus **squid pod and Service endpoint** state so CI failures are actionable instead of only showing filtered diagnostic lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06801e1da9a60e2d7eab820a6fef34383b28c9b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->