### PR TITLE
ci: code-quality caller (advisory)

### DIFF
--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -1,0 +1,21 @@
+name: Code quality
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+# Supersede the previous run when a branch is pushed again. Measured:
+# workflows missing this stack ~10-minute duplicate runs per push.
+concurrency:
+  group: code-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    uses: tracebloc/.github/.github/workflows/code-quality.yml@main
+    with:
+      shell: true           # repos with shell scripts
+      # soft-fail: false    # flip once the backlog is clear


### PR DESCRIPTION
Adds the org's reusable code-quality workflow as an advisory caller: shellcheck, gitleaks, and house-rules run on every PR with `soft-fail` at its default (`true`) — findings land as diff annotations and in the job summary, and nothing blocks. Flipping the jobs to required checks once the backlog is clear is tracked separately in tracebloc/backend#1303.

Part of tracebloc/backend#1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow wiring only; no runtime, auth, or data-path changes, and checks are advisory until soft-fail is disabled.
> 
> **Overview**
> Adds **`.github/workflows/code-quality-caller.yml`** so every pull request runs the org reusable **code-quality** workflow (shellcheck, gitleaks, house-rules) in **advisory** mode via the default soft-fail behavior.
> 
> The caller triggers on PR **opened**, **reopened**, **synchronize**, and **ready_for_review**, sets **`contents: read`**, and uses a **concurrency** group with **`cancel-in-progress: true`** to drop superseded runs on new pushes. It invokes **`tracebloc/.github/.github/workflows/code-quality.yml@main`** with **`shell: true`**; a commented **`soft-fail: false`** line documents flipping to blocking checks later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01cec07c6f398eef1825b42249bdff16ce6c6e16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->