### PR TITLE
fix(e2e): era-aware --reuse-values pin assertion — baseline release now carries the prod pin

### DIFF
--- a/scripts/tests/e2e-auto-upgrade.sh
+++ b/scripts/tests/e2e-auto-upgrade.sh
@@ -104,6 +104,10 @@ echo "  E2E auto-upgrade gate   arch: $(uname -m)   kernel: $(uname -r)"
 echo "═══════════════════════════════════════════════════════════════════════"
 
 has docker || error "Docker is not available on this host."
+# jq reads the baseline release's computed values (BASELINE_PROD_DIGEST).
+# Preinstalled on GitHub-hosted runners; local runs must bring their own —
+# fail fast here instead of a mid-run pipeline abort.
+has jq || error "jq is required (it reads the baseline release's computed values)."
 umask 022
 install_kubectl
 install_k3d

--- a/scripts/tests/e2e-auto-upgrade.sh
+++ b/scripts/tests/e2e-auto-upgrade.sh
@@ -14,9 +14,12 @@
 #  paths and asserts the contract that keeps the fleet safe:
 #    1. `--reuse-values`            -> upgrade succeeds (nil-guards hold), the
 #                                      egress lockdown does NOT engage by
-#                                      accident, and the prod ingestor pin does
-#                                      NOT arrive (stored computed values
-#                                      predate the key — documented limitation).
+#                                      accident, and the prod ingestor pin
+#                                      matches the BASELINE release: absent when
+#                                      the published chart predates the pin key,
+#                                      replayed VERBATIM when it carries one —
+#                                      never injected from the new chart's
+#                                      defaults (documented limitation).
 #    2. `--reset-then-reuse-values` -> upgrade succeeds, new defaults flow in
 #                                      (egress gateway deploys, inert),
 #                                      out-of-band image-refresh annotations
@@ -126,6 +129,17 @@ helm install "$NS" "${REPO_NAME}/client" --version "$PREV" \
   --set clientPassword=ci-e2e-upgrade \
   --set storageClass.provisioner=rancher.io/local-path
 
+# The baseline (published) release's computed prod-ingestor pin, if any. This
+# decides which era path 1 asserts: releases published before client#398 have
+# no images.ingestor.prodDigest to replay (the pin must NOT arrive via
+# --reuse-values), while releases since client#383 carry it in their computed
+# values (the SAME pin must be replayed verbatim). Read it from the release,
+# not from a date or version compare, so the test is correct in both eras.
+# jq is preinstalled on the stock runners.
+BASELINE_PROD_DIGEST="$(helm get values "$NS" -n "$NS" --all -o json \
+  | jq -r '.images.ingestor.prodDigest // ""')"
+echo "   baseline prod ingestor pin: ${BASELINE_PROD_DIGEST:-<none — pre-pin era>}"
+
 echo "── simulate an image-refresh-managed annotation (must survive upgrades) ──"
 kubectl annotate -n "$NS" "$(jm_deploy)" \
   "tracebloc.io/last-refreshed-jobs-manager-digest=sha256:e2e-sentinel" --overwrite
@@ -137,13 +151,22 @@ helm upgrade "$NS" "$CHART_DIR" --namespace "$NS" --reuse-values
 netpol_has_external_443 || fail "--reuse-values upgrade dropped the external 443 rule (lockdown engaged by accident)"
 [ -z "$(jm_egress_proxy_url)" ] || fail "--reuse-values upgrade injected EGRESS_PROXY_URL (routing engaged by accident)"
 # Documented limitation, asserted so it stays a known quantity: plain
-# --reuse-values replays the old release's COMPUTED values, which predate
-# images.ingestor.prodDigest, so the prod pin does NOT arrive on this path. The
-# fleet does not use it (path 2 does) — but an operator upgrading by hand with
-# this flag stays on the floating tag.
-[ -z "$(jm_ingestor_digest)" ] \
-  || fail "--reuse-values unexpectedly applied a prod ingestor pin; this path replays stored computed values and should still float"
-echo "   OK: upgrade succeeded, lockdown stayed off, ingestor still floating"
+# --reuse-values replays the old release's COMPUTED values and ignores the new
+# chart's defaults. What that means for the prod ingestor pin depends on the
+# baseline era: a published release that predates images.ingestor.prodDigest
+# has no key to replay, so the pin must NOT arrive; a release that already
+# carries the pin must have it replayed VERBATIM — the baseline's digest, not
+# the working tree's. Either way nothing may be injected from the new chart's
+# defaults on this path. The fleet does not use this flag (path 2 does) — an
+# operator upgrading by hand with it keeps exactly the values the edge had.
+if [ -z "$BASELINE_PROD_DIGEST" ]; then
+  [ -z "$(jm_ingestor_digest)" ] \
+    || fail "--reuse-values unexpectedly applied a prod ingestor pin; the baseline release predates the key, so replayed computed values cannot contain it"
+else
+  [ "$(jm_ingestor_digest)" = "$BASELINE_PROD_DIGEST" ] \
+    || fail "--reuse-values did not replay the baseline prod pin verbatim: got '$(jm_ingestor_digest)', want '$BASELINE_PROD_DIGEST' (stored computed values must win over new chart defaults on this path)"
+fi
+echo "   OK: upgrade succeeded, lockdown stayed off, ingestor pin matches the baseline era (${BASELINE_PROD_DIGEST:-floating})"
 
 echo "── path 2: the fleet auto-upgrade — helm upgrade --reset-then-reuse-values ──"
 helm upgrade "$NS" "$CHART_DIR" --namespace "$NS" --reset-then-reuse-values
@@ -158,12 +181,18 @@ DEPLOYED="$(helm list -n "$NS" --filter "^${NS}\$" -o yaml \
   | awk '/^[[:space:]]*chart:/ {print $2; exit}')"
 [ "$DEPLOYED" = "client-${LOCAL_VERSION}" ] || fail "deployed chart is $DEPLOYED, expected client-${LOCAL_VERSION}"
 # backend#1245 acceptance criterion: publishing a chart with an updated prod pin
-# must change the digest on an ALREADY-INSTALLED edge. The release was installed
-# from the published chart (no prodDigest key at all, floating on the tag); this
-# upgrade is the exact command the fleet auto-upgrade CronJob runs, with no `-f`
-# and no `--set`. The pin arriving here is what the old `-f values-prod.yaml`
-# overlay could never do — an overlay value is user-supplied, so it would be
-# replayed verbatim forever while the chart's copy was ignored.
+# must change the digest on an ALREADY-INSTALLED edge. This upgrade is the exact
+# command the fleet auto-upgrade CronJob runs, with no `-f` and no `--set`. The
+# pin arriving here is what the old `-f values-prod.yaml` overlay could never
+# do — an overlay value is user-supplied, so it would be replayed verbatim
+# forever while the chart's copy was ignored.
+# ERA NOTE: path 1's --reuse-values rewrote this release's recorded values to
+# the baseline's full computed set, so against a post-pin baseline the replayed
+# pin and the local chart default coincide only while nobody has bumped the
+# pin. If a pin bump makes them differ, the assertion below fails — and that
+# failure is a real signal, not test noise: an edge that was ever hand-upgraded
+# with --reuse-values stops receiving chart pin updates the same way. Decide
+# then whether to isolate path 2 from path 1 or fix the replay contamination.
 WANT_DIGEST="$(local_prod_digest)"
 [ -n "$WANT_DIGEST" ] \
   || fail "images.ingestor.prodDigest is empty in the working-tree chart — prod would silently lose its reproducibility pin"

--- a/scripts/tests/e2e-auto-upgrade.sh
+++ b/scripts/tests/e2e-auto-upgrade.sh
@@ -134,12 +134,14 @@ helm install "$NS" "${REPO_NAME}/client" --version "$PREV" \
   --set storageClass.provisioner=rancher.io/local-path
 
 # The baseline (published) release's computed prod-ingestor pin, if any. This
-# decides which era path 1 asserts: releases published before client#398 have
-# no images.ingestor.prodDigest to replay (the pin must NOT arrive via
-# --reuse-values), while releases since client#383 carry it in their computed
+# decides which era path 1 asserts. The boundary is the #383 promotion
+# (2026-07-27) — the first PUBLISHED chart release to carry the
+# images.ingestor.prodDigest default that #398 added to the chart source.
+# Baselines published before it have no pin to replay (the pin must NOT
+# arrive via --reuse-values); baselines since carry it in their computed
 # values (the SAME pin must be replayed verbatim). Read it from the release,
 # not from a date or version compare, so the test is correct in both eras.
-# jq is preinstalled on the stock runners.
+# jq is guarded in the preflight above.
 BASELINE_PROD_DIGEST="$(helm get values "$NS" -n "$NS" --all -o json \
   | jq -r '.images.ingestor.prodDigest // ""')"
 echo "   baseline prod ingestor pin: ${BASELINE_PROD_DIGEST:-<none — pre-pin era>}"
@@ -195,8 +197,9 @@ DEPLOYED="$(helm list -n "$NS" --filter "^${NS}\$" -o yaml \
 # pin and the local chart default coincide only while nobody has bumped the
 # pin. If a pin bump makes them differ, the assertion below fails — and that
 # failure is a real signal, not test noise: an edge that was ever hand-upgraded
-# with --reuse-values stops receiving chart pin updates the same way. Decide
-# then whether to isolate path 2 from path 1 or fix the replay contamination.
+# with --reuse-values stops receiving chart pin updates the same way. Tracked
+# in client#459 — the first prodDigest bump trips this deliberately; decide
+# there whether to isolate path 2 from path 1 or fix the replay contamination.
 WANT_DIGEST="$(local_prod_digest)"
 [ -n "$WANT_DIGEST" ] \
   || fail "images.ingestor.prodDigest is empty in the working-tree chart — prod would silently lose its reproducibility pin"


### PR DESCRIPTION
## Summary

Unblocks **#454** and every other chart-touching PR: the "Fleet auto-upgrade E2E (k3d)" check has failed since yesterday's develop → main promotion (#383), because the path-1 assertion hardcoded an era that promotion ended.

**Cause.** `--reuse-values` replays the *baseline* release's computed values and ignores new chart defaults. The assertion expected `jm_ingestor_digest` to be **empty** after that upgrade, which was only true while the last published release predated `images.ingestor.prodDigest` (#398). The #383 promotion published a release that carries the pin in its computed values, so the replay now (correctly) delivers it, and the hardcoded expectation fails — exactly the era boundary the test's own comment described. Diagnosis first posted on #454.

**Fix.** The expectation is now derived from the baseline release itself, right after it is installed:

- `BASELINE_PROD_DIGEST="$(helm get values --all -o json | jq -r '.images.ingestor.prodDigest // ""')"`
- Pin **absent** in baseline ⇒ assert it does **not** arrive (the old behavior, still correct against pre-#398 releases).
- Pin **present** ⇒ assert the **same digest is replayed verbatim** — strictly stronger than "non-empty": it still proves the documented limitation (nothing injected from the new chart's defaults) in the new era.

Era-stale comments updated (header contract, path 1, path 2). Other assertions untouched.

**Flagged, not fixed here (path-2 era note added in code).** Path 1's `--reuse-values` rewrites the release's recorded values to the baseline's full computed set, so path 2's `--reset-then-reuse-values` replays the baseline pin *as if user-supplied*. Today baseline pin == working-tree pin, so path 2's `GOT == WANT` holds — but the first PR that **bumps** `prodDigest` will fail path 2. That failure is a genuine signal, not noise: any real edge that was ever hand-upgraded with `--reuse-values` stops receiving chart pin updates the same way. Worth a follow-up decision (isolate path 2 from path 1, or treat as the intended tripwire for the replay-contamination issue).

## Type

- [x] Fix (CI)

## Test plan

- `bash -n` + `shellcheck` clean.
- Era logic: baseline without pin ⇒ old assertion path (unchanged behavior); baseline with pin ⇒ verbatim-replay assertion. `jq` is preinstalled on the stock runners.
- The real proof is this PR's own **Helm Chart CI** run: its E2E installs the current (post-#383, pin-carrying) release and exercises the new era-B branch end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to e2e-auto-upgrade.sh assertions and comments; no production Helm chart or runtime behavior is modified.
> 
> **Overview**
> Fixes the **Fleet auto-upgrade E2E (k3d)** gate after published charts started carrying `images.ingestor.prodDigest` in computed values.
> 
> The path-1 `--reuse-values` check no longer assumes the prod ingestor pin is always absent. After installing the last published release, the script reads **`BASELINE_PROD_DIGEST`** from `helm get values --all` (via **`jq`**, with a new preflight) and branches: **no baseline pin** ⇒ digest must stay empty; **baseline pin present** ⇒ digest must match the baseline **verbatim** (proving new chart defaults are not injected on this path).
> 
> Header and inline comments are updated to describe both eras. Path 2 behavior is unchanged; a new **ERA NOTE** documents that path 1 can contaminate stored values so a future `prodDigest` bump may fail path 2 on purpose (**client#459**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e582dcd62466f63ffb35958292ef0527e8a1180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->