### PR TITLE
chore(chart): refresh prod ingestor digest pin to v0.7.5 (backend#1028)

### DIFF
--- a/client/values-prod.yaml
+++ b/client/values-prod.yaml
@@ -41,6 +41,6 @@
 images:
   ingestor:
     # ghcr.io/tracebloc/ingestor multi-arch index for the 0.7 line.
-    # v0.7.0 (== tag `0.7` / `0.7.0`) — VERIFIED against ghcr.io 2026-07-10
+    # v0.7.5 (== tag `0.7` / `0.7.5`) — VERIFIED against ghcr.io 2026-07-23
     # (linux/amd64 + linux/arm64 OCI image index). Re-verify at each prod cut.
-    digest: "sha256:78f21a08d1fb186b9764ad96090dcaf9c381c6407c7778f2085a56dea2d8f117"
+    digest: "sha256:a5f2650b2ffbe027cbf4401b8778c4376e383d56d673df297babe150ecf49414"


### PR DESCRIPTION
## Summary

The prod overlay's ingestor digest pin (`client/values-prod.yaml`) was resolved on **2026-07-13** when client#334 introduced it — i.e. it pins the **v0.7.0-era** `0.7` index. Since then **v0.7.4** (di#368 end-to-end correlation id, di#369 orphan-row reconcile — backend#1028 items 2/3) and **v0.7.5** shipped, so a prod install kept spawning a pre-fix ingestor while dev/staging (floating `0.7`, no pin) already run v0.7.5.

This refreshes the pin per the release convention documented in the overlay itself ("re-verify the digest every time the prod ingestor line is cut") and updates the audit-trail comment.

## Type
- [x] Chore / maintenance

## Test plan
- Resolved with the repo helper, not hand-typed: `scripts/resolve-ingestor-digest.sh 0.7 --write`
- Helper output: `ghcr.io/tracebloc/ingestor@sha256:a5f2650b…49414 (tag 0.7; platforms: linux/amd64 linux/arm64)` — multi-arch index guard passed
- Cross-checked the digest equals the `0.7.5` tag's index digest exactly (and differs from `0.7.4`), confirming `0.7` currently floats to v0.7.5
- Note: helm-ci's `ingestor-multiarch` guard inspects the base `values.yaml` digest only, so the helper's own multi-arch check above is the verification for this overlay

## Checklist
- [x] Digest resolved via `scripts/resolve-ingestor-digest.sh` (never hand-typed)
- [x] Multi-arch (amd64+arm64) index confirmed
- [x] Audit-trail comment (`VERIFIED …`) updated

Part of **tracebloc/backend#1028** (item 1 follow-through). Epic: tracebloc/backend#1008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm values-only change with no application code; risk is limited to prod clusters using this overlay picking up ingestor v0.7.5 behavior on the next deploy.
> 
> **Overview**
> **Prod ingestor image pin** in `client/values-prod.yaml` moves from the **v0.7.0** multi-arch index digest to **v0.7.5** (`sha256:a5f2650…`), so Helm installs with the prod overlay spawn ingestion jobs on the current certified `0.7` line instead of a stale pre–v0.7.4/v0.7.5 build.
> 
> The inline **VERIFIED** audit comment is updated to **2026-07-23** and **v0.7.5**; resolution is intended via `scripts/resolve-ingestor-digest.sh 0.7 --write`, not manual digest entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 206b66dff670c6a0aba193171e0c4b57518b4e18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->