### PR TITLE
Installer copy catalog (byte-exact golden of what a user sees)

### DIFF
--- a/scripts/testdata/golden/00-install.golden
+++ b/scripts/testdata/golden/00-install.golden
@@ -1,0 +1,88 @@
+tracebloc installer — what you see while installing
+===================================================
+What scrolls past when you run the installer (curl | bash, or ./install-k8s.sh
+directly). Shown byte-exact, colour off. The banner and the "2. Installing"
+roadmap print once up front; then each step prints its running header. The
+titles below are read live from install-k8s.sh, so they can't drift from what
+the installer actually prints. Interactive prompts and per-component progress
+stream during the run and aren't pinned here.
+
+$ ./install-k8s.sh   # banner (curl|bash pins a version; direct run omits it)
+
+
+  Setting up tracebloc on your machine · v1.9.5
+
+  ────────────────────────────────────────
+
+
+$ ./install-k8s.sh   # banner, direct run (no version suffix)
+
+
+  Setting up tracebloc on your machine
+
+  ────────────────────────────────────────
+
+
+$ ./install-k8s.sh   # the plan, printed once before install begins
+  2. Installing
+
+  a) Check your machine
+  b) Install what tracebloc needs
+  c) Create your secure environment
+  d) Register this machine
+  e) Install tracebloc
+  f) Connect to the tracebloc network
+
+
+
+$ ./install-k8s.sh   # the six running step headers (a-f), titles from install-k8s.sh
+  a) Checking your machine
+
+  b) Installing what tracebloc needs
+
+  c) Creating your secure environment
+
+  d) Registering this machine
+
+  e) Installing tracebloc
+
+  f) Connecting to the tracebloc network
+
+
+
+------------------------------------------------------------
+--help
+------------------------------------------------------------
+$ ./install-k8s.sh --help
+tracebloc — client setup
+
+  Set up a secure compute environment on your machine
+  and connect it to the tracebloc network.
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/tracebloc/client/main/scripts/install.sh | bash
+  ./install-k8s.sh [--help] [--diagnose] [--force]
+
+Commands:
+  --diagnose     Collect a redacted support bundle (logs + cluster/host status)
+                 into ~/.tracebloc/tracebloc-diagnose-<timestamp>.tgz and exit.
+                 Run this if something went wrong, then send the file to support
+                 (passwords and proxy credentials are removed before it is written).
+  --force        Skip the "already set up" check and re-run every step. Use this
+  --reinstall    to force a full reinstall on a machine that is already set up.
+                 (Same effect as TRACEBLOC_FORCE_REINSTALL=1 for curl | bash.)
+
+Advanced configuration (environment variables):
+  CLUSTER_NAME   Cluster name                   (default: tracebloc)
+  TB_NAMESPACE   Secure-environment name        (default: tracebloc)
+  SERVERS        Control-plane nodes             (default: 1)
+  AGENTS         Worker nodes                    (default: 1)
+  K8S_VERSION    k3s image tag                   (default: v1.29.4-k3s1)
+  HOST_DATA_DIR  Persistent data directory       (default: ~/.tracebloc)
+                 Must be on a LOCAL disk — NFS/CIFS/SMB is rejected (the database
+                 corrupts on network storage). TRACEBLOC_ALLOW_NETWORK_FS=1 overrides.
+
+Windows:
+  irm https://raw.githubusercontent.com/tracebloc/client/main/scripts/install.ps1 | iex
+
+Learn more: https://docs.tracebloc.io

--- a/scripts/testdata/golden/01-outcomes.golden
+++ b/scripts/testdata/golden/01-outcomes.golden
@@ -1,0 +1,70 @@
+tracebloc installer — the final summary
+=======================================
+The last thing you see. After applying the chart the installer waits for your
+services and reports one of these end states (summary.sh, print_summary). Shown
+byte-exact, colour off. The "your data never leaves this machine" trust claim
+appears ONLY on a verified connection.
+
+$ (install finished — connected)
+
+  ✔ Connected to tracebloc
+
+  Environment : tracebloc
+  Version     : 1.9.5
+  Mode        : CPU
+
+  Your secure environment is live 🟢
+    See it on your dashboard:  https://ai.tracebloc.io/clients
+
+  What's next
+    1. Ingest your data       tracebloc data ingest
+    2. Create a use case      https://ai.tracebloc.io/my-use-cases
+    3. Invite collaborators — they train on your data; it never leaves this machine
+
+  Run  tracebloc  to get started.
+
+  ────────────────────────────────────────
+  Logs ~/.tracebloc  ·  Data /tracebloc/tracebloc
+  After a reboot, tracebloc restarts automatically.
+
+
+$ (install finished — starting)
+
+  ⚠  Almost there — tracebloc is installed but still starting.
+
+  Components are still downloading/starting (first run can take a few minutes).
+  Check progress:   kubectl get pods -n tracebloc
+
+  Your client will show as 🟢 Online at https://ai.tracebloc.io/clients
+  once it finishes. Re-running this installer is safe.
+
+
+$ (install finished — bad_creds)
+
+  ✖ Couldn't connect — your Client ID or password was rejected.
+
+  The environment installed, but tracebloc refused those credentials.
+    1. Re-check them at https://ai.tracebloc.io/clients
+    2. Re-run this installer (safe to re-run)
+
+
+$ (install finished — image_pull)
+
+  ✖ Setup didn't finish — an image couldn't be pulled.
+
+  Inspect:  kubectl get pods -n tracebloc
+  Logs:     ~/.tracebloc/install-*.log
+  Re-running this installer is safe.
+
+
+$ (install finished — crash)
+
+  ✖ Setup didn't finish — a container is restarting (crash loop).
+
+  Inspect:  kubectl get pods -n tracebloc
+  Logs:     ~/.tracebloc/install-*.log
+  Re-running this installer is safe.
+
+
+$ (connected, on macOS/Windows — the reboot footer differs)
+  After a reboot, open Docker Desktop to bring tracebloc back.

--- a/scripts/tests/copy-catalog.bats
+++ b/scripts/tests/copy-catalog.bats
@@ -25,6 +25,11 @@ load test_helper
 
 setup() {
   export NO_COLOR=1          # empty every tone → byte-exact plain copy
+  # print_banner no-ops when TRACEBLOC_BANNER_SHOWN is set (the curl|bash
+  # bootstrap exports it after drawing the banner). An inherited value would
+  # blank both banner samples in emit_install and drift the golden — clear it
+  # so the catalog always renders them (mirrors common.bats).
+  unset TRACEBLOC_BANNER_SHOWN
   load_lib summary.sh        # common.sh (banner/roadmap/help/step_header) + summary.sh
   # Deterministic env for the copy-emitting functions (values a user never sees
   # under NO_COLOR affect only the silent log(), but set them so `set -u`-style

--- a/scripts/tests/copy-catalog.bats
+++ b/scripts/tests/copy-catalog.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# =============================================================================
+#  copy-catalog.bats — the installer copy catalog.
+#
+#  Renders every stable piece of installer copy byte-exact (colour off) into
+#  scripts/testdata/golden/, so the wording AND layout a user sees while
+#  installing can be reviewed without running an install. Mirrors the CLI's
+#  golden catalog (cli repo, internal/cli/testdata/golden/).
+#
+#  Two files, ordered like the run:
+#    00-install.golden  — banner, the "2. Installing" roadmap, the six running
+#                         step headers (titles read live from install-k8s.sh),
+#                         and --help.
+#    01-outcomes.golden — the state-branched final summary (connected / starting
+#                         / bad creds / image pull / crash) + the reboot footer.
+#
+#  Copy that only streams mid-flow (interactive prompts, per-component progress,
+#  the curl|bash bootstrap's "1. Downloading" section) isn't a stable screen and
+#  isn't pinned here.
+#
+#  The tests fail on drift; regenerate after an intentional copy change:
+#    TB_UPDATE_GOLDEN=1 bats scripts/tests/copy-catalog.bats
+# =============================================================================
+load test_helper
+
+setup() {
+  export NO_COLOR=1          # empty every tone → byte-exact plain copy
+  load_lib summary.sh        # common.sh (banner/roadmap/help/step_header) + summary.sh
+  # Deterministic env for the copy-emitting functions (values a user never sees
+  # under NO_COLOR affect only the silent log(), but set them so `set -u`-style
+  # references never trip).
+  OS=Linux; ARCH=amd64; CLUSTER_NAME=tracebloc; SERVERS=1; AGENTS=1
+  GPU_VENDOR=none; TB_NAMESPACE=tracebloc; HOST_DATA_DIR="$HOME/.tracebloc"
+  # Stub the one live read the summary makes, so it's deterministic.
+  _chart_version() { echo "1.9.5"; }
+}
+
+GOLDEN_DIR="${BATS_TEST_DIRNAME}/../testdata/golden"
+
+# check_golden NAME — compare stdin against the golden file, or (re)write it
+# when TB_UPDATE_GOLDEN is set. Byte-exact via file comparison (not $output,
+# which strips trailing newlines).
+check_golden() {
+  local golden="${GOLDEN_DIR}/$1" actual="${BATS_TEST_TMPDIR}/$1"
+  cat >"$actual"
+  if [ -n "${TB_UPDATE_GOLDEN:-}" ]; then
+    mkdir -p "$GOLDEN_DIR"
+    cp "$actual" "$golden"
+    return 0
+  fi
+  diff -u "$golden" "$actual"
+}
+
+# ── 00 install — what you see while it runs ──────────────────────────────────
+emit_install() {
+  cat <<'PROSE'
+tracebloc installer — what you see while installing
+===================================================
+What scrolls past when you run the installer (curl | bash, or ./install-k8s.sh
+directly). Shown byte-exact, colour off. The banner and the "2. Installing"
+roadmap print once up front; then each step prints its running header. The
+titles below are read live from install-k8s.sh, so they can't drift from what
+the installer actually prints. Interactive prompts and per-component progress
+stream during the run and aren't pinned here.
+PROSE
+
+  printf '\n$ ./install-k8s.sh   # banner (curl|bash pins a version; direct run omits it)\n'
+  TB_VERSION="v1.9.5" print_banner
+  printf '\n$ ./install-k8s.sh   # banner, direct run (no version suffix)\n'
+  TB_VERSION="" print_banner
+
+  printf '\n$ ./install-k8s.sh   # the plan, printed once before install begins\n'
+  print_roadmap
+
+  printf '\n$ ./install-k8s.sh   # the six running step headers (a-f), titles from install-k8s.sh\n'
+  sed -nE 's/.*step_header ([a-f]) "([^"]*)".*/\1 \2/p' "${SCRIPTS_DIR}/install-k8s.sh" \
+    | while read -r letter title; do step_header "$letter" "$title"; done
+
+  printf '\n\n------------------------------------------------------------\n--help\n------------------------------------------------------------\n'
+  printf '$ ./install-k8s.sh --help\n'
+  print_help
+}
+
+@test "installer copy catalog: 00-install is current" {
+  emit_install | check_golden 00-install.golden
+}
+
+# ── 01 outcomes — the final summary, one per end state ───────────────────────
+emit_outcomes() {
+  cat <<'PROSE'
+tracebloc installer — the final summary
+=======================================
+The last thing you see. After applying the chart the installer waits for your
+services and reports one of these end states (summary.sh, print_summary). Shown
+byte-exact, colour off. The "your data never leaves this machine" trust claim
+appears ONLY on a verified connection.
+PROSE
+
+  local state
+  for state in connected starting bad_creds image_pull crash; do
+    printf '\n$ (install finished — %s)\n' "$state"
+    CLIENT_STATE="$state" print_summary 2>&1
+  done
+
+  printf '\n$ (connected, on macOS/Windows — the reboot footer differs)\n'
+  OS=Darwin _reboot_note
+}
+
+@test "installer copy catalog: 01-outcomes is current" {
+  emit_outcomes | check_golden 01-outcomes.golden
+}


### PR DESCRIPTION
## Summary

Adds a **copy catalog** for the installer — a byte-exact golden of every stable piece of user-facing copy, so wording + layout can be reviewed without running an install. Mirrors the CLI's golden catalog (`cli` repo, `internal/cli/testdata/golden/`).

`scripts/tests/copy-catalog.bats` renders the copy colour-off (`NO_COLOR`) into two files under `scripts/testdata/golden/`, ordered like the run:

- **`00-install.golden`** — the banner (versioned + direct-run variants), the "2. Installing" roadmap, the six running step headers (a–f; titles read **live** from `install-k8s.sh` so they can't drift), and `--help`.
- **`01-outcomes.golden`** — `print_summary`'s five end states (connected / starting / bad creds / image pull / crash) + the reboot footer, including the macOS/Windows variant.

## Why

So we stop the "change copy → deploy → see it in prod → fix" loop: the catalog is reviewable on any PR that touches installer copy, and the test fails on drift.

## Determinism

- Colour off → text is byte-exact.
- The one live read (`_chart_version`) is stubbed; `$HOME` collapses to `~` in the summary, so the goldens are stable across machines/CI.
- The step titles are extracted from `install-k8s.sh` at test time, so they track the real installer.

## Test plan

- `TB_UPDATE_GOLDEN=1 bats scripts/tests/copy-catalog.bats` regenerates; plain `bats scripts/tests/copy-catalog.bats` verifies (drift guard). Both green locally.
- Not in the R8 manifest (`tests/` + `testdata/` aren't installer scripts). CI already globs `scripts/tests/*.bats` and excludes `.bats` from shellcheck, so it runs with no wiring changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions (BATS + golden fixtures); installer runtime behavior is unchanged.
> 
> **Overview**
> Adds an **installer copy catalog**: BATS tests render stable, user-facing installer text (with `NO_COLOR`) into golden files under `scripts/testdata/golden/`, mirroring the CLI’s golden pattern.
> 
> **`copy-catalog.bats`** drives `print_banner`, `print_roadmap`, step headers (titles parsed live from `install-k8s.sh`), `print_help`, and `print_summary` for each end state. Output is compared byte-for-byte to **`00-install.golden`** and **`01-outcomes.golden`**; drift fails CI unless you regenerate with `TB_UPDATE_GOLDEN=1`.
> 
> Determinism comes from stubbing `_chart_version`, clearing `TRACEBLOC_BANNER_SHOWN`, and fixed env vars—no full install required for copy review on PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65b9e8abca270fd830ab841dd86a64350ae874d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->