### PR TITLE
ci(release): tag/chart-version guard + strict stability rule (release train)

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -13,8 +13,50 @@ env:
   HELM_EXPERIMENTAL_OCI: 0
 
 jobs:
+  # Gate for BOTH jobs below (Bugbot on #460: a guard living only inside
+  # `release` left sign-installer-manifest stamping and attaching installers
+  # for a bad release anyway).
+  verify:
+    name: Verify tag / chart version / stability
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # demote a mis-marked release to prerelease
+    steps:
+      - name: Checkout the released tag
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Verify tag matches chart version + stability rule
+        # Release-train guard (backend#1301): the tag's base X.Y.Z must equal
+        # client/Chart.yaml's version -- train-cut or manual -- so the chart
+        # version can never go silently stale after an out-of-train release
+        # (hard fail: that needs a chart bump, nothing to auto-fix). A
+        # non-final tag left marked stable would sit as GitHub 'latest' --
+        # exactly what the installer bootstrap resolves -- so it is DEMOTED
+        # to prerelease here (self-healing: 'latest' snaps back to the
+        # previous stable), then publishing continues as a proper
+        # pre-release. Tag passed via env, never interpolated into the
+        # script (R8, backend#889).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          BASE=$(printf '%s' "${TAG#v}" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || true)
+          CHART=$(grep -E '^version:' client/Chart.yaml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          if [ -z "$BASE" ] || [ "$BASE" != "$CHART" ]; then
+            echo "::error::release tag '$TAG' (base '${BASE:-none}') does not match client/Chart.yaml version ($CHART) - bump the chart version on develop first."
+            exit 1
+          fi
+          if ! printf '%s' "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' && [ "$IS_PRERELEASE" != "true" ]; then
+            echo "::warning::non-final tag '$TAG' was published as a STABLE release - demoting to prerelease so 'latest' (the installer bootstrap) snaps back to the previous stable."
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --prerelease
+          fi
+
   release:
     name: Package and publish tracebloc chart
+    needs: verify
     runs-on: ubuntu-latest
     permissions:
       contents: write   # push to gh-pages, create release and upload assets on tag
@@ -36,29 +78,6 @@ jobs:
         uses: azure/setup-helm@v4
         with:
           version: v3.15.4
-
-      - name: Verify tag matches chart version + stability rule
-        # Release-train guard (backend#1301): the tag's base X.Y.Z must equal
-        # client/Chart.yaml's version -- train-cut or manual -- so the chart
-        # version can never go silently stale after an out-of-train release.
-        # STRICT stability: only a plain vX.Y.Z release may be stable; an
-        # rc-ish tag left unmarked would become 'latest' (what the installer
-        # bootstrap resolves) and enter the helm index as stable. Tag passed
-        # via env, never interpolated into the script (R8, backend#889).
-        env:
-          TAG: ${{ github.event.release.tag_name }}
-          IS_PRERELEASE: ${{ github.event.release.prerelease }}
-        run: |
-          BASE=$(printf '%s' "${TAG#v}" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || true)
-          CHART=$(grep -E '^version:' client/Chart.yaml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-          if [ -z "$BASE" ] || [ "$BASE" != "$CHART" ]; then
-            echo "::error::release tag '$TAG' (base '${BASE:-none}') does not match client/Chart.yaml version ($CHART) - bump the chart version on develop first."
-            exit 1
-          fi
-          if ! printf '%s' "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' && [ "$IS_PRERELEASE" != "true" ]; then
-            echo "::error::non-final tag '$TAG' must be marked PRE-release - it would otherwise become 'latest' and enter the helm index as stable."
-            exit 1
-          fi
 
       - name: Lint charts
         # The parent `client` chart needs a CI values file so `--strict` sees
@@ -181,6 +200,7 @@ jobs:
   # ───────────────────────────────────────────────────────────────────────────
   sign-installer-manifest:
     name: Sign installer manifest (R8)
+    needs: verify
     runs-on: ubuntu-latest
     permissions:
       contents: write   # attach assets to the release

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -37,6 +37,29 @@ jobs:
         with:
           version: v3.15.4
 
+      - name: Verify tag matches chart version + stability rule
+        # Release-train guard (backend#1301): the tag's base X.Y.Z must equal
+        # client/Chart.yaml's version -- train-cut or manual -- so the chart
+        # version can never go silently stale after an out-of-train release.
+        # STRICT stability: only a plain vX.Y.Z release may be stable; an
+        # rc-ish tag left unmarked would become 'latest' (what the installer
+        # bootstrap resolves) and enter the helm index as stable. Tag passed
+        # via env, never interpolated into the script (R8, backend#889).
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          BASE=$(printf '%s' "${TAG#v}" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || true)
+          CHART=$(grep -E '^version:' client/Chart.yaml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          if [ -z "$BASE" ] || [ "$BASE" != "$CHART" ]; then
+            echo "::error::release tag '$TAG' (base '${BASE:-none}') does not match client/Chart.yaml version ($CHART) - bump the chart version on develop first."
+            exit 1
+          fi
+          if ! printf '%s' "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' && [ "$IS_PRERELEASE" != "true" ]; then
+            echo "::error::non-final tag '$TAG' must be marked PRE-release - it would otherwise become 'latest' and enter the helm index as stable."
+            exit 1
+          fi
+
       - name: Lint charts
         # The parent `client` chart needs a CI values file so `--strict` sees
         # non-empty clientId / clientPassword (the defaults in values.yaml are

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -45,13 +45,17 @@ jobs:
         run: |
           BASE=$(printf '%s' "${TAG#v}" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || true)
           CHART=$(grep -E '^version:' client/Chart.yaml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-          if [ -z "$BASE" ] || [ "$BASE" != "$CHART" ]; then
-            echo "::error::release tag '$TAG' (base '${BASE:-none}') does not match client/Chart.yaml version ($CHART) - bump the chart version on develop first."
-            exit 1
-          fi
+          # Demote FIRST, hard-fail second: a release that is BOTH mis-marked
+          # stable and version-mismatched must still lose 'latest' before the
+          # exit 1 below strands it (Bugbot: demotion-after-fail left a stable
+          # husk as 'latest' with a 404ing bootstrap behind it).
           if ! printf '%s' "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' && [ "$IS_PRERELEASE" != "true" ]; then
             echo "::warning::non-final tag '$TAG' was published as a STABLE release - demoting to prerelease so 'latest' (the installer bootstrap) snaps back to the previous stable."
             gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --prerelease
+          fi
+          if [ -z "$BASE" ] || [ "$BASE" != "$CHART" ]; then
+            echo "::error::release tag '$TAG' (base '${BASE:-none}') does not match client/Chart.yaml version ($CHART) - bump the chart version on develop first."
+            exit 1
           fi
 
   release:


### PR DESCRIPTION
## What (backend#1301, Q5 — approved by Lukas)

Two guards in `release-helm-chart.yaml`, running before lint/package on every published release:

1. **tag ↔ chart version**: the tag's base `X.Y.Z` must equal `client/Chart.yaml`'s `version` — train-cut *or manual* — so the chart version can never go silently stale after an out-of-train release.
2. **Strict stability**: any non-plain-semver tag (e.g. `v1.9.7-rc.1`, or a malformed `v1.9.7rc1`) must be marked **pre-release** — otherwise it would become `latest` (what the installer bootstrap resolves) and enter the helm index as stable.

Tag reaches the script via env, never interpolated (R8, backend#889).

## Context

client is joining the release train: staging hop → train creates pre-release `v1.X.Y-rc.N` (rc numbering strictly numeric) → FR from the rc's own stamped installer; prod hop → stable `v1.X.Y`. The stamped-installer flow needs **zero changes** — the fail-closed guard is placeholder-based, so rc-stamped installers verify at their own tag as-is. Helm-side safety: `helm install` excludes pre-release chart versions unless `--devel`/explicit `--version`.

## Test plan

- actionlint clean
- First rc after merge+App-install: verify the guard passes, the release is marked pre-release, `releases/latest` still points at the last stable, and `helm search repo tracebloc -l --devel` shows the rc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and can edit GitHub release metadata (prerelease demotion) and block publishing on mismatch; it does not alter runtime app code but affects what becomes `latest` and what ships on publish.
> 
> **Overview**
> Adds a **`verify` job** that runs before Helm packaging and installer manifest signing on every published release, so bad releases no longer get charts or stamped installers attached.
> 
> The guard compares the release tag’s base **X.Y.Z** to **`client/Chart.yaml`** `version` and **fails the workflow** if they differ (chart must be bumped first). For tags that are not plain **`vX.Y.Z`** but were published as stable, it **demotes the GitHub release to prerelease** first so **`latest`** (installer bootstrap) does not point at an RC or malformed tag; demotion runs before the version check so a doubly-broken release still loses **`latest`**. The tag is passed only via **env**, not shell interpolation.
> 
> **`release`** and **`sign-installer-manifest`** now **`needs: verify`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1349746c1c19323f8fa017024440b5eda138202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->