### PR TITLE
ci: cover scripts/resolve-ingestor-digest.sh in CI shellcheck

### DIFF
--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -66,11 +66,11 @@ jobs:
           # common.sh and consumed in other sourced files. Warnings are printed
           # below for visibility but don't fail the gate.
           shellcheck --severity=error --shell=bash \
-            scripts/install.sh scripts/install-k8s.sh scripts/gen-manifest.sh scripts/check-style.sh scripts/lib/*.sh \
+            scripts/install.sh scripts/install-k8s.sh scripts/gen-manifest.sh scripts/check-style.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
             scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/path-persist.sh
           echo "── shellcheck warnings (advisory, non-blocking) ──"
           shellcheck --severity=warning --shell=bash \
-            scripts/install.sh scripts/install-k8s.sh scripts/gen-manifest.sh scripts/check-style.sh scripts/lib/*.sh \
+            scripts/install.sh scripts/install-k8s.sh scripts/gen-manifest.sh scripts/check-style.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
             scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/path-persist.sh || true
 
       - name: Installer manifest is current (supply-chain, R8)

--- a/.github/workflows/standard-checks.yml
+++ b/.github/workflows/standard-checks.yml
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
           shellcheck --version | grep version
           shellcheck --severity=error --shell=bash \
-            scripts/install.sh scripts/install-k8s.sh scripts/lib/*.sh \
+            scripts/install.sh scripts/install-k8s.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
             scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh scripts/tests/e2e-auto-upgrade.sh
 
   unit-tests:


### PR DESCRIPTION
Both CI shellcheck invocations (`standard-checks.yml` Lint job + `installer-tests.yaml`'s error gate and advisory warning pass) enumerate script files explicitly, and **both omitted `scripts/resolve-ingestor-digest.sh`** — it was never linted in CI. Added to all three command lines.

No-risk: the file passes `shellcheck --severity=error --shell=bash` (0.11.0) today. The pre-commit hook from #465 already covers it locally (`^scripts/.*\.sh$`); this closes the same gap CI-side. No files under `scripts/` touched — no manifest impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow edits; no runtime or installer behavior changes.
> 
> **Overview**
> Adds **`scripts/resolve-ingestor-digest.sh`** to the explicit ShellCheck file lists in **`standard-checks.yml`** (Lint job) and **`installer-tests.yaml`** (error gate and advisory warning pass), so CI linting matches other installer entrypoints.
> 
> No changes under `scripts/` — only workflow wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a5c5201bf391d600454a4268d3411ca54d5251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->