### PR TITLE
ci: arm the code-quality gate (soft-fail off) + all-files dispatch

### DIFF
--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -3,6 +3,14 @@ name: Code quality
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+  # Manual whole-tree scan (gitleaks baseline etc.) -- runs every enabled
+  # job in all-files mode instead of a PR diff.
+  workflow_dispatch:
+    inputs:
+      all-files:
+        description: "Scan the whole repo, not a diff"
+        type: boolean
+        default: true
 
 # Supersede the previous run when a branch is pushed again. Measured:
 # workflows missing this stack ~10-minute duplicate runs per push.
@@ -18,4 +26,7 @@ jobs:
     uses: tracebloc/.github/.github/workflows/code-quality.yml@main
     with:
       shell: true           # repos with shell scripts
-      # soft-fail: false    # flip once the backlog is clear
+      # The gate is armed: findings fail the job. Backlog cleared to zero
+      # fleet-wide + advisory soak done (backend#1303).
+      soft-fail: false
+      all-files: ${{ inputs.all-files || false }}


### PR DESCRIPTION
The #1303 flip: `soft-fail: false` — from this merge on, ruff/shellcheck/gitleaks/house-rules findings **fail the check** (which is already marked required on develop). This repo's backlog is at zero, so only *new* findings can ever block. Also adds `workflow_dispatch(all-files)` for whole-tree scans (the gitleaks baseline run follows the merge).

This PR is its own proof-run: the armed configuration must pass on this very diff.

Part of tracebloc/backend#1303

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI enforcement only, but merges can now be blocked by new lint/security findings on a required check.
> 
> **Overview**
> **Arms the required code-quality check** by passing `soft-fail: false` into the shared `code-quality.yml` workflow, so ruff, shellcheck, gitleaks, and house-rules findings **fail the job** instead of advisory-only behavior (backend#1303).
> 
> Adds **`workflow_dispatch`** with an `all-files` boolean (default `true`) so maintainers can trigger a **full-repo scan** rather than a PR diff, and forwards `all-files: ${{ inputs.all-files || false }}` on normal PR runs (false when the input is absent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31fe64ce64da935283a1f826a0b762c4f7d25926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->