### PR TITLE
fix(chart): pin mysql-client by digest — keep fleets on the 5.7-lineage prod image

### DIFF
--- a/client/tests/mysql_test.yaml
+++ b/client/tests/mysql_test.yaml
@@ -178,3 +178,10 @@ tests:
           content:
             name: mysql-tmp
             mountPath: /tmp
+
+  - it: pins the mysql-client image by digest (chart default — fleets stay on the 5.7-lineage image)
+    template: templates/mysql-deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^docker\.io/tracebloc/mysql-client@sha256:[a-f0-9]{64}$

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -459,7 +459,14 @@ images:
     # if you are publishing your own fork with a different tag. Never use
     # "latest"; pin via digest instead.
     tag: ""
-    digest: ""
+    # Pinned (2026-07-28) to the current MySQL 5.7-lineage :prod image
+    # (pushed 2026-04-24). Workspace datadirs are 5.7-format and MySQL
+    # supports only staged upgrades (5.7 -> 8.0 -> 8.4), while this repo's
+    # Dockerfile.mysql_client already builds 8.4 (backend#723) — so a
+    # re-published :prod tag must never reach fleets implicitly. Remove or
+    # replace this pin only as an explicit step of the staged migration
+    # plan in backend#723.
+    digest: "sha256:f546e47fb339e0982c902cef063b081ccf2cbbaf35b475287d583b9bf3163354"
   busybox:
     tag: "1.35"
     digest: ""

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -466,6 +466,11 @@ images:
     # re-published :prod tag must never reach fleets implicitly. Remove or
     # replace this pin only as an explicit step of the staged migration
     # plan in backend#723.
+    # NOTE: this digest is a single-arch (amd64) image manifest — identical
+    # to what the floating tag always resolved to, so fleet behavior is
+    # unchanged (arm64 hosts keep running it emulated). A future re-pin
+    # (the 8.4 multi-arch image, backend#723) should pin the manifest-INDEX
+    # digest, like images.ingestor.prodDigest does.
     digest: "sha256:f546e47fb339e0982c902cef063b081ccf2cbbaf35b475287d583b9bf3163354"
   busybox:
     tag: "1.35"

--- a/scripts/tests/e2e-auto-upgrade.sh
+++ b/scripts/tests/e2e-auto-upgrade.sh
@@ -104,6 +104,10 @@ echo "  E2E auto-upgrade gate   arch: $(uname -m)   kernel: $(uname -r)"
 echo "═══════════════════════════════════════════════════════════════════════"
 
 has docker || error "Docker is not available on this host."
+# jq reads the baseline release's computed values (BASELINE_PROD_DIGEST).
+# Preinstalled on GitHub-hosted runners; local runs must bring their own —
+# fail fast here instead of a mid-run pipeline abort.
+has jq || error "jq is required (it reads the baseline release's computed values)."
 umask 022
 install_kubectl
 install_k3d

--- a/scripts/tests/e2e-auto-upgrade.sh
+++ b/scripts/tests/e2e-auto-upgrade.sh
@@ -14,9 +14,12 @@
 #  paths and asserts the contract that keeps the fleet safe:
 #    1. `--reuse-values`            -> upgrade succeeds (nil-guards hold), the
 #                                      egress lockdown does NOT engage by
-#                                      accident, and the prod ingestor pin does
-#                                      NOT arrive (stored computed values
-#                                      predate the key — documented limitation).
+#                                      accident, and the prod ingestor pin
+#                                      matches the BASELINE release: absent when
+#                                      the published chart predates the pin key,
+#                                      replayed VERBATIM when it carries one —
+#                                      never injected from the new chart's
+#                                      defaults (documented limitation).
 #    2. `--reset-then-reuse-values` -> upgrade succeeds, new defaults flow in
 #                                      (egress gateway deploys, inert),
 #                                      out-of-band image-refresh annotations
@@ -126,6 +129,17 @@ helm install "$NS" "${REPO_NAME}/client" --version "$PREV" \
   --set clientPassword=ci-e2e-upgrade \
   --set storageClass.provisioner=rancher.io/local-path
 
+# The baseline (published) release's computed prod-ingestor pin, if any. This
+# decides which era path 1 asserts: releases published before client#398 have
+# no images.ingestor.prodDigest to replay (the pin must NOT arrive via
+# --reuse-values), while releases since client#383 carry it in their computed
+# values (the SAME pin must be replayed verbatim). Read it from the release,
+# not from a date or version compare, so the test is correct in both eras.
+# jq is preinstalled on the stock runners.
+BASELINE_PROD_DIGEST="$(helm get values "$NS" -n "$NS" --all -o json \
+  | jq -r '.images.ingestor.prodDigest // ""')"
+echo "   baseline prod ingestor pin: ${BASELINE_PROD_DIGEST:-<none — pre-pin era>}"
+
 echo "── simulate an image-refresh-managed annotation (must survive upgrades) ──"
 kubectl annotate -n "$NS" "$(jm_deploy)" \
   "tracebloc.io/last-refreshed-jobs-manager-digest=sha256:e2e-sentinel" --overwrite
@@ -137,13 +151,22 @@ helm upgrade "$NS" "$CHART_DIR" --namespace "$NS" --reuse-values
 netpol_has_external_443 || fail "--reuse-values upgrade dropped the external 443 rule (lockdown engaged by accident)"
 [ -z "$(jm_egress_proxy_url)" ] || fail "--reuse-values upgrade injected EGRESS_PROXY_URL (routing engaged by accident)"
 # Documented limitation, asserted so it stays a known quantity: plain
-# --reuse-values replays the old release's COMPUTED values, which predate
-# images.ingestor.prodDigest, so the prod pin does NOT arrive on this path. The
-# fleet does not use it (path 2 does) — but an operator upgrading by hand with
-# this flag stays on the floating tag.
-[ -z "$(jm_ingestor_digest)" ] \
-  || fail "--reuse-values unexpectedly applied a prod ingestor pin; this path replays stored computed values and should still float"
-echo "   OK: upgrade succeeded, lockdown stayed off, ingestor still floating"
+# --reuse-values replays the old release's COMPUTED values and ignores the new
+# chart's defaults. What that means for the prod ingestor pin depends on the
+# baseline era: a published release that predates images.ingestor.prodDigest
+# has no key to replay, so the pin must NOT arrive; a release that already
+# carries the pin must have it replayed VERBATIM — the baseline's digest, not
+# the working tree's. Either way nothing may be injected from the new chart's
+# defaults on this path. The fleet does not use this flag (path 2 does) — an
+# operator upgrading by hand with it keeps exactly the values the edge had.
+if [ -z "$BASELINE_PROD_DIGEST" ]; then
+  [ -z "$(jm_ingestor_digest)" ] \
+    || fail "--reuse-values unexpectedly applied a prod ingestor pin; the baseline release predates the key, so replayed computed values cannot contain it"
+else
+  [ "$(jm_ingestor_digest)" = "$BASELINE_PROD_DIGEST" ] \
+    || fail "--reuse-values did not replay the baseline prod pin verbatim: got '$(jm_ingestor_digest)', want '$BASELINE_PROD_DIGEST' (stored computed values must win over new chart defaults on this path)"
+fi
+echo "   OK: upgrade succeeded, lockdown stayed off, ingestor pin matches the baseline era (${BASELINE_PROD_DIGEST:-floating})"
 
 echo "── path 2: the fleet auto-upgrade — helm upgrade --reset-then-reuse-values ──"
 helm upgrade "$NS" "$CHART_DIR" --namespace "$NS" --reset-then-reuse-values
@@ -158,12 +181,18 @@ DEPLOYED="$(helm list -n "$NS" --filter "^${NS}\$" -o yaml \
   | awk '/^[[:space:]]*chart:/ {print $2; exit}')"
 [ "$DEPLOYED" = "client-${LOCAL_VERSION}" ] || fail "deployed chart is $DEPLOYED, expected client-${LOCAL_VERSION}"
 # backend#1245 acceptance criterion: publishing a chart with an updated prod pin
-# must change the digest on an ALREADY-INSTALLED edge. The release was installed
-# from the published chart (no prodDigest key at all, floating on the tag); this
-# upgrade is the exact command the fleet auto-upgrade CronJob runs, with no `-f`
-# and no `--set`. The pin arriving here is what the old `-f values-prod.yaml`
-# overlay could never do — an overlay value is user-supplied, so it would be
-# replayed verbatim forever while the chart's copy was ignored.
+# must change the digest on an ALREADY-INSTALLED edge. This upgrade is the exact
+# command the fleet auto-upgrade CronJob runs, with no `-f` and no `--set`. The
+# pin arriving here is what the old `-f values-prod.yaml` overlay could never
+# do — an overlay value is user-supplied, so it would be replayed verbatim
+# forever while the chart's copy was ignored.
+# ERA NOTE: path 1's --reuse-values rewrote this release's recorded values to
+# the baseline's full computed set, so against a post-pin baseline the replayed
+# pin and the local chart default coincide only while nobody has bumped the
+# pin. If a pin bump makes them differ, the assertion below fails — and that
+# failure is a real signal, not test noise: an edge that was ever hand-upgraded
+# with --reuse-values stops receiving chart pin updates the same way. Decide
+# then whether to isolate path 2 from path 1 or fix the replay contamination.
 WANT_DIGEST="$(local_prod_digest)"
 [ -n "$WANT_DIGEST" ] \
   || fail "images.ingestor.prodDigest is empty in the working-tree chart — prod would silently lose its reproducibility pin"

--- a/scripts/tests/e2e-auto-upgrade.sh
+++ b/scripts/tests/e2e-auto-upgrade.sh
@@ -134,12 +134,14 @@ helm install "$NS" "${REPO_NAME}/client" --version "$PREV" \
   --set storageClass.provisioner=rancher.io/local-path
 
 # The baseline (published) release's computed prod-ingestor pin, if any. This
-# decides which era path 1 asserts: releases published before client#398 have
-# no images.ingestor.prodDigest to replay (the pin must NOT arrive via
-# --reuse-values), while releases since client#383 carry it in their computed
+# decides which era path 1 asserts. The boundary is the #383 promotion
+# (2026-07-27) — the first PUBLISHED chart release to carry the
+# images.ingestor.prodDigest default that #398 added to the chart source.
+# Baselines published before it have no pin to replay (the pin must NOT
+# arrive via --reuse-values); baselines since carry it in their computed
 # values (the SAME pin must be replayed verbatim). Read it from the release,
 # not from a date or version compare, so the test is correct in both eras.
-# jq is preinstalled on the stock runners.
+# jq is guarded in the preflight above.
 BASELINE_PROD_DIGEST="$(helm get values "$NS" -n "$NS" --all -o json \
   | jq -r '.images.ingestor.prodDigest // ""')"
 echo "   baseline prod ingestor pin: ${BASELINE_PROD_DIGEST:-<none — pre-pin era>}"
@@ -195,8 +197,9 @@ DEPLOYED="$(helm list -n "$NS" --filter "^${NS}\$" -o yaml \
 # pin and the local chart default coincide only while nobody has bumped the
 # pin. If a pin bump makes them differ, the assertion below fails — and that
 # failure is a real signal, not test noise: an edge that was ever hand-upgraded
-# with --reuse-values stops receiving chart pin updates the same way. Decide
-# then whether to isolate path 2 from path 1 or fix the replay contamination.
+# with --reuse-values stops receiving chart pin updates the same way. Tracked
+# in client#459 — the first prodDigest bump trips this deliberately; decide
+# there whether to isolate path 2 from path 1 or fix the replay contamination.
 WANT_DIGEST="$(local_prod_digest)"
 [ -n "$WANT_DIGEST" ] \
   || fail "images.ingestor.prodDigest is empty in the working-tree chart — prod would silently lose its reproducibility pin"


### PR DESCRIPTION
## Summary

`images.mysqlClient` now defaults to a **digest pin** on the current `tracebloc/mysql-client:prod` image (5.7-lineage, pushed 2026-04-24) instead of following the floating `:prod` tag.

**Why:** the repo's `Dockerfile.mysql_client` has moved ahead to MySQL 8.4 (backend#723), but every existing workspace datadir is 5.7-format, and MySQL supports only staged upgrades (5.7 → 8.0 → 8.4) — an 8.4 server refuses to start on a 5.7 datadir. With a floating tag, any republish of `:prod` would reach fleets implicitly: fresh installs immediately, running workspaces on their next fresh pull (cache eviction / node replacement). Pinning by digest makes the MySQL engine upgrade an explicit, reviewed chart change — exactly what the surrounding comment already recommends ("pin via digest instead").

Decided 2026-07-28 (Lukas + Saqlain) as part of the mysql-client migration sequencing on backend#723. The companion guard on the manual build path is in tracebloc/client-runtime#213.

## Type

- [x] Fix

## Test plan

- `helm template` (with required install values set) renders the mysql container as `docker.io/tracebloc/mysql-client@sha256:f546e47f…` — the digest path of the `tracebloc.image` helper. Verified locally.
- Digest verified equal to the current Docker Hub `:prod` manifest digest (tag_last_pushed 2026-04-24).
- `values.schema.json` digest pattern (`^(sha256:[a-f0-9]{64})?$`) satisfied — chart schema validation passes.

## Rollout

No image change is triggered by this PR — it pins what fleets already run. Takes effect per fleet at its next `helm upgrade`. Remove/replace the pin only as an explicit step of the staged migration in backend#723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pins the data-plane MySQL image digest (correctness-sensitive for 5.7 datadirs); rollout is no-op until helm upgrade, with low blast radius because the pin matches the current tag.
> 
> **Overview**
> **Pins `images.mysqlClient.digest`** in chart defaults to the current MySQL 5.7-lineage `tracebloc/mysql-client:prod` image so fleets no longer follow the floating `:prod` tag. A republish of `:prod` (e.g. toward 8.4 per backend#723) would otherwise reach installs implicitly while existing workspace datadirs still require staged upgrades; behavior is unchanged because the digest matches what the tag already resolved to.
> 
> Adds a **Helm unittest** on `mysql-deployment.yaml` that the mysql container image renders as `docker.io/tracebloc/mysql-client@sha256:…`.
> 
> The **e2e auto-upgrade** script now reads the baseline release’s `images.ingestor.prodDigest` via `helm get values` + `jq` (with a `jq` preflight) and asserts that **`helm upgrade --reuse-values`** either leaves the ingestor pin absent (pre-pin baselines) or replays the baseline digest verbatim—not the new chart default—with notes on path-1/path-2 interaction when pins diverge (client#459).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c118c619133a1e30db399f1dff22f156bdae1568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->