### PR TITLE
docs(pr-template): owner-qualify cross-repo closing keywords

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- 1–3 sentences. What does this PR do and why? -->
 
 ## Related
-<!-- Closes #123 / Ref tracebloc/other-repo#456 -->
+<!-- Same repo: Closes #123 · Cross-repo: Fixes tracebloc/backend#456 (owner-qualified — a bare backend#456 closes nothing). PRs land on develop, not the default branch, so confirm the issue actually closed. -->
 
 ## Type of change
 - [ ] Feature
@@ -27,3 +27,4 @@
 - [ ] No secrets / credentials in the diff
 - [ ] For security-sensitive paths: appropriate reviewer requested
 - [ ] Terminal output follows [STYLE.md](../STYLE.md) — tone helpers (no hardcoded colour/emoji), "secure environment" not "workspace"; `bash scripts/check-style.sh` passes
+- [ ] Cross-repo issues use `Fixes tracebloc/<repo>#N` — a bare `repo#N` closes nothing


### PR DESCRIPTION
## Summary

GitHub auto-closes an issue in **another** repository only when the PR body uses an **owner-qualified** closing keyword. A bare `repo#N` — or a plain `#N` aimed at another repo — creates a cross-reference and closes nothing. This template's own hint taught `Ref tracebloc/other-repo#456`, and `Ref` is not a closing keyword at all, so the template was part of the problem rather than the fix.

Two lines change: the `Related` hint now shows the qualified form as the visible example, and one checklist item turns it into a gate. Nothing else — a template nobody reads because it grew is worse than the bug.

**One extra wrinkle specific to this repo.** Its default branch is `main`, but every PR targets `develop` per the org rule. GitHub fires closing keywords *only* on merges into the default branch, so a correctly-written `Closes #N` here will not auto-close on merge to `develop` either — not just cross-repo ones. The `Related` hint says so, and asks the author to confirm the issue actually closed. That matches the observed evidence: tracebloc/client#376 is an issue *in this repo* that stayed open behind a merged PR.

## Related

Epic: tracebloc/backend#930 (developer feedback loop)

## Evidence

Eight code-complete issues with merged PRs sat open for days-to-weeks:

- tracebloc/backend#1171, tracebloc/backend#1172, tracebloc/backend#1173, tracebloc/backend#1174, tracebloc/backend#1175, tracebloc/backend#1176
- tracebloc/client#376
- tracebloc/cli#393

Two epics consequently under-reported their progress by a wide margin. Someone had to notice and close all eight by hand.

## Type of change
- [x] Docs

## Test plan

Markdown-only change to `.github/pull_request_template.md`; no code paths touched, no installer scripts touched (so no `scripts/gen-manifest.sh` re-run needed).

One thing worth stating explicitly, since it is the reason the example can be concrete rather than a placeholder: **closing keywords inside an HTML comment are inert.** These templates have carried `<!-- Closes #123 -->` since they were written and have never once touched issue #123. So the new `Fixes tracebloc/<repo>#456` example teaches the shape without ever firing.

## Deployment notes

None. Takes effect on the next PR opened after merge.

## Checklist
- [x] Docs updated if behavior or config changed
- [x] No secrets / credentials in the diff
- [x] Terminal output follows STYLE.md — n/a, no terminal output changed
- [x] Cross-repo issues use `Fixes tracebloc/<repo>#N` — a bare `repo#N` closes nothing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only change to the PR template; no runtime, auth, or deployment behavior.
> 
> **Overview**
> **Pull request template** guidance is tightened so authors stop using cross-repo references that GitHub will not auto-close.
> 
> The **Related** HTML comment now shows `Closes #123` for same-repo work and `Fixes tracebloc/backend#456` for cross-repo work, with an explicit warning that bare `backend#456` closes nothing. It also notes that PRs here merge into **`develop`**, not the default branch, so even correct `Closes #N` may not fire until someone confirms the issue state.
> 
> A new **checklist** item requires cross-repo links to use `Fixes tracebloc/<repo>#N` instead of unqualified `repo#N`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3262633113dd4347abc9d2cfaf1bde2229d8efb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->