### PR TITLE
Add pre-commit hooks (Layer 0, lint-only)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# File used for configuring project pre-commit hooks.
+# Layer 0: an optional local lint guard — CI remains the enforcement layer
+# (standard-checks / installer-tests).
+#
+# LINT-ONLY BY DESIGN: scripts/manifest.sha256 must always match the bytes
+# under scripts/ (see scripts/gen-manifest.sh), so no hook in this file may
+# rewrite a file. Do not add formatters/fixers (end-of-file-fixer, shfmt, ...).
+repos:
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.11.0.1
+  hooks:
+  - id: shellcheck
+    # Same gate as CI: error severity, bash dialect, installer scripts only.
+    args: [--severity=error, --shell=bash]
+    files: ^scripts/.*\.sh$
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.1.0
+  hooks:
+  - id: check-json
+  - id: check-yaml
+    # Helm templates are Go-templated — not parseable as plain YAML.
+    exclude: ^(client|ingestor)/templates/

--- a/README.md
+++ b/README.md
@@ -139,3 +139,9 @@ Platform-specific walkthroughs: [Linux](https://docs.tracebloc.io/environment-se
 Apache 2.0 — see [LICENSE](LICENSE).
 
 **Deployment help?** [support@tracebloc.io](mailto:support@tracebloc.io) or [open an issue](https://github.com/tracebloc/client/issues).
+
+## Pre-commit
+
+Optional but recommended: `pip install pre-commit && pre-commit install` sets up the git hooks from [`.pre-commit-config.yaml`](.pre-commit-config.yaml).
+The hooks run automatically on each commit and are lint-only (ShellCheck at the same error-severity gate as CI) — nothing rewrites files, so `scripts/manifest.sha256` always stays true to `scripts/`.
+They are a fast local guard — CI remains the guarantee.


### PR DESCRIPTION
## What

Adds `.pre-commit-config.yaml` — Layer 0, an optional local lint guard — and appends a short Pre-commit section to `README.md`.

Hooks (revs pinned to tags):

- `shellcheck` @ shellcheck-py `v0.11.0.1`, `--severity=error --shell=bash`, scoped to `^scripts/.*\.sh$` — the same gate the CI Lint / installer-tests jobs run. Verified locally with ShellCheck 0.11.0: every `scripts/**/*.sh` passes at error severity (including `scripts/resolve-ingestor-digest.sh`, which the CI file list currently misses).
- `check-json`, `check-yaml` @ pre-commit-hooks `v4.1.0`, with `client/templates/` and `ingestor/templates/` excluded from `check-yaml` (Go-templated Helm manifests are not plain YAML).

## Why

One consistent Layer 0 across the org: catch lint at commit time instead of in review. Installing the hooks is opt-in (`pre-commit install`); CI is unchanged and remains the guarantee (Layer 1).

## Notes

- **Lint-only by design — no formatters/fixers.** `scripts/manifest.sha256` must always match the bytes under `scripts/` (see `scripts/gen-manifest.sh`), so hooks that modify files (`end-of-file-fixer` and friends, included in the Python-repo rollout) are deliberately left out here, and the config header says so. Nothing under `scripts/` is touched by this PR.
- backend's `gitlint` hook was deliberately not carried over: it runs at the commit-msg stage, which a plain `pre-commit install` does not install, so it would be dead config.

Part of tracebloc/backend#1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer workflow and documentation only; no runtime, deployment, or security behavior changes.
> 
> **Overview**
> Adds **optional Layer 0** local git hooks via a new `.pre-commit-config.yaml`, plus a short **Pre-commit** section in `README.md` (`pip install pre-commit && pre-commit install`).
> 
> Hooks are **lint-only** (no formatters/fixers) so nothing rewrites files under `scripts/` and `scripts/manifest.sha256` stays aligned with committed bytes. **ShellCheck** runs at `--severity=error` / `--shell=bash` on `scripts/**/*.sh`, matching the CI gate; **check-json** and **check-yaml** run repo-wide, with `client/templates/` and `ingestor/templates/` excluded from YAML parsing because Helm templates are Go-templated.
> 
> CI enforcement is unchanged — hooks are a fast local guard only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b006fcef8c8f80f949c3882b5882d9221bed3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->