### PR TITLE
main -> Release v1.9.5: location-drop + installer hardening

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.4
-appVersion: "1.9.4"
+version: 1.9.5
+appVersion: "1.9.5"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
Release sync `develop → main` to cut **v1.9.5**.

Ships the installer changes accumulated on `main` since v1.9.4 — production only receives them via a stamped release asset (`tracebloc.io/i.sh` → latest release), so this promotion + a published release is what actually reaches users.

**Headline:** stop prompting for location during registration — auto-derive the carbon zone from the system timezone, never ask (#354/#355/#356), Bugbot hint fix (#357).
**Also:** `client/Chart.yaml` bumped 1.9.4 → 1.9.5 (#359).

After merge: publish GitHub Release `v1.9.5` targeting `main` (stamps `install.sh`, packages the chart, updates gh-pages, flips fleet auto-upgrade at :23).

Tracks #358.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only chart version bump with no template, values, or runtime logic changes in the diff.
> 
> **Overview**
> **Release v1.9.5** — updates `client/Chart.yaml` so both `version` and `appVersion` move from **1.9.4** to **1.9.5**, aligning the packaged chart with the promoted `develop → main` release (installer and other product changes referenced in the release notes land via the published release asset, not in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3471e6ee3fef3b1387ce0953e86c3a7f0d990590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->