### PR TITLE
docs(bugbot): add .cursor/BUGBOT.md project context

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,114 @@
+# Bugbot guide — tracebloc/client
+
+## Context
+
+Helm charts (`client/`, `ingestor/`) plus a `curl | bash` installer: `scripts/install.sh`
+is the signed trust root that fetches and verifies `scripts/install-k8s.sh` +
+`scripts/lib/*.sh`, with PowerShell peers (`install.ps1`, `install-k8s.ps1`).
+
+This runs on **customer-operated Kubernetes**: on-prem, frequently headless over SSH,
+often behind a TLS-inspecting corporate proxy, sometimes against a mirrored registry.
+Operators are usually not Kubernetes people, and there is no telemetry — if the
+installer prints "ready" when it isn't, nobody finds out for days. Optimise findings
+for *what the operator sees and can act on*, not code elegance.
+
+## Always flag
+
+- **Missing `set -euo pipefail` in an entry-point script**, unquoted `$var` / `$(...)`,
+  `eval`, or parsing that breaks on spaces/newlines. Note the house idiom: a top-level
+  `[[ -f x ]] && source x` **trips `set -e`** when the test is false — require an `if`
+  block instead (`scripts/install-k8s.sh:70-80`).
+
+- **A `curl` call without the TLS floor.** `CURL_SECURE="--tlsv1.2"`
+  (`scripts/lib/common.sh:10`) is a *constant, not a wrapper* — every call site splices
+  it manually, so a new call silently loses it, and a TLS-inspecting proxy will happily
+  negotiate down. Already missing at `common.sh:326,347`, `gpu-amd.sh:29,52`,
+  `gpu-nvidia.sh:92,99`, `install-client-helm.sh:269`. (`scripts/install.sh` hardcodes
+  the literal because it cannot source `common.sh` — it is the file fetching it. Correct.)
+
+- **An unbounded external call.** `kubectl` takes `--request-timeout=5s`. `helm` has no
+  `--request-timeout`, so the convention is to gate a helm call behind a bounded
+  `kubectl cluster-info --request-timeout=5s` probe (`scripts/lib/diagnose.sh:149-152`).
+  `curl` takes `--connect-timeout` plus `-m`/`--max-time`, or the
+  `--speed-limit`/`--speed-time` stall pair. Against a wedged API server an unbounded
+  call hangs a headless install forever, with no output to interpret.
+
+- **A version/tag/ref interpolated into a URL without validation.** There is no shared
+  validator — each path adds its own gate: `scripts/install.sh:184,193,214-219` (ref
+  charset + immutable-tag regex + a literal `*/*` / `*..*` check, defending
+  `v1.2.3-../../heads/main`), `scripts/lib/setup-linux.sh:406,413` for `K3D_VERSION`.
+  A new download path needs its own.
+
+- **A guard that fails open.** A failed or unparsable `kubectl`/`helm`/`docker` result
+  must never read as a benign "nothing there". Canonical:
+  `detect_installed_client()` sets `INSTALLED_CLIENT_UNKNOWN=1` rather than "no client
+  here" when `helm list` exits non-zero (`scripts/lib/install-client-helm.sh:166-205`) —
+  failing open lets a re-install silently overwrite a live client. Also
+  `client/templates/egress-reachability-check.yaml:79-97` keys its verdict on curl's
+  **exit code**, not the HTTP status, because curl without `--fail` exits 0 on a 500.
+
+- **Success reported without verifying it.** `docs/SEAL-CHECK.md:34` — "unsealed, never
+  silently sealed": a check that cannot verify its guarantee fails loudly. Flag any step
+  that prints ✓ / "healthy" / "ready" on a path where the underlying assertion was
+  skipped, degraded, or errored, and any summary that counts a skipped check as passed.
+
+- **A read of a *new* `values.yaml` key with no nil-guard.** `helm upgrade --reuse-values`
+  keeps the OLD stored values, so a template reading a key that didn't exist at install
+  time nil-pointers before any resource lands. Require `default` / `with` / `hasKey`;
+  worked example at `client/templates/metadata-backfill-hook.yaml:1-18`. Both upgrade
+  paths must survive: `scripts/lib/install-client-helm.sh:390-391` feature-detects
+  `--reset-then-reuse-values` and falls back to `--reuse-values` on Helm < 3.14, while
+  `client/templates/auto-upgrade-cronjob.yaml:84` hardcodes the reset form — a new chart
+  *default* only reaches an existing release on the reset path.
+
+- **Anything assuming a live `helm.sh/resource-policy: keep` annotation protects data.**
+  Helm reads that annotation from the **stored release manifest**, not the live object, so
+  `kubectl annotate pvc … resource-policy=keep` does not survive `helm uninstall`. This
+  cost a production PVC set on 2026-04-22 (`docs/MIGRATIONS.md`, "The resource-policy:
+  keep gotcha"). Templates that legitimately render it: `logs-pvc.yaml`,
+  `shared-images-pvc.yaml`, `mysql-storage-pvc.yaml`, `namespace.yaml`,
+  `node-agents-namespace.yaml`, `priority-class.yaml`.
+
+- **Image pinning drift.** Images are pinned by digest with the tag kept for readability
+  only — the digest is authoritative (`client/values.yaml:291-298`). Digests must be
+  multi-arch *index* digests; `scripts/resolve-ingestor-digest.sh` refuses a single-arch
+  one. CI's `ingestor-multiarch` guard reads `client/values.yaml` **only** and does not
+  validate `client/values-prod.yaml` (stated at `values-prod.yaml:36-40`) — flag a
+  prod-overlay digest change with no `# VERIFIED` audit note.
+
+- **Credentials in `values*.yaml`, logs, argv, or a `--diagnose` bundle**; secret/values
+  files should be mode 0600.
+
+- **A changed bootstrap-fetched script without a regenerated `scripts/manifest.sha256`**
+  (`scripts/gen-manifest.sh`). The "Installer manifest is current (supply-chain, R8)" step
+  in `installer-tests.yaml` fails, and a stale manifest breaks `install.sh`'s verified fetch.
+
+- **A `Chart.yaml` `version` bump without the matching `appVersion`** — the
+  `app.kubernetes.io/version` label depends on it.
+
+## Known non-issues — do not flag
+
+- **`scripts/lib/*.sh` have no `set -euo pipefail` by design.** They are only ever
+  `source`d by `scripts/install-k8s.sh`, which sets it at line 44 *before* sourcing.
+- `scripts/check-style.sh`, `scripts/tests/check-drift.sh`, `scripts/tests/distro-prereqs.sh`
+  and `scripts/tests/path-persist.sh` deliberately use `set -uo pipefail` **without `-e`**
+  so they can inspect a failing check's exit code instead of aborting.
+- **SC2034 "unused variable" in `scripts/lib/*.sh` is a known false positive** — those vars
+  are consumed cross-file once the libs are sourced together. CI blocks at
+  `--severity=error` and runs `--severity=warning` advisory-only (`installer-tests.yaml:63-67`).
+- `scripts/manifest.sha256` and `scripts/testdata/golden/*.golden` are **generated**. The
+  golden copy catalog is regenerated with
+  `TB_UPDATE_GOLDEN=1 bats scripts/tests/copy-catalog.bats`, never hand-edited — review the
+  copy itself, not the diff mechanics.
+- **`clientId` is intentionally not redacted** from `--diagnose` bundles: it is the
+  identifier support needs, not a secret (`scripts/lib/diagnose.sh:13`).
+- Existing `# shellcheck disable=…` lines each carry a stated reason — don't re-litigate them.
+- `docs/`, chart lockfiles, and generated sections of `client/values.schema.json`.
+
+## Tone
+
+Direct. Name the file and line. Give a concrete fix, not "consider". Lead with the
+operator-visible consequence (what they see, what breaks, at which step).
+
+This repo is **public** — never put a customer name, internal hostname, or internal-only
+ticket detail in a finding. A bare `tracebloc/backend#NNNN` reference is fine.


### PR DESCRIPTION
## Summary

Adds `.cursor/BUGBOT.md` — project context for the Cursor Bugbot reviewer. **Zero repos in the org have one today**, so Bugbot reviews every repo blind. This is item 4 of tracebloc/backend#930 and RFC 0001's own highest-value change.

On this repo it matters most: Bugbot writes roughly **21.6x the human inline review volume** here, so it is effectively the entire code review. Every house rule it re-derives from scratch is a pass not spent on a genuinely hard finding.

## What's in it

Rules are grounded in this repo, not generic security advice — each carries the reason and a real reference:

- **`$CURL_SECURE` is a constant, not a wrapper** (`scripts/lib/common.sh:10`), so a new `curl` call silently loses the `--tlsv1.2` floor. Lists the sites already missing it.
- **Timeout conventions per tool** — `kubectl --request-timeout=5s`; `helm` has none, so gate it behind a bounded `cluster-info` probe; `curl` needs connect + max-time or the stall pair.
- **Validate any version/tag before URL interpolation** — there is no shared validator, each path adds its own gate.
- **Guards must fail closed** — `detect_installed_client()` sets `INSTALLED_CLIENT_UNKNOWN=1` rather than "no client here", because failing open lets a re-install overwrite a live client.
- **Never report success you have not verified** — the SEAL-CHECK "unsealed, never silently sealed" principle.
- **Helm nil-guards on new `values.yaml` keys**, and why both `--reuse-values` and `--reset-then-reuse-values` paths have to survive.
- **The `helm.sh/resource-policy: keep` stored-manifest trap** that cost a production PVC set.
- **Digest pinning**, including the documented CI blind spot where `ingestor-multiarch` does not read the prod overlay.
- **R8 manifest regeneration** after any change to a bootstrap-fetched script.

Plus a **verified** known-non-issues section so Bugbot stops re-reporting false positives — chiefly that `scripts/lib/*.sh` omit `set -euo pipefail` **by design** (they are sourced after `install-k8s.sh:44` sets it), the four guard scripts that deliberately drop `-e`, and the cross-file SC2034 "unused variable" class that CI already treats as advisory.

## Type

Docs / DevEx. No code or chart changes.

## Test plan

- No runtime impact — a single markdown file read by Cursor.
- Every path, line reference and non-issue in the file was verified against this checkout before writing; nothing unverified was included. Notably, a rule about `client_logger` vs `print_and_log` was dropped after confirming those symbols do not exist in this repo.

## Checklist

- [x] Targets `develop`
- [x] Public repo — no customer names, internal hostnames, or internal-only ticket detail
- [x] Only `.cursor/BUGBOT.md` in this PR
- [x] Assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, chart, or installer behavior changes.
> 
> **Overview**
> Adds **`.cursor/BUGBOT.md`**, a Cursor Bugbot playbook for this repo so automated reviews stop re-deriving house rules from scratch.
> 
> The doc frames the product (Helm charts + verified `curl | bash` installer on customer-operated clusters) and tells Bugbot to prioritize **operator-visible failures** over style. **Always flag** covers installer/chart pitfalls with file:line anchors: entry-point `set -euo pipefail` and the `[[ -f x ]] && source` trap, per-call `CURL_SECURE` / bounded `kubectl`/`curl`/`helm` probes, ref validation before URL interpolation, fail-closed guards, no false “ready” without verification, nil-safe new `values.yaml` keys across reuse vs reset upgrade paths, the `resource-policy: keep` stored-manifest gotcha, digest pinning and prod-overlay CI blind spots, credential hygiene, `manifest.sha256` regeneration, and `Chart.yaml` `version`/`appVersion` pairing.
> 
> A **known non-issues** section suppresses repeat noise (sourced libs without their own `set -e`, guard scripts without `-e`, SC2034 cross-file, generated artifacts, `clientId` in diagnose bundles). **Tone** rules keep findings concrete and public-safe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce3cd50a28ec53a122033da67a59fa3d0e29804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->