### PR TITLE
docs(rfc): qualified identifier for the rootless spike + fix the LPI back-link

### DIFF
--- a/docs/rfcs/0001-rootless-spike.md
+++ b/docs/rfcs/0001-rootless-spike.md
@@ -1,7 +1,8 @@
 # RFC 0001 — Spike: rootless Docker as the k3d backend
 
-**Ticket:** tracebloc/backend#1176 · **Epic:** tracebloc/backend#1168 · **RFC:** [0001-least-privilege-install.md](./0001-least-privilege-install.md)
-**Status:** analysis + validation plan (preliminary go/no-go). The experiments in §5 need real target hosts before Tier 1 (#1177) ships.
+**Qualified ID:** `RFC-CLIENT-0001` — cite this document by its qualified ID, never as a bare "RFC 0001"; `backend` and `cli` each have their own 0001. Org-wide index: `docs/rfcs/README.md` in `tracebloc/backend` (private).
+**Ticket:** tracebloc/backend#1176 · **Epic:** tracebloc/backend#1168 · **RFC:** [`RFC-CLIENT-0002` — 0002-least-privilege-install.md](./0002-least-privilege-install.md)
+**Status:** Draft — analysis + validation plan (preliminary go/no-go). The experiments in §5 need real target hosts before Tier 1 (#1177) ships.
 
 ## 0. Why this spike gates Tier 1
 


### PR DESCRIPTION
## Summary

Two small fixes to `docs/rfcs/0001-rootless-spike.md`, both consequences of RFC numbers being assigned **per repo** — a bare `0001` currently names **four** different documents across the org.

1. **Qualified identifier.** The header now states `RFC-CLIENT-0001`, in the bold-label style this document already uses, and carries an explicit `Draft` status.
2. **Fixed the `RFC:` back-link.** It pointed at `./0001-least-privilege-install.md` — a link that is **broken on `develop` today** and that collided with this very file's own number.

## The within-repo collision

`client` had a genuine collision, not just a cross-repo one: the least-privilege-install RFC in #369 was also numbered `0001`, the same number as the rootless spike already on `develop`.

That one is being **renumbered to `0002-least-privilege-install.md`** (`RFC-CLIENT-0002`) in #369, so the back-link here now targets `0002`. `0002` was the next free number in this repo.

**No merge-order requirement.** The link is dead either way until #369 merges — it is dead on `develop` right now. If this lands first it stays dead for the gap; if #369 lands first it resolves immediately.

## The stray duplicate file

`docs/rfcs/0001-rootless-spike 2.md` — a macOS copy artifact — **was never committed to git.** It existed only as an untracked file in a local working tree (`git ls-files` and `git log --all` both return nothing for it).

Verdict: it is a **byte-for-byte duplicate** of `0001-rootless-spike.md`, not an inferior or diverged copy — both are 6842 bytes with md5 `6544a40cd86f84940725bc8bcad29c3c`, matching the copy on `origin/develop` exactly. Its only difference was a `-rw-------` permission bit. It has been deleted from the working tree; **no repository change was required**, which is why this PR shows no deletion.

## Public-repo note

`client` is public. The added text names only `tracebloc/backend` and issue numbers, both of which this document already referenced on `develop`. No customer names, hostnames or internal-only detail.

## Companion PRs

| Repo | PR | Contents |
|---|---|---|
| `backend` | tracebloc/backend#1259 | the scheme + the org-wide index (`docs/rfcs/README.md`, private repo by design) |
| `cli` | tracebloc/cli#412 | qualified IDs in the three cli RFC headers |
| `client` | #369 | `RFC-CLIENT-0002`: the renumber, status Accepted, un-drafted |

**In-flight:** tracebloc/backend#1146 adds `backend/docs/rfcs/0002-platform-cost-autoscale-architecture.md`. It will need the same header treatment (`RFC-BACKEND-0002`) when it merges — it is already listed in the index.

## Test plan

Docs-only; no chart, script or workflow touched. Verified the document renders and that the only link change is the intended `0001` → `0002` repoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only header and link updates with no runtime, chart, or workflow changes.
> 
> **Overview**
> Updates **`docs/rfcs/0001-rootless-spike.md`** so cross-repo RFC numbering is unambiguous: the header now declares **`RFC-CLIENT-0001`**, tells readers not to cite a bare "RFC 0001", and points at the org index in `tracebloc/backend`.
> 
> **Status** is explicitly **Draft** (prepended to the existing status line). The **`RFC:`** back-link no longer targets `./0001-least-privilege-install.md` (broken and same-number collision); it now links **`RFC-CLIENT-0002`** at `./0002-least-privilege-install.md`, aligned with the companion renumber in #369.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ee638d4047fe64aa3689ae5593182f2e62c2d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->