### PR TITLE
chore(release): bump chart to 1.9.7

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.6
-appVersion: "1.9.6"
+version: 1.9.7
+appVersion: "1.9.7"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
Declares the next release so the train can create pre-release `v1.9.7-rc.N` on the staging hop — the first FR-able artifact for the Windows installer sweep (#437–#447, #377) — and stable `v1.9.7` on the prod hop. version + appVersion bumped in lockstep per existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file metadata bump with no behavioral or deployment logic changes.
> 
> **Overview**
> Bumps **`client/Chart.yaml`** **`version`** and **`appVersion`** from **1.9.6** to **1.9.7** in lockstep so the release train can cut **`v1.9.7-rc.N`** on staging and stable **`v1.9.7`** on prod.
> 
> No chart templates, values, or application code change in this diff—only the declared chart release identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7a5c7fd7aad4bc65d2ae1a679835f07a7cc92f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->