### PR TITLE
chore(release): bump chart to 1.9.8

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.7
-appVersion: "1.9.7"
+version: 1.9.8
+appVersion: "1.9.8"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
Next-cycle bump after v1.9.7 shipped to prod. The staging wave that just landed (#480) couldn't cut an rc — 1.9.7 is already final — so the next dev→staging hop cuts v1.9.8-rc.1 once this merges. Rides with #481 (rootless header fix) and whatever else lands on develop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime, security, or deployment template changes.
> 
> **Overview**
> Bumps the unified `client` Helm chart release metadata from **1.9.7** to **1.9.8** by updating both `version` and `appVersion` in `Chart.yaml`.
> 
> This is a release-cycle version bump so the next develop→staging hop can tag **v1.9.8-rc.1** after merge; no chart templates, values, or application code are modified in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ff10cf137bc9312b73e7a6e4ff848a2079c7f72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->