### PR TITLE
ci: guard — chart content change requires a Chart.yaml version bump

### DIFF
--- a/.github/workflows/chart-version-guard.yml
+++ b/.github/workflows/chart-version-guard.yml
@@ -1,0 +1,39 @@
+# Chart content can only reach installs via a NEW chart version — a Helm repo
+# publishes on version change, so an unbumped template/values edit reaches
+# nobody (this is exactly how the perIngestionTables flag block shipped to
+# staging but never rendered: PR #472 changed the template without bumping
+# Chart.yaml, so the published 1.9.7 stayed stale). This gate makes the bump
+# non-optional.
+name: Chart version guard
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  require-version-bump:
+    name: chart content ⇒ Chart.yaml version bump
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Require a Chart.yaml version bump when chart content changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          changed="$(git diff --name-only "${BASE_SHA}...HEAD")"
+          if ! printf '%s\n' "$changed" | grep -qE '^client/(templates/|values\.yaml)'; then
+            echo "No chart template/values change in this PR — guard N/A."
+            exit 0
+          fi
+          if printf '%s\n' "$changed" | grep -qxE 'client/Chart\.yaml' \
+             && git diff "${BASE_SHA}...HEAD" -- client/Chart.yaml | grep -qE '^\+version:'; then
+            echo "Chart content changed and client/Chart.yaml 'version:' was bumped. ✓"
+            exit 0
+          fi
+          echo "::error::client/templates/** or client/values.yaml changed, but client/Chart.yaml 'version:' was NOT bumped. A Helm chart repo publishes only on a version change, so an unbumped edit reaches no installs (this is how the perIngestionTables flag block shipped dark — PR #472). Bump client/Chart.yaml version in this PR."
+          exit 1


### PR DESCRIPTION
Prevents the gap Divya's staging test surfaced: PR #472 changed `client/templates/jobs-manager-deployment.yaml` (the `perIngestionTables` env block) **without bumping `Chart.yaml`**, so the published `1.9.7` package stayed stale and the flag never rendered on installs — even though the source was correct and the helm-unittest passed (it renders the *source*, not the *published artifact*).

This blocking gate: any PR touching `client/templates/**` or `client/values.yaml` must also bump `client/Chart.yaml`'s `version:` line, else it fails. Non-chart PRs are unaffected (guard short-circuits to N/A).

After merge, add it to `develop`/`staging`/`main` required status checks (admin) so it actually blocks.

Sibling guard for the ingestor image (which had the analogous gap — #408 merged without a `__version__` bump, so no image was released): tracebloc/data-ingestors (next PR).

Epic: tracebloc/backend#1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guard with read-only repo permissions; no runtime or deployment behavior changes until the check is added to required status checks.
> 
> **Overview**
> Adds a **blocking PR workflow** so Helm chart edits cannot merge without a publishable version bump.
> 
> On every pull request, if the diff touches `client/templates/**` or `client/values.yaml`, the job requires `client/Chart.yaml` to include a new `+version:` line; otherwise it fails with an actionable error. PRs that only change non-chart paths exit successfully with “guard N/A.”
> 
> This closes the gap where template/values fixes could pass tests and land in git but never ship to installs because the chart repo only publishes when `version` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efa2b251a970a240dce8d3251019d3634dd6071b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->