### PR TITLE
chore(chart): bump client 1.9.4 → 1.9.5 (version + appVersion)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.4
-appVersion: "1.9.4"
+version: 1.9.5
+appVersion: "1.9.5"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
Release-prep bump so the installer changes on `main` since **v1.9.4** can be cut as **v1.9.5** and reach production (R8 ships only via the stamped release asset — a `main` merge alone doesn't reach `tracebloc.io/i.sh`).

Headline: **location drop** — auto-derive the carbon zone from the system timezone, never prompt (#354/#355/#356), + Bugbot hint fix (#357) + earlier installer hardening (#345/#350/#351/#352/#353).

`version` + `appVersion` bumped in lockstep (appVersion feeds the `app.kubernetes.io/version` label cluster-info reads).

Next: `develop → main` sync PR, then publish Release `v1.9.5` (flips fleet auto-upgrade at :23).

Closes #358 partially — tracks the full release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only chart version bump with no behavioral code changes in the diff.
> 
> **Overview**
> **Release version stamp only** — `client/Chart.yaml` `version` and `appVersion` move from **1.9.4** to **1.9.5** in lockstep. No template or installer logic changes in this diff.
> 
> `appVersion` drives the `app.kubernetes.io/version` label via `tracebloc.labels` in `_helpers.tpl`, so cluster metadata will report **1.9.5** after this chart is deployed. The bump is release prep so installer work already on `main` (e.g. location/timezone carbon zone behavior and related fixes called out in the PR) can ship as **v1.9.5** via the stamped release asset rather than a bare merge to `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d4100e1aa4eca5d503c973d13514b7b2f13ea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->