### PR TITLE
docs: refresh stale BUGBOT.md guidance (curl_secure + prodDigest) — Bugbot #383

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -19,12 +19,15 @@ for *what the operator sees and can act on*, not code elegance.
   `[[ -f x ]] && source x` **trips `set -e`** when the test is false — require an `if`
   block instead (`scripts/install-k8s.sh:70-80`).
 
-- **A `curl` call without the TLS floor.** `CURL_SECURE="--tlsv1.2"`
-  (`scripts/lib/common.sh:10`) is a *constant, not a wrapper* — every call site splices
-  it manually, so a new call silently loses it, and a TLS-inspecting proxy will happily
-  negotiate down. Already missing at `common.sh:326,347`, `gpu-amd.sh:29,52`,
-  `gpu-nvidia.sh:92,99`, `install-client-helm.sh:269`. (`scripts/install.sh` hardcodes
-  the literal because it cannot source `common.sh` — it is the file fetching it. Correct.)
+- **A bare `curl` that bypasses `curl_secure()`.** Every fetch goes through the
+  `curl_secure()` wrapper (`scripts/lib/common.sh`), which bakes in the TLS floor
+  (`--tlsv1.2`) and the connect/stall timeouts so a call site can't silently drop them
+  and a TLS-inspecting proxy can't negotiate down. `check-style.sh` (rule 3, "no bare
+  `curl`") enforces this in CI, so flag any new bare `curl` that isn't `curl_secure`.
+  Legitimately exempt (the style rule already allows these): `scripts/install.sh` and the
+  WSL here-string in `install-k8s.ps1` name `--tlsv1.2` directly because they can't source
+  `common.sh`; comments; `has curl` / `command -v curl` presence tests; and the
+  `curl … | sh` one-liner printed for the user to copy.
 
 - **An unbounded external call.** `kubectl` takes `--request-timeout=5s`. `helm` has no
   `--request-timeout`, so the convention is to gate a helm call behind a bounded
@@ -70,11 +73,16 @@ for *what the operator sees and can act on*, not code elegance.
   `node-agents-namespace.yaml`, `priority-class.yaml`.
 
 - **Image pinning drift.** Images are pinned by digest with the tag kept for readability
-  only — the digest is authoritative (`client/values.yaml:291-298`). Digests must be
-  multi-arch *index* digests; `scripts/resolve-ingestor-digest.sh` refuses a single-arch
-  one. CI's `ingestor-multiarch` guard reads `client/values.yaml` **only** and does not
-  validate `client/values-prod.yaml` (stated at `values-prod.yaml:36-40`) — flag a
-  prod-overlay digest change with no `# VERIFIED` audit note.
+  only — the digest is authoritative (`client/values.yaml`, `images.ingestor`). Pinned
+  digests must be multi-arch *index* digests; `scripts/resolve-ingestor-digest.sh` refuses
+  a single-arch one. The fleet-wide prod pin is the chart default
+  `images.ingestor.prodDigest` (in `client/values.yaml`), **not** an install-time overlay —
+  the old `client/values-prod.yaml` was deleted and the pin moved into chart defaults
+  (backend#1245). CI's `ingestor-multiarch` guard (`.github/workflows/helm-ci.yaml`) reads
+  `client/values.yaml` and hard-fails if `prodDigest` is empty (that silently un-pins prod)
+  or not multi-arch; it also checks the floating `images.ingestor.tag` and the per-edge
+  `images.ingestor.digest` when set. Flag a `prodDigest`/`digest` change that isn't a
+  verified multi-arch index digest (resolve with `scripts/resolve-ingestor-digest.sh`).
 
 - **Credentials in `values*.yaml`, logs, argv, or a `--diagnose` bundle**; secret/values
   files should be mode 0600.


### PR DESCRIPTION
Resolves two Cursor Bugbot findings on the client promotion PR (#383, develop → main) — both stale reviewer guidance in `.cursor/BUGBOT.md`.

Fixes:
- **Stale curl TLS guidance** (Medium) — the "Always flag" bullet still described `CURL_SECURE="--tlsv1.2"` as a *constant every call site splices by hand* and listed "already missing" TLS sites. The real current rule is the `curl_secure()` wrapper in `scripts/lib/common.sh` (bakes in the TLS floor + timeouts), enforced by `scripts/check-style.sh` rule 3 ("no bare `curl`"). Rewrote the bullet to flag a bare `curl` that bypasses `curl_secure()`, and listed the real exemptions (`install.sh` / the WSL here-string that can't source `common.sh`, comments, presence tests, the user-facing `curl … | sh` one-liner). (https://github.com/tracebloc/client/pull/383#discussion_r3655678591)
- **Stale prod overlay pin guidance** (Medium) — the "Image pinning drift" bullet told reviewers CI ignores `client/values-prod.yaml` and to flag prod-overlay digest edits. That overlay was **deleted**; the fleet-wide prod pin moved to the chart default `images.ingestor.prodDigest` in `client/values.yaml`, and the `ingestor-multiarch` guard in `.github/workflows/helm-ci.yaml` reads it and **hard-fails** if it's empty or not multi-arch (also checks `images.ingestor.tag` and per-edge `images.ingestor.digest`). Rewrote to the real contract. (https://github.com/tracebloc/client/pull/383#discussion_r3655678604)

Verified against the current `common.sh` `curl_secure()`, `check-style.sh` rule 3, the deleted `values-prod.yaml`, `client/values.yaml` `images.ingestor.prodDigest`, and the `ingestor-multiarch` job before rewriting. Docs-only.

Lands on develop; the promotion PR head picks these up on the next develop sync and Bugbot re-reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Bugbot guidance; no runtime, CI logic, or chart behavior is modified.
> 
> **Overview**
> **Docs-only refresh** of Cursor Bugbot reviewer rules in `.cursor/BUGBOT.md` so automated review matches how the installer and chart actually work today.
> 
> The **TLS / curl** “Always flag” bullet no longer describes `CURL_SECURE` as something every call site must splice by hand or lists stale “missing TLS” file paths. It now tells reviewers to flag **bare `curl`** that bypasses **`curl_secure()`** in `scripts/lib/common.sh`, notes **CI enforcement** via `check-style.sh` rule 3, and documents the **real exemptions** (`install.sh`, WSL here-string, comments, presence checks, user-facing `curl | sh` one-liner).
> 
> The **image pinning drift** bullet no longer references **`client/values-prod.yaml`** or “CI ignores the prod overlay.” It documents the **fleet-wide prod pin** as chart default **`images.ingestor.prodDigest`** in `client/values.yaml` (overlay removed per backend#1245) and the **`ingestor-multiarch`** job in `.github/workflows/helm-ci.yaml` — including hard-fail on empty `prodDigest` and checks on `tag`, `prodDigest`, and per-edge `digest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fc092a143f51108f86b9830fd532482839de538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->