### PR TITLE
feat(chart): perIngestionTables — RFC-0003 D16 enablement knob (backend#1205)

### DIFF
--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -99,6 +99,14 @@ spec:
           value: {{ include "tracebloc.clientLogsPvc" . | quote }}
         - name: MYSQL_HOST
           value: "mysql-client"
+        {{- if .Values.perIngestionTables }}
+        # RFC-0003 D16 (backend#1204 / backend#1205): forwarded by
+        # jobs-manager into every ingestion Job it spawns — the ingestor
+        # then writes one immutable ds_<uuid4 hex> table per run. Rendered
+        # only when enabled so default installs stay byte-identical.
+        - name: PER_INGESTION_TABLES
+          value: "1"
+        {{- end }}
         # Ingestor image wiring for the POST /internal/submit-ingestion-run
         # endpoint. jobs-manager spawns each ingestion Job from these values
         # (see client-runtime submit_ingestion_run._build_image_reference):

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -326,3 +326,21 @@ tests:
             value: "cpu=4,memory=16Gi"
           count: 1
 
+
+  - it: does not render PER_INGESTION_TABLES by default (RFC-0003 D16 knob off)
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PER_INGESTION_TABLES
+            value: "1"
+
+  - it: renders PER_INGESTION_TABLES=1 when perIngestionTables is enabled
+    set:
+      perIngestionTables: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PER_INGESTION_TABLES
+            value: "1"

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -326,7 +326,6 @@ tests:
             value: "cpu=4,memory=16Gi"
           count: 1
 
-
   - it: does not render PER_INGESTION_TABLES by default (RFC-0003 D16 knob off)
     asserts:
       - notContains:

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -287,6 +287,10 @@
         }
       }
     },
+    "perIngestionTables": {
+      "type": "boolean",
+      "description": "RFC-0003 D16 (backend#1204/#1205): stamp PER_INGESTION_TABLES=1 into every ingestion Job. Flip per environment, dev first; file-bearing categories are refused under the flag until client-runtime#203 phase 2."
+    },
     "ingestionAuthz": {
       "type": "object",
       "description": "Authorization policy for POST /internal/submit-ingestion-run on jobs-manager (client-runtime#21). Rendered into the ingestion-authz ConfigMap.",

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -748,6 +748,24 @@ imageRefresh:
       memory: "128Mi"
 
 # ============================================================
+# Per-ingestion dataset tables (RFC-0003 D16 — backend#1204 / backend#1205)
+# ============================================================
+# When true, jobs-manager stamps PER_INGESTION_TABLES=1 into every ingestion
+# Job it spawns: each ingest run then writes its own IMMUTABLE physical table
+# ds_<uuid4 hex> (append disabled) and reports the handle to the backend,
+# which resolves it into the experiment payload (data_info.tables) for the
+# training read path and for per-experiment grant scoping.
+#
+# FLIP PER ENVIRONMENT, dev first — and only once that environment's
+# backend, engine images, and jobs-manager all carry the D-series (merged to
+# develop 2026-07-29). An edge flipped early ingests datasets its training
+# path cannot locate. File-bearing categories (images/text) are refused
+# under the flag until the per-dataset mount work (client-runtime#203
+# phase 2) — row-only categories (tabular / time-series) are the v1 target.
+# Default false: legacy shared label-named tables, byte-for-byte.
+perIngestionTables: false
+
+# ============================================================
 # Ingestion endpoint authorization (client-runtime#21)
 # ============================================================
 # jobs-manager's POST /internal/submit-ingestion-run authenticates callers
@@ -764,22 +782,6 @@ imageRefresh:
 #       - service_account: my-dataset-ingestor
 #         namespace: tracebloc
 #         table_prefixes: ["chest_xrays_", "tumors_"]
-# -- RFC-0003 D16: per-ingestion dataset tables (backend#1204 / backend#1205).
-# When true, jobs-manager stamps PER_INGESTION_TABLES=1 into every ingestion
-# Job it spawns: each ingest run then writes its own IMMUTABLE physical table
-# ds_<uuid4 hex> (append disabled) and reports the handle to the backend,
-# which resolves it into the experiment payload (data_info.tables) for the
-# training read path and for per-experiment grant scoping.
-#
-# FLIP PER ENVIRONMENT, dev first — and only once that environment's
-# backend, engine images, and jobs-manager all carry the D-series (merged to
-# develop 2026-07-29). An edge flipped early ingests datasets its training
-# path cannot locate. File-bearing categories (images/text) are refused
-# under the flag until the per-dataset mount work (client-runtime#203
-# phase 2) — row-only categories (tabular / time-series) are the v1 target.
-# Default false: legacy shared label-named tables, byte-for-byte.
-perIngestionTables: false
-
 ingestionAuthz:
   # -- Name of the shared ServiceAccount this chart creates for ingestor
   # subchart releases (client#129). Single source of truth: the SA

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -764,6 +764,22 @@ imageRefresh:
 #       - service_account: my-dataset-ingestor
 #         namespace: tracebloc
 #         table_prefixes: ["chest_xrays_", "tumors_"]
+# -- RFC-0003 D16: per-ingestion dataset tables (backend#1204 / backend#1205).
+# When true, jobs-manager stamps PER_INGESTION_TABLES=1 into every ingestion
+# Job it spawns: each ingest run then writes its own IMMUTABLE physical table
+# ds_<uuid4 hex> (append disabled) and reports the handle to the backend,
+# which resolves it into the experiment payload (data_info.tables) for the
+# training read path and for per-experiment grant scoping.
+#
+# FLIP PER ENVIRONMENT, dev first — and only once that environment's
+# backend, engine images, and jobs-manager all carry the D-series (merged to
+# develop 2026-07-29). An edge flipped early ingests datasets its training
+# path cannot locate. File-bearing categories (images/text) are refused
+# under the flag until the per-dataset mount work (client-runtime#203
+# phase 2) — row-only categories (tabular / time-series) are the v1 target.
+# Default false: legacy shared label-named tables, byte-for-byte.
+perIngestionTables: false
+
 ingestionAuthz:
   # -- Name of the shared ServiceAccount this chart creates for ingestor
   # subchart releases (client#129). Single source of truth: the SA


### PR DESCRIPTION
## Summary

The **enablement knob** for RFC-0003 D16 per-ingestion tables — the one wire the merged D-series (tracebloc/data-ingestors#408 → tracebloc/backend#1300 → tracebloc/tracebloc-engine#543 → cli#424 + tracebloc/client-runtime#222) was still missing: nothing ever set `PER_INGESTION_TABLES` on an ingestion Job.

- `values.perIngestionTables` (**default `false`**, schema-typed, heavily documented in values.yaml): renders `PER_INGESTION_TABLES="1"` onto the jobs-manager api container; the jobs-manager forwards it into every ingestion Job it spawns (companion: tracebloc/client-runtime#225).
- Conditional block — **default installs render byte-identically** (helm-unittest pins both sides: absent by default, `"1"` when set; 298/298 green).

## Enablement sequence (dev first)

1. Merge this + the client-runtime companion; let dev images/deploys roll (dev pulls floating tags).
2. Flip `perIngestionTables: true` on the **dev** fleet values, `helm upgrade`.
3. Validate end-to-end with the ready-made tabular sample dataset: `tb data ingest` → confirm the summary carries the handle and the backend row has `physical_table` set → run a tabular training experiment (e2e harness) → confirm `data_info.tables` reaches the pod and training reads `ds_<hex>` → `tb data delete` → confirm table + salt + journal rows are gone and the dataset tombstones.
4. Staging → prod per fleet, same checklist. File-bearing categories stay refused under the flag until client-runtime#203 phase 2.

Epic: tracebloc/backend#1151 · Design: tracebloc/backend#1204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in feature flag with default false and unittest guards; no behavior change until operators flip the value per environment.
> 
> **Overview**
> Adds an **opt-in Helm value** `perIngestionTables` (default **`false`**) to turn on RFC-0003 D16 per-ingestion physical tables. When set to `true`, the jobs-manager **api** container gets `PER_INGESTION_TABLES=1`, which jobs-manager is expected to forward into spawned ingestion Jobs so ingestors write immutable `ds_<hex>` tables instead of legacy shared label-named tables.
> 
> The env block is **conditional** so default installs stay unchanged. `values.yaml`, `values.schema.json`, and helm-unittest cases lock in absent-by-default vs `PER_INGESTION_TABLES=1` when enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0362930608b39e86ddcac38669984f5cd3b4ee60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->