### PR TITLE
docs: add Bugbot resolve-and-reply team norm to .cursor/BUGBOT.md

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -120,3 +120,11 @@ operator-visible consequence (what they see, what breaks, at which step).
 
 This repo is **public** — never put a customer name, internal hostname, or internal-only
 ticket detail in a finding. A bare `tracebloc/backend#NNNN` reference is fine.
+
+## Working with Bugbot findings (team norm)
+
+Every Bugbot review thread gets a reply, then gets resolved:
+- **Fixed**: say what changed and in which commit.
+- **False positive**: say why, with evidence (file/line, measured behavior).
+Unresolved cursor threads HOLD release-train promotions (soft gate) — an
+unaddressed finding blocks the fleet, not just this PR.


### PR DESCRIPTION
Appends the team norm for Bugbot findings to `.cursor/BUGBOT.md`: every review thread gets a reply (fixed, or false positive with evidence), then gets resolved.
Unresolved cursor threads hold release-train promotions (soft gate), so the norm now lives next to the Bugbot guide itself.

Part of tracebloc/backend#1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `.cursor/BUGBOT.md` with no runtime, CI, or chart behavior impact.
> 
> **Overview**
> Adds a **Working with Bugbot findings (team norm)** section to `.cursor/BUGBOT.md` so the process lives next to the Bugbot reviewer guide.
> 
> The norm requires every Bugbot thread to get a reply (**Fixed** with commit, or **False positive** with evidence) and then be resolved. It also documents that unresolved Cursor threads are a soft gate on release-train promotions—unaddressed findings can block fleet promotion, not only the current PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c01af8883f18cd5c864c11dac660d5a94a4ab718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->