### PR TITLE
feat(ingestor): resolve the spawned tag per environment (:dev / :stg)

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -143,11 +143,27 @@ jobs:
             echo "OK — $label is multi-arch (amd64 + arm64)."
           }
 
-          # The floating tag is the default spawn target — always validate it.
-          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
-            echo "::error::images.ingestor.tag is empty — the chart must define a floating tag to spawn by."; exit 1
+          # Every tag this chart can spawn by must be multi-arch. Since
+          # backend#1360 that is `tag` (an explicit override, empty by default)
+          # PLUS each per-environment entry in `channelTags` — an edge resolves
+          # exactly one of them, so a single-arch value in any of them breaks
+          # ingestion on arm64 for whichever environment lands on it.
+          checked=0
+          if [ -n "$tag" ] && [ "$tag" != "null" ]; then
+            assert_multiarch "${repo}:${tag}" "explicit tag override (images.ingestor.tag)"
+            checked=$((checked + 1))
           fi
-          assert_multiarch "${repo}:${tag}" "floating tag"
+          for env_key in dev stg prod; do
+            channel=$(yq ".images.ingestor.channelTags.${env_key}" client/values.yaml)
+            if [ -z "$channel" ] || [ "$channel" = "null" ]; then
+              continue
+            fi
+            assert_multiarch "${repo}:${channel}" "channelTags.${env_key}"
+            checked=$((checked + 1))
+          done
+          if [ "$checked" -eq 0 ]; then
+            echo "::error::no spawnable ingestor tag is defined — images.ingestor.tag is empty and channelTags has no entries, so an edge with no digest has nothing to spawn."; exit 1
+          fi
 
           # The prod pin is a chart DEFAULT that reaches every prod edge through
           # the fleet auto-upgrade, so a single-arch value here would break

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.8
-appVersion: "1.9.8"
+version: 1.9.9
+appVersion: "1.9.9"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -274,6 +274,40 @@ defeating the pin. Every read is nil-guarded for the same reason.
 
 Usage: {{ include "tracebloc.ingestorDigest" . }}
 */}}
+{{/*
+  Effective floating tag for spawned ingestion Jobs (backend#1360).
+
+  Precedence, mirroring tracebloc.ingestorDigest:
+    1. `images.ingestor.tag`          explicit override, any environment
+    2. `images.ingestor.channelTags[CLIENT_ENV]`   per-environment channel
+    3. "0.7"                          last-resort literal, so a release that
+                                      predates these keys still renders under
+                                      `--reuse-values`
+
+  Only consulted when no digest applies: jobs-manager builds `repo@digest`
+  when tracebloc.ingestorDigest is non-empty, and `repo:tag` otherwise
+  (client-runtime submit_ingestion_run._build_image_reference).
+
+  dev/stg resolve to the UNSIGNED internal channels. Prod is a semver float,
+  not a `:prod` tag — none is published.
+*/}}
+{{- define "tracebloc.ingestorTag" -}}
+{{- $ing := default dict .Values.images.ingestor -}}
+{{- $explicit := $ing.tag | default "" -}}
+{{- if $explicit -}}
+{{- $explicit -}}
+{{- else -}}
+{{- $clientEnv := (default dict .Values.env).CLIENT_ENV | default "prod" -}}
+{{- $channels := default dict $ing.channelTags -}}
+{{- $channel := get $channels $clientEnv | default "" -}}
+{{- if $channel -}}
+{{- $channel -}}
+{{- else -}}
+{{- "0.7" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
 {{- define "tracebloc.ingestorDigest" -}}
 {{- $ing := default dict .Values.images.ingestor -}}
 {{- $explicit := $ing.digest | default "" -}}

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -275,6 +275,28 @@ defeating the pin. Every read is nil-guarded for the same reason.
 Usage: {{ include "tracebloc.ingestorDigest" . }}
 */}}
 {{/*
+  Resolved CLIENT_ENV, with the documented aliases normalized to the
+  canonical dev|stg|prod keys.
+
+  ONE definition on purpose. Bugbot caught the first cut normalizing inside
+  tracebloc.ingestorTag only, so CLIENT_ENV=production selected the prod
+  float tag while tracebloc.ingestorDigest still compared the RAW value to
+  "prod" and returned nothing -- silently dropping the reproducibility pin
+  (backend#1028/#1245) on an edge that looked correctly configured. Any future
+  consumer of CLIENT_ENV must go through here rather than re-deriving it, the
+  same reason ENV_ALIASES lives once in client-runtime proxy_config.
+*/}}
+{{- define "tracebloc.clientEnv" -}}
+{{- $raw := (default dict .Values.env).CLIENT_ENV | default "prod" -}}
+{{- $aliases := dict "development" "dev" "staging" "stg" "production" "prod" -}}
+{{- if hasKey $aliases $raw -}}
+{{- get $aliases $raw -}}
+{{- else -}}
+{{- $raw -}}
+{{- end -}}
+{{- end }}
+
+{{/*
   Effective floating tag for spawned ingestion Jobs (backend#1360).
 
   Precedence, mirroring tracebloc.ingestorDigest:
@@ -297,21 +319,7 @@ Usage: {{ include "tracebloc.ingestorDigest" . }}
 {{- if $explicit -}}
 {{- $explicit -}}
 {{- else -}}
-{{- $clientEnv := (default dict .Values.env).CLIENT_ENV | default "prod" -}}
-{{/*
-  Normalize the documented aliases before the lookup. The chart docs and the
-  SDK say dev|staging|prod while these keys are dev|stg|prod, and
-  client-runtime normalizes the same three at runtime
-  (proxy_config.ENV_ALIASES). Without this, CLIENT_ENV=staging -- the value
-  the schema documents -- missed channelTags entirely and fell back to the
-  prod float: the service would talk to the stg backend while spawning the
-  release ingestor, which is precisely the split-brain client-runtime#227
-  was filed for. Review catch on client#494.
-*/}}
-{{- $aliases := dict "development" "dev" "staging" "stg" "production" "prod" -}}
-{{- if hasKey $aliases $clientEnv -}}
-{{- $clientEnv = get $aliases $clientEnv -}}
-{{- end -}}
+{{- $clientEnv := include "tracebloc.clientEnv" . -}}
 {{- $channels := default dict $ing.channelTags -}}
 {{- $channel := get $channels $clientEnv | default "" -}}
 {{- if $channel -}}
@@ -332,7 +340,7 @@ Usage: {{ include "tracebloc.ingestorDigest" . }}
 {{- if hasKey $ing "prodPin" -}}
 {{- $prodPin = $ing.prodPin -}}
 {{- end -}}
-{{- $clientEnv := (default dict .Values.env).CLIENT_ENV | default "prod" -}}
+{{- $clientEnv := include "tracebloc.clientEnv" . -}}
 {{- if and $prodPin (eq $clientEnv "prod") -}}
 {{- $ing.prodDigest | default "" -}}
 {{- end -}}

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -298,6 +298,20 @@ Usage: {{ include "tracebloc.ingestorDigest" . }}
 {{- $explicit -}}
 {{- else -}}
 {{- $clientEnv := (default dict .Values.env).CLIENT_ENV | default "prod" -}}
+{{/*
+  Normalize the documented aliases before the lookup. The chart docs and the
+  SDK say dev|staging|prod while these keys are dev|stg|prod, and
+  client-runtime normalizes the same three at runtime
+  (proxy_config.ENV_ALIASES). Without this, CLIENT_ENV=staging -- the value
+  the schema documents -- missed channelTags entirely and fell back to the
+  prod float: the service would talk to the stg backend while spawning the
+  release ingestor, which is precisely the split-brain client-runtime#227
+  was filed for. Review catch on client#494.
+*/}}
+{{- $aliases := dict "development" "dev" "staging" "stg" "production" "prod" -}}
+{{- if hasKey $aliases $clientEnv -}}
+{{- $clientEnv = get $aliases $clientEnv -}}
+{{- end -}}
 {{- $channels := default dict $ing.channelTags -}}
 {{- $channel := get $channels $clientEnv | default "" -}}
 {{- if $channel -}}

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -134,7 +134,7 @@ spec:
         - name: INGESTOR_IMAGE_REPOSITORY
           value: {{ (default dict .Values.images.ingestor).repository | default "ghcr.io/tracebloc/ingestor" | quote }}
         - name: INGESTOR_IMAGE_TAG
-          value: {{ (default dict .Values.images.ingestor).tag | default "0.7" | quote }}
+          value: {{ include "tracebloc.ingestorTag" . | quote }}
         - name: INGESTOR_IMAGE_DIGEST
           value: {{ include "tracebloc.ingestorDigest" . | quote }}
         - name: REQUESTS_PROXY_URL

--- a/client/tests/ingestor_channel_tag_test.yaml
+++ b/client/tests/ingestor_channel_tag_test.yaml
@@ -97,3 +97,37 @@ tests:
           content:
             name: INGESTOR_IMAGE_DIGEST
             value: ""
+
+  - it: the documented alias "staging" resolves to the stg channel, not the prod float
+    # Review catch (#494): the schema documents dev|staging|prod while these
+    # keys are dev|stg|prod, so CLIENT_ENV=staging previously missed
+    # channelTags and silently fell back to 0.7 while client-runtime
+    # normalized it to stg at runtime — the split-brain of client-runtime#227.
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "stg"
+
+  - it: the documented alias "development" resolves to the dev channel
+    set:
+      env.CLIENT_ENV: development
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "dev"
+
+  - it: the documented alias "production" resolves to the prod float
+    set:
+      env.CLIENT_ENV: production
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "0.7"

--- a/client/tests/ingestor_channel_tag_test.yaml
+++ b/client/tests/ingestor_channel_tag_test.yaml
@@ -1,0 +1,99 @@
+suite: ingestor per-environment channel tag (backend#1360)
+templates:
+  - templates/jobs-manager-deployment.yaml
+release:
+  name: stg
+  namespace: tracebloc
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: dev edges spawn the :dev internal channel
+    set:
+      env.CLIENT_ENV: dev
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "dev"
+
+  - it: staging edges spawn the :stg internal channel
+    set:
+      env.CLIENT_ENV: stg
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "stg"
+
+  - it: prod stays on the semver float, never a :prod tag (none is published)
+    set:
+      env.CLIENT_ENV: prod
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "0.7"
+
+  - it: defaults to the prod float when CLIENT_ENV is unset
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "0.7"
+
+  - it: an explicit tag override wins over the channel for every environment
+    set:
+      env.CLIENT_ENV: dev
+      images.ingestor.tag: "0.8.0"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "0.8.0"
+
+  - it: an unknown CLIENT_ENV falls back to the literal rather than rendering empty
+    set:
+      env.CLIENT_ENV: produktion
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "0.7"
+
+  - it: renders for a release predating channelTags (--reuse-values replay)
+    set:
+      env.CLIENT_ENV: dev
+      images.ingestor.channelTags: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "0.7"
+
+  - it: prod still pins by digest, so the tag is not the spawn target there
+    set:
+      env.CLIENT_ENV: prod
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_DIGEST
+            value: "sha256:9098b3c9b83951f825e262d6ff1e9c47c46c5b5cafbfc8fef1ed82ccbadebb24"
+
+  - it: dev gets no digest, so it spawns by the floating channel tag
+    set:
+      env.CLIENT_ENV: dev
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_DIGEST
+            value: ""

--- a/client/tests/ingestor_channel_tag_test.yaml
+++ b/client/tests/ingestor_channel_tag_test.yaml
@@ -131,3 +131,19 @@ tests:
           content:
             name: INGESTOR_IMAGE_TAG
             value: "0.7"
+
+  - it: the "production" alias keeps the prod reproducibility pin
+    # Bugbot catch (#494): the first alias fix normalized inside
+    # tracebloc.ingestorTag only, so CLIENT_ENV=production got the prod float
+    # tag while tracebloc.ingestorDigest still compared the RAW value to
+    # "prod" and returned nothing — silently dropping the pin
+    # (backend#1028/#1245) on an edge that looked correctly configured. Both
+    # helpers now share tracebloc.clientEnv.
+    set:
+      env.CLIENT_ENV: production
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_DIGEST
+            value: "sha256:9098b3c9b83951f825e262d6ff1e9c47c46c5b5cafbfc8fef1ed82ccbadebb24"

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -123,7 +123,11 @@ tests:
             name: INGESTOR_IMAGE_DIGEST
             value: "sha256:9098b3c9b83951f825e262d6ff1e9c47c46c5b5cafbfc8fef1ed82ccbadebb24"
 
-  - it: keeps the ingestor floating on dev (CLIENT_ENV=dev => no digest)
+  - it: keeps the ingestor floating on dev (CLIENT_ENV=dev => no digest, :dev channel)
+    # Since backend#1360 the dev float is the per-environment INTERNAL
+    # channel (:dev) rather than the 0.7 release float — the point of the
+    # change: a dev edge tracks develop, so an ingestor change can be
+    # validated on a real edge without a production release.
     # dev/staging carry env.CLIENT_ENV in their user-supplied values, so the prod
     # pin does not apply: DIGEST empty => client-runtime spawns repo:tag with
     # imagePullPolicy=Always and the edge is never frozen on a stale build.
@@ -140,7 +144,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: INGESTOR_IMAGE_TAG
-            value: "0.7"
+            value: "dev"
 
   - it: keeps the ingestor floating on staging (CLIENT_ENV=stg => no digest)
     set:

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -2,10 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Tracebloc Helm Chart Values",
   "type": "object",
-  "required": [
-    "clientId",
-    "clientPassword"
-  ],
+  "required": ["clientId", "clientPassword"],
   "properties": {
     "env": {
       "type": "object",
@@ -14,20 +11,12 @@
         "CLIENT_ENV": {
           "type": "string",
           "default": "prod",
-          "description": "Environment identifier and Docker image tag (dev, staging, prod). Defaults to 'prod' if not set or empty."
+          "description": "Environment identifier and Docker image tag. Canonical values are `dev`, `stg`, `prod`; the documented aliases `development`/`staging`/`production` are accepted and normalized (matching client-runtime proxy_config.ENV_ALIASES). Load-bearing: it selects images.ingestor.channelTags and the prod digest pin. Defaults to 'prod' if not set or empty."
         },
-        "HTTP_PROXY_HOST": {
-          "type": "string"
-        },
-        "HTTP_PROXY_PORT": {
-          "type": "string"
-        },
-        "HTTP_PROXY_USERNAME": {
-          "type": "string"
-        },
-        "HTTP_PROXY_PASSWORD": {
-          "type": "string"
-        },
+        "HTTP_PROXY_HOST": { "type": "string" },
+        "HTTP_PROXY_PORT": { "type": "string" },
+        "HTTP_PROXY_USERNAME": { "type": "string" },
+        "HTTP_PROXY_PASSWORD": { "type": "string" },
         "RESOURCE_REQUESTS": {
           "type": "string",
           "default": "cpu=2,memory=8Gi",
@@ -50,9 +39,7 @@
           "default": "nvidia.com/gpu=1",
           "description": "Optional GPU limits for spawned jobs (defaults to 'nvidia.com/gpu=1' if not set)"
         },
-        "RUNTIME_CLASS_NAME": {
-          "type": "string"
-        },
+        "RUNTIME_CLASS_NAME": { "type": "string" },
         "SINGLE_NODE": {
           "type": "string",
           "description": "Single-node (fixed, non-elastic) cluster flag. Gates jobs-manager's GPU->CPU pending-job fallback (client-runtime#92). 'true' -> downgrade a stuck Pending GPU pod to CPU (correct on fixed single-host clusters where GPU presence is known at install time); 'false' -> leave it for the autoscaler/backend (correct for EKS/AKS/OpenShift). If unset, defaults to hostPath.enabled."
@@ -64,10 +51,7 @@
     },
     "storageClass": {
       "type": "object",
-      "required": [
-        "create",
-        "name"
-      ],
+      "required": ["create", "name"],
       "properties": {
         "create": {
           "type": "boolean",
@@ -87,25 +71,15 @@
         },
         "volumeBindingMode": {
           "type": "string",
-          "enum": [
-            "",
-            "Immediate",
-            "WaitForFirstConsumer"
-          ]
+          "enum": ["", "Immediate", "WaitForFirstConsumer"]
         },
         "reclaimPolicy": {
           "type": "string",
-          "enum": [
-            "",
-            "Delete",
-            "Retain"
-          ]
+          "enum": ["", "Delete", "Retain"]
         },
         "mountOptions": {
           "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "items": { "type": "string" }
         },
         "parameters": {
           "type": "object",
@@ -153,11 +127,7 @@
     },
     "pvcAccessMode": {
       "type": "string",
-      "enum": [
-        "ReadWriteOnce",
-        "ReadWriteMany",
-        "ReadOnlyMany"
-      ],
+      "enum": ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"],
       "description": "Access mode for PVCs"
     },
     "clusterScope": {
@@ -176,9 +146,7 @@
       "properties": {
         "namespace": {
           "type": "object",
-          "required": [
-            "name"
-          ],
+          "required": ["name"],
           "properties": {
             "create": {
               "type": "boolean",
@@ -223,36 +191,21 @@
           "properties": {
             "warn": {
               "type": "string",
-              "enum": [
-                "",
-                "privileged",
-                "baseline",
-                "restricted"
-              ]
+              "enum": ["", "privileged", "baseline", "restricted"]
             },
             "warnVersion": {
               "type": "string"
             },
             "audit": {
               "type": "string",
-              "enum": [
-                "",
-                "privileged",
-                "baseline",
-                "restricted"
-              ]
+              "enum": ["", "privileged", "baseline", "restricted"]
             },
             "auditVersion": {
               "type": "string"
             },
             "enforce": {
               "type": "string",
-              "enum": [
-                "",
-                "privileged",
-                "baseline",
-                "restricted"
-              ]
+              "enum": ["", "privileged", "baseline", "restricted"]
             },
             "enforceVersion": {
               "type": "string"
@@ -276,11 +229,11 @@
             "allowExternalHttps": {
               "type": "boolean",
               "default": true,
-              "description": "When false, drop the 0.0.0.0/0:443 egress rule so training pods reach only DNS, MySQL, requests-proxy and the egress gateway (SECURITY \u00a78.2 / client-runtime#102). Default true keeps existing behaviour; flip per-fleet after verifying the egress gateway works (G2)."
+              "description": "When false, drop the 0.0.0.0/0:443 egress rule so training pods reach only DNS, MySQL, requests-proxy and the egress gateway (SECURITY §8.2 / client-runtime#102). Default true keeps existing behaviour; flip per-fleet after verifying the egress gateway works (G2)."
             },
             "enforcementProbeHost": {
               "type": "string",
-              "description": "Host the `helm test` enforcement check curls directly (when allowExternalHttps=false) to verify the CNI blocks egress; non-enforcement fails the test (a test hook never affects install/upgrade) \u2014 client-runtime#104. Empty string disables it (e.g. air-gapped clusters)."
+              "description": "Host the `helm test` enforcement check curls directly (when allowExternalHttps=false) to verify the CNI blocks egress; non-enforcement fails the test (a test hook never affects install/upgrade) — client-runtime#104. Empty string disables it (e.g. air-gapped clusters)."
             },
             "enforcementProbeTimeoutSeconds": {
               "type": "integer",
@@ -302,7 +255,7 @@
             },
             "clusterCidrs": {
               "type": "array",
-              "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs. Must be non-empty when networkPolicy.training.enabled is true \u2014 an empty list renders `except: null` and Kubernetes treats that as no exceptions, silently allowing unrestricted in-cluster egress.",
+              "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs. Must be non-empty when networkPolicy.training.enabled is true — an empty list renders `except: null` and Kubernetes treats that as no exceptions, silently allowing unrestricted in-cluster egress.",
               "items": {
                 "type": "string",
                 "pattern": "^[0-9.]+/[0-9]+$"
@@ -311,19 +264,13 @@
           },
           "if": {
             "properties": {
-              "enabled": {
-                "const": true
-              }
+              "enabled": { "const": true }
             },
-            "required": [
-              "enabled"
-            ]
+            "required": ["enabled"]
           },
           "then": {
             "properties": {
-              "clusterCidrs": {
-                "minItems": 1
-              }
+              "clusterCidrs": { "minItems": 1 }
             }
           }
         }
@@ -370,9 +317,7 @@
               },
               "table_prefixes": {
                 "type": "array",
-                "items": {
-                  "type": "string"
-                },
+                "items": { "type": "string" },
                 "description": "Table-name prefixes this SA may ingest into. [\"*\"] = any table."
               }
             }
@@ -393,11 +338,11 @@
     },
     "sealCheck": {
       "type": "object",
-      "description": "Seal check \u2014 the chart's conformance suite (RFC-0003 \u00a78.2 / backend#1184). Every check is a `helm test` hook Job labelled tracebloc.io/seal-check=true + tracebloc.io/seal-check-name=<check> (the enumeration contract the tracebloc CLI consumes, cli#393). See docs/SEAL-CHECK.md.",
+      "description": "Seal check — the chart's conformance suite (RFC-0003 §8.2 / backend#1184). Every check is a `helm test` hook Job labelled tracebloc.io/seal-check=true + tracebloc.io/seal-check-name=<check> (the enumeration contract the tracebloc CLI consumes, cli#393). See docs/SEAL-CHECK.md.",
       "properties": {
         "storageAssertions": {
           "type": "object",
-          "description": "In-cluster storage assertions: release PVCs Bound on the expected StorageClass; in dynamic-PVC mode (hostPath.enabled=false) no release PVC backed by a hostPath PV on an unmanaged host tree (leftover chart hostPath PVs capture claims via claimRef \u2014 RFC-0003 D3/D4).",
+          "description": "In-cluster storage assertions: release PVCs Bound on the expected StorageClass; in dynamic-PVC mode (hostPath.enabled=false) no release PVC backed by a hostPath PV on an unmanaged host tree (leftover chart hostPath PVs capture claims via claimRef — RFC-0003 D3/D4).",
           "properties": {
             "enabled": {
               "type": "boolean",
@@ -412,35 +357,16 @@
             },
             "nodeLocalPathPrefixes": {
               "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "hostPath prefixes accepted as provisioner-managed node-local storage in dynamic mode (k3s local-path: /var/lib/rancher/\u2026; upstream local-path-provisioner: /opt/local-path-provisioner/). Entries match whole path segments (trailing slash optional) \u2014 a prefix admits itself and paths under it, never sibling paths. Any other hostPath backing fails the check."
+              "items": { "type": "string" },
+              "description": "hostPath prefixes accepted as provisioner-managed node-local storage in dynamic mode (k3s local-path: /var/lib/rancher/…; upstream local-path-provisioner: /opt/local-path-provisioner/). Entries match whole path segments (trailing slash optional) — a prefix admits itself and paths under it, never sibling paths. Any other hostPath backing fails the check."
             },
             "image": {
               "type": "object",
               "description": "kubectl-capable image for the assertion pod (same image the image-refresh CronJob uses).",
               "properties": {
-                "repository": {
-                  "type": "string",
-                  "default": "alpine/k8s"
-                },
-                "tag": {
-                  "type": "string",
-                  "not": {
-                    "const": "latest"
-                  },
-                  "default": "1.30.5"
-                },
-                "pullPolicy": {
-                  "type": "string",
-                  "enum": [
-                    "Always",
-                    "IfNotPresent",
-                    "Never"
-                  ],
-                  "default": "IfNotPresent"
-                }
+                "repository": { "type": "string", "default": "alpine/k8s" },
+                "tag": { "type": "string", "not": { "const": "latest" }, "default": "1.30.5" },
+                "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
               }
             }
           }
@@ -449,56 +375,25 @@
     },
     "egressProxy": {
       "type": "object",
-      "description": "In-cluster squid egress gateway (SECURITY \u00a78.2 / client-runtime#102). Forward proxy that permits HTTPS CONNECT only to the allowlist, so a locked-down training pod can reach the backend + App Insights and nothing else.",
+      "description": "In-cluster squid egress gateway (SECURITY §8.2 / client-runtime#102). Forward proxy that permits HTTPS CONNECT only to the allowlist, so a locked-down training pod can reach the backend + App Insights and nothing else.",
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "default": true
-        },
-        "routeWorkloads": {
-          "type": "boolean",
-          "default": false,
-          "description": "Route training-pod outbound HTTPS through the gateway (jobs-manager injects HTTPS_PROXY). Default false \u2014 enable per-fleet, verify a run, then drop the direct egress rule (networkPolicy.training.allowExternalHttps=false)."
-        },
-        "port": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 65535,
-          "default": 3128
-        },
-        "runAsUser": {
-          "type": "integer",
-          "minimum": 1
-        },
+        "enabled": { "type": "boolean", "default": true },
+        "routeWorkloads": { "type": "boolean", "default": false, "description": "Route training-pod outbound HTTPS through the gateway (jobs-manager injects HTTPS_PROXY). Default false — enable per-fleet, verify a run, then drop the direct egress rule (networkPolicy.training.allowExternalHttps=false)." },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 3128 },
+        "runAsUser": { "type": "integer", "minimum": 1 },
         "image": {
           "type": "object",
           "properties": {
-            "registry": {
-              "type": "string"
-            },
-            "repository": {
-              "type": "string",
-              "minLength": 1
-            },
-            "tag": {
-              "type": "string",
-              "not": {
-                "const": "latest"
-              }
-            },
-            "digest": {
-              "type": "string",
-              "pattern": "^(sha256:[a-f0-9]{64})?$"
-            }
+            "registry": { "type": "string" },
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string", "not": { "const": "latest" } },
+            "digest": { "type": "string", "pattern": "^(sha256:[a-f0-9]{64})?$" }
           }
         },
         "allowlist": {
           "type": "array",
           "description": "FQDNs the gateway permits HTTPS CONNECT to (squid dstdomain syntax: leading dot = subdomain match, bare host = exact).",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
+          "items": { "type": "string", "minLength": 1 }
         },
         "resources": {
           "type": "object",
@@ -506,27 +401,15 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             }
           }
@@ -576,7 +459,7 @@
         },
         "ingestor": {
           "type": "object",
-          "description": "Image used for spawned ingestion Jobs. jobs-manager resolves one effective digest from these keys (see the tracebloc.ingestorDigest helper) and builds the reference from it (client-runtime submit_ingestion_run): digest set -> repo@digest + IfNotPresent, digest empty -> repo:tag + Always. Prod pins `prodDigest` (a chart default, so a republished pin propagates through the fleet auto-upgrade \u2014 backend#1245); dev/staging float on `tag`, resolving the current published digest at every spawn.",
+          "description": "Image used for spawned ingestion Jobs. jobs-manager resolves one effective digest from these keys (see the tracebloc.ingestorDigest helper) and builds the reference from it (client-runtime submit_ingestion_run): digest set -> repo@digest + IfNotPresent, digest empty -> repo:tag + Always. Prod pins `prodDigest` (a chart default, so a republished pin propagates through the fleet auto-upgrade — backend#1245); dev/staging float on `tag`, resolving the current published digest at every spawn.",
           "properties": {
             "repository": {
               "type": "string",
@@ -585,10 +468,32 @@
             },
             "tag": {
               "type": "string",
-              "not": {
-                "const": "latest"
-              },
-              "description": "Explicit floating-tag override for the spawned ingestor. EMPTY by default: the effective tag then comes from channelTags[CLIENT_ENV]. `latest` is rejected \u2014 spawn behaviour must not drift. To pin an exact image prefer `digest`, which wins over any tag. Surfaces as INGESTOR_IMAGE_TAG."
+              "not": { "const": "latest" },
+              "description": "Explicit floating-tag override for the spawned ingestor. EMPTY by default: the effective tag then comes from channelTags[CLIENT_ENV] (backend#1360). `latest` is rejected — spawn behaviour must not drift. To pin an exact image prefer `digest`, which wins over any tag. Surfaces as INGESTOR_IMAGE_TAG."
+            },
+            "channelTags": {
+              "type": "object",
+              "description": "Per-environment floating tags, keyed on the resolved CLIENT_ENV, used when `tag` is empty. `dev`/`stg` track the UNSIGNED internal channels published from the matching data-ingestors branch; `prod` stays a semver float because no :prod tag is published. backend#1360.",
+              "properties": {
+                "dev": {
+                  "type": "string",
+                  "minLength": 1,
+                  "not": { "const": "latest" },
+                  "description": "Tag spawned when CLIENT_ENV resolves to dev."
+                },
+                "stg": {
+                  "type": "string",
+                  "minLength": 1,
+                  "not": { "const": "latest" },
+                  "description": "Tag spawned when CLIENT_ENV resolves to stg."
+                },
+                "prod": {
+                  "type": "string",
+                  "minLength": 1,
+                  "not": { "const": "latest" },
+                  "description": "Tag spawned when CLIENT_ENV resolves to prod and no digest applies."
+                }
+              }
             },
             "prodDigest": {
               "type": "string",
@@ -603,36 +508,6 @@
               "type": "string",
               "pattern": "^(sha256:[a-f0-9]{64})?$",
               "description": "Optional explicit per-edge pin (sha256:<64 hex>). Empty (default) = let prodPin/CLIENT_ENV decide. When set it wins over `prodDigest` and over `prodPin: false` in ANY environment, and every ingestion Job runs this exact image with imagePullPolicy=IfNotPresent (reproducibility). Must be a multi-arch index (#186). Surfaces as INGESTOR_IMAGE_DIGEST."
-            },
-            "channelTags": {
-              "type": "object",
-              "description": "Per-environment floating tags, keyed on the resolved CLIENT_ENV, used when `tag` is empty. dev/stg track the unsigned internal channels published from the matching data-ingestors branch; prod stays a semver float (no :prod tag is published). backend#1360.",
-              "properties": {
-                "dev": {
-                  "type": "string",
-                  "minLength": 1,
-                  "not": {
-                    "const": "latest"
-                  },
-                  "description": "Tag spawned when CLIENT_ENV resolves to dev."
-                },
-                "stg": {
-                  "type": "string",
-                  "minLength": 1,
-                  "not": {
-                    "const": "latest"
-                  },
-                  "description": "Tag spawned when CLIENT_ENV resolves to stg."
-                },
-                "prod": {
-                  "type": "string",
-                  "minLength": 1,
-                  "not": {
-                    "const": "latest"
-                  },
-                  "description": "Tag spawned when CLIENT_ENV resolves to prod."
-                }
-              }
             }
           }
         },
@@ -641,9 +516,7 @@
           "properties": {
             "tag": {
               "type": "string",
-              "not": {
-                "const": "latest"
-              },
+              "not": { "const": "latest" },
               "description": "Image tag for mysql-client. Empty falls back to env.CLIENT_ENV. Must not be \"latest\"."
             },
             "digest": {
@@ -657,9 +530,7 @@
           "properties": {
             "tag": {
               "type": "string",
-              "not": {
-                "const": "latest"
-              }
+              "not": { "const": "latest" }
             },
             "digest": {
               "type": "string",
@@ -679,28 +550,16 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             },
             "limits": {
               "type": "object",
-              "description": "CPU limit deliberately omitted in defaults \u2014 throttling causes InnoDB lock-wait timeouts.",
+              "description": "CPU limit deliberately omitted in defaults — throttling causes InnoDB lock-wait timeouts.",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             }
           }
@@ -711,27 +570,15 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             }
           }
@@ -742,27 +589,15 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             }
           }
@@ -773,27 +608,15 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             }
           }
@@ -802,42 +625,21 @@
     },
     "priorityClass": {
       "type": "object",
-      "description": "Cluster-scoped PriorityClass for tracebloc data-plane workloads (mysql). An empty `name` disables the priorityClassName reference on the mysql pod entirely (mysql falls back to default priority 0 \u2014 only set this if you explicitly want no OOM protection from the scheduler).",
+      "description": "Cluster-scoped PriorityClass for tracebloc data-plane workloads (mysql). An empty `name` disables the priorityClassName reference on the mysql pod entirely (mysql falls back to default priority 0 — only set this if you explicitly want no OOM protection from the scheduler).",
       "properties": {
-        "create": {
-          "type": "boolean",
-          "default": true
-        },
-        "name": {
-          "type": "string",
-          "default": "tracebloc-data-plane"
-        },
-        "value": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 1000000000,
-          "default": 1000000
-        }
+        "create": { "type": "boolean", "default": true },
+        "name":   { "type": "string", "default": "tracebloc-data-plane" },
+        "value":  { "type": "integer", "minimum": 0, "maximum": 1000000000, "default": 1000000 }
       },
       "allOf": [
         {
-          "$comment": "If we are templating the PriorityClass resource, name must not be empty. `required: [create]` is needed because draft-07 `properties` only validates keys that are present \u2014 without it, omitting `create` passes the `if` vacuously and unconditionally enforces `then`. Same pattern as dockerRegistry below.",
+          "$comment": "If we are templating the PriorityClass resource, name must not be empty. `required: [create]` is needed because draft-07 `properties` only validates keys that are present — without it, omitting `create` passes the `if` vacuously and unconditionally enforces `then`. Same pattern as dockerRegistry below.",
           "if": {
-            "properties": {
-              "create": {
-                "const": true
-              }
-            },
-            "required": [
-              "create"
-            ]
+            "properties": { "create": { "const": true } },
+            "required": ["create"]
           },
           "then": {
-            "properties": {
-              "name": {
-                "minLength": 1
-              }
-            }
+            "properties": { "name": { "minLength": 1 } }
           }
         }
       ]
@@ -849,19 +651,13 @@
         "mysql": {
           "type": "object",
           "properties": {
-            "create": {
-              "type": "boolean",
-              "default": true
-            }
+            "create": { "type": "boolean", "default": true }
           }
         },
         "jobsManager": {
           "type": "object",
           "properties": {
-            "create": {
-              "type": "boolean",
-              "default": true
-            }
+            "create": { "type": "boolean", "default": true }
           }
         }
       }
@@ -869,17 +665,13 @@
     "clientId": {
       "type": "string",
       "minLength": 1,
-      "not": {
-        "pattern": "^<.*>$"
-      },
+      "not": { "pattern": "^<.*>$" },
       "description": "Client ID for authentication. Must be a real value, not a placeholder like <CLIENT_ID>."
     },
     "clientPassword": {
       "type": "string",
       "minLength": 1,
-      "not": {
-        "pattern": "^<.*>$"
-      },
+      "not": { "pattern": "^<.*>$" },
       "description": "Client authentication password. Must be a real value, not a placeholder like <CLIENT_PASSWORD>."
     },
     "autoUpgrade": {
@@ -935,30 +727,18 @@
         },
         "image": {
           "type": "object",
-          "required": [
-            "repository",
-            "tag"
-          ],
+          "required": ["repository", "tag"],
           "properties": {
-            "repository": {
-              "type": "string",
-              "minLength": 1
-            },
+            "repository": { "type": "string", "minLength": 1 },
             "tag": {
               "type": "string",
               "minLength": 1,
-              "not": {
-                "const": "latest"
-              },
-              "description": "Pin the helm version. `latest` is rejected \u2014 auto-upgrade behaviour must not drift."
+              "not": { "const": "latest" },
+              "description": "Pin the helm version. `latest` is rejected — auto-upgrade behaviour must not drift."
             },
             "pullPolicy": {
               "type": "string",
-              "enum": [
-                "Always",
-                "IfNotPresent",
-                "Never"
-              ]
+              "enum": ["Always", "IfNotPresent", "Never"]
             }
           }
         },
@@ -968,27 +748,15 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             }
           }
@@ -1033,30 +801,18 @@
         },
         "image": {
           "type": "object",
-          "required": [
-            "repository",
-            "tag"
-          ],
+          "required": ["repository", "tag"],
           "properties": {
-            "repository": {
-              "type": "string",
-              "minLength": 1
-            },
+            "repository": { "type": "string", "minLength": 1 },
             "tag": {
               "type": "string",
               "minLength": 1,
-              "not": {
-                "const": "latest"
-              },
-              "description": "Pin the alpine/k8s version. `latest` is rejected \u2014 image-refresh behaviour must not drift."
+              "not": { "const": "latest" },
+              "description": "Pin the alpine/k8s version. `latest` is rejected — image-refresh behaviour must not drift."
             },
             "pullPolicy": {
               "type": "string",
-              "enum": [
-                "Always",
-                "IfNotPresent",
-                "Never"
-              ]
+              "enum": ["Always", "IfNotPresent", "Never"]
             }
           }
         },
@@ -1066,27 +822,15 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu": {
-                  "type": "string",
-                  "pattern": "^[0-9]+m?$"
-                },
-                "memory": {
-                  "type": "string",
-                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
-                }
+                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
+                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
               }
             }
           }
@@ -1094,10 +838,7 @@
       }
     },
     "dockerRegistry": {
-      "type": [
-        "object",
-        "null"
-      ],
+      "type": ["object", "null"],
       "description": "Optional. Omit entirely or set null for public images (no secret or imagePullSecrets). Only create when set and create is true.",
       "properties": {
         "create": {
@@ -1123,21 +864,12 @@
         {
           "if": {
             "properties": {
-              "create": {
-                "const": true
-              }
+              "create": { "const": true }
             },
-            "required": [
-              "create"
-            ]
+            "required": ["create"]
           },
           "then": {
-            "required": [
-              "server",
-              "username",
-              "password",
-              "email"
-            ]
+            "required": ["server", "username", "password", "email"]
           }
         }
       ]

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -2,7 +2,10 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Tracebloc Helm Chart Values",
   "type": "object",
-  "required": ["clientId", "clientPassword"],
+  "required": [
+    "clientId",
+    "clientPassword"
+  ],
   "properties": {
     "env": {
       "type": "object",
@@ -13,10 +16,18 @@
           "default": "prod",
           "description": "Environment identifier and Docker image tag (dev, staging, prod). Defaults to 'prod' if not set or empty."
         },
-        "HTTP_PROXY_HOST": { "type": "string" },
-        "HTTP_PROXY_PORT": { "type": "string" },
-        "HTTP_PROXY_USERNAME": { "type": "string" },
-        "HTTP_PROXY_PASSWORD": { "type": "string" },
+        "HTTP_PROXY_HOST": {
+          "type": "string"
+        },
+        "HTTP_PROXY_PORT": {
+          "type": "string"
+        },
+        "HTTP_PROXY_USERNAME": {
+          "type": "string"
+        },
+        "HTTP_PROXY_PASSWORD": {
+          "type": "string"
+        },
         "RESOURCE_REQUESTS": {
           "type": "string",
           "default": "cpu=2,memory=8Gi",
@@ -39,7 +50,9 @@
           "default": "nvidia.com/gpu=1",
           "description": "Optional GPU limits for spawned jobs (defaults to 'nvidia.com/gpu=1' if not set)"
         },
-        "RUNTIME_CLASS_NAME": { "type": "string" },
+        "RUNTIME_CLASS_NAME": {
+          "type": "string"
+        },
         "SINGLE_NODE": {
           "type": "string",
           "description": "Single-node (fixed, non-elastic) cluster flag. Gates jobs-manager's GPU->CPU pending-job fallback (client-runtime#92). 'true' -> downgrade a stuck Pending GPU pod to CPU (correct on fixed single-host clusters where GPU presence is known at install time); 'false' -> leave it for the autoscaler/backend (correct for EKS/AKS/OpenShift). If unset, defaults to hostPath.enabled."
@@ -51,7 +64,10 @@
     },
     "storageClass": {
       "type": "object",
-      "required": ["create", "name"],
+      "required": [
+        "create",
+        "name"
+      ],
       "properties": {
         "create": {
           "type": "boolean",
@@ -71,15 +87,25 @@
         },
         "volumeBindingMode": {
           "type": "string",
-          "enum": ["", "Immediate", "WaitForFirstConsumer"]
+          "enum": [
+            "",
+            "Immediate",
+            "WaitForFirstConsumer"
+          ]
         },
         "reclaimPolicy": {
           "type": "string",
-          "enum": ["", "Delete", "Retain"]
+          "enum": [
+            "",
+            "Delete",
+            "Retain"
+          ]
         },
         "mountOptions": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "parameters": {
           "type": "object",
@@ -127,7 +153,11 @@
     },
     "pvcAccessMode": {
       "type": "string",
-      "enum": ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"],
+      "enum": [
+        "ReadWriteOnce",
+        "ReadWriteMany",
+        "ReadOnlyMany"
+      ],
       "description": "Access mode for PVCs"
     },
     "clusterScope": {
@@ -146,7 +176,9 @@
       "properties": {
         "namespace": {
           "type": "object",
-          "required": ["name"],
+          "required": [
+            "name"
+          ],
           "properties": {
             "create": {
               "type": "boolean",
@@ -191,21 +223,36 @@
           "properties": {
             "warn": {
               "type": "string",
-              "enum": ["", "privileged", "baseline", "restricted"]
+              "enum": [
+                "",
+                "privileged",
+                "baseline",
+                "restricted"
+              ]
             },
             "warnVersion": {
               "type": "string"
             },
             "audit": {
               "type": "string",
-              "enum": ["", "privileged", "baseline", "restricted"]
+              "enum": [
+                "",
+                "privileged",
+                "baseline",
+                "restricted"
+              ]
             },
             "auditVersion": {
               "type": "string"
             },
             "enforce": {
               "type": "string",
-              "enum": ["", "privileged", "baseline", "restricted"]
+              "enum": [
+                "",
+                "privileged",
+                "baseline",
+                "restricted"
+              ]
             },
             "enforceVersion": {
               "type": "string"
@@ -229,11 +276,11 @@
             "allowExternalHttps": {
               "type": "boolean",
               "default": true,
-              "description": "When false, drop the 0.0.0.0/0:443 egress rule so training pods reach only DNS, MySQL, requests-proxy and the egress gateway (SECURITY §8.2 / client-runtime#102). Default true keeps existing behaviour; flip per-fleet after verifying the egress gateway works (G2)."
+              "description": "When false, drop the 0.0.0.0/0:443 egress rule so training pods reach only DNS, MySQL, requests-proxy and the egress gateway (SECURITY \u00a78.2 / client-runtime#102). Default true keeps existing behaviour; flip per-fleet after verifying the egress gateway works (G2)."
             },
             "enforcementProbeHost": {
               "type": "string",
-              "description": "Host the `helm test` enforcement check curls directly (when allowExternalHttps=false) to verify the CNI blocks egress; non-enforcement fails the test (a test hook never affects install/upgrade) — client-runtime#104. Empty string disables it (e.g. air-gapped clusters)."
+              "description": "Host the `helm test` enforcement check curls directly (when allowExternalHttps=false) to verify the CNI blocks egress; non-enforcement fails the test (a test hook never affects install/upgrade) \u2014 client-runtime#104. Empty string disables it (e.g. air-gapped clusters)."
             },
             "enforcementProbeTimeoutSeconds": {
               "type": "integer",
@@ -255,7 +302,7 @@
             },
             "clusterCidrs": {
               "type": "array",
-              "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs. Must be non-empty when networkPolicy.training.enabled is true — an empty list renders `except: null` and Kubernetes treats that as no exceptions, silently allowing unrestricted in-cluster egress.",
+              "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs. Must be non-empty when networkPolicy.training.enabled is true \u2014 an empty list renders `except: null` and Kubernetes treats that as no exceptions, silently allowing unrestricted in-cluster egress.",
               "items": {
                 "type": "string",
                 "pattern": "^[0-9.]+/[0-9]+$"
@@ -264,13 +311,19 @@
           },
           "if": {
             "properties": {
-              "enabled": { "const": true }
+              "enabled": {
+                "const": true
+              }
             },
-            "required": ["enabled"]
+            "required": [
+              "enabled"
+            ]
           },
           "then": {
             "properties": {
-              "clusterCidrs": { "minItems": 1 }
+              "clusterCidrs": {
+                "minItems": 1
+              }
             }
           }
         }
@@ -317,7 +370,9 @@
               },
               "table_prefixes": {
                 "type": "array",
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "description": "Table-name prefixes this SA may ingest into. [\"*\"] = any table."
               }
             }
@@ -338,11 +393,11 @@
     },
     "sealCheck": {
       "type": "object",
-      "description": "Seal check — the chart's conformance suite (RFC-0003 §8.2 / backend#1184). Every check is a `helm test` hook Job labelled tracebloc.io/seal-check=true + tracebloc.io/seal-check-name=<check> (the enumeration contract the tracebloc CLI consumes, cli#393). See docs/SEAL-CHECK.md.",
+      "description": "Seal check \u2014 the chart's conformance suite (RFC-0003 \u00a78.2 / backend#1184). Every check is a `helm test` hook Job labelled tracebloc.io/seal-check=true + tracebloc.io/seal-check-name=<check> (the enumeration contract the tracebloc CLI consumes, cli#393). See docs/SEAL-CHECK.md.",
       "properties": {
         "storageAssertions": {
           "type": "object",
-          "description": "In-cluster storage assertions: release PVCs Bound on the expected StorageClass; in dynamic-PVC mode (hostPath.enabled=false) no release PVC backed by a hostPath PV on an unmanaged host tree (leftover chart hostPath PVs capture claims via claimRef — RFC-0003 D3/D4).",
+          "description": "In-cluster storage assertions: release PVCs Bound on the expected StorageClass; in dynamic-PVC mode (hostPath.enabled=false) no release PVC backed by a hostPath PV on an unmanaged host tree (leftover chart hostPath PVs capture claims via claimRef \u2014 RFC-0003 D3/D4).",
           "properties": {
             "enabled": {
               "type": "boolean",
@@ -357,16 +412,35 @@
             },
             "nodeLocalPathPrefixes": {
               "type": "array",
-              "items": { "type": "string" },
-              "description": "hostPath prefixes accepted as provisioner-managed node-local storage in dynamic mode (k3s local-path: /var/lib/rancher/…; upstream local-path-provisioner: /opt/local-path-provisioner/). Entries match whole path segments (trailing slash optional) — a prefix admits itself and paths under it, never sibling paths. Any other hostPath backing fails the check."
+              "items": {
+                "type": "string"
+              },
+              "description": "hostPath prefixes accepted as provisioner-managed node-local storage in dynamic mode (k3s local-path: /var/lib/rancher/\u2026; upstream local-path-provisioner: /opt/local-path-provisioner/). Entries match whole path segments (trailing slash optional) \u2014 a prefix admits itself and paths under it, never sibling paths. Any other hostPath backing fails the check."
             },
             "image": {
               "type": "object",
               "description": "kubectl-capable image for the assertion pod (same image the image-refresh CronJob uses).",
               "properties": {
-                "repository": { "type": "string", "default": "alpine/k8s" },
-                "tag": { "type": "string", "not": { "const": "latest" }, "default": "1.30.5" },
-                "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+                "repository": {
+                  "type": "string",
+                  "default": "alpine/k8s"
+                },
+                "tag": {
+                  "type": "string",
+                  "not": {
+                    "const": "latest"
+                  },
+                  "default": "1.30.5"
+                },
+                "pullPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Always",
+                    "IfNotPresent",
+                    "Never"
+                  ],
+                  "default": "IfNotPresent"
+                }
               }
             }
           }
@@ -375,25 +449,56 @@
     },
     "egressProxy": {
       "type": "object",
-      "description": "In-cluster squid egress gateway (SECURITY §8.2 / client-runtime#102). Forward proxy that permits HTTPS CONNECT only to the allowlist, so a locked-down training pod can reach the backend + App Insights and nothing else.",
+      "description": "In-cluster squid egress gateway (SECURITY \u00a78.2 / client-runtime#102). Forward proxy that permits HTTPS CONNECT only to the allowlist, so a locked-down training pod can reach the backend + App Insights and nothing else.",
       "properties": {
-        "enabled": { "type": "boolean", "default": true },
-        "routeWorkloads": { "type": "boolean", "default": false, "description": "Route training-pod outbound HTTPS through the gateway (jobs-manager injects HTTPS_PROXY). Default false — enable per-fleet, verify a run, then drop the direct egress rule (networkPolicy.training.allowExternalHttps=false)." },
-        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 3128 },
-        "runAsUser": { "type": "integer", "minimum": 1 },
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "routeWorkloads": {
+          "type": "boolean",
+          "default": false,
+          "description": "Route training-pod outbound HTTPS through the gateway (jobs-manager injects HTTPS_PROXY). Default false \u2014 enable per-fleet, verify a run, then drop the direct egress rule (networkPolicy.training.allowExternalHttps=false)."
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 3128
+        },
+        "runAsUser": {
+          "type": "integer",
+          "minimum": 1
+        },
         "image": {
           "type": "object",
           "properties": {
-            "registry": { "type": "string" },
-            "repository": { "type": "string", "minLength": 1 },
-            "tag": { "type": "string", "not": { "const": "latest" } },
-            "digest": { "type": "string", "pattern": "^(sha256:[a-f0-9]{64})?$" }
+            "registry": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
+            "tag": {
+              "type": "string",
+              "not": {
+                "const": "latest"
+              }
+            },
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$"
+            }
           }
         },
         "allowlist": {
           "type": "array",
           "description": "FQDNs the gateway permits HTTPS CONNECT to (squid dstdomain syntax: leading dot = subdomain match, bare host = exact).",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
         "resources": {
           "type": "object",
@@ -401,15 +506,27 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -459,7 +576,7 @@
         },
         "ingestor": {
           "type": "object",
-          "description": "Image used for spawned ingestion Jobs. jobs-manager resolves one effective digest from these keys (see the tracebloc.ingestorDigest helper) and builds the reference from it (client-runtime submit_ingestion_run): digest set -> repo@digest + IfNotPresent, digest empty -> repo:tag + Always. Prod pins `prodDigest` (a chart default, so a republished pin propagates through the fleet auto-upgrade — backend#1245); dev/staging float on `tag`, resolving the current published digest at every spawn.",
+          "description": "Image used for spawned ingestion Jobs. jobs-manager resolves one effective digest from these keys (see the tracebloc.ingestorDigest helper) and builds the reference from it (client-runtime submit_ingestion_run): digest set -> repo@digest + IfNotPresent, digest empty -> repo:tag + Always. Prod pins `prodDigest` (a chart default, so a republished pin propagates through the fleet auto-upgrade \u2014 backend#1245); dev/staging float on `tag`, resolving the current published digest at every spawn.",
           "properties": {
             "repository": {
               "type": "string",
@@ -468,9 +585,10 @@
             },
             "tag": {
               "type": "string",
-              "minLength": 1,
-              "not": { "const": "latest" },
-              "description": "Floating ghcr.io/tracebloc/ingestor tag spawned when no digest applies (imagePullPolicy=Always). `latest` is rejected — spawn behaviour must not drift. Surfaces as INGESTOR_IMAGE_TAG."
+              "not": {
+                "const": "latest"
+              },
+              "description": "Explicit floating-tag override for the spawned ingestor. EMPTY by default: the effective tag then comes from channelTags[CLIENT_ENV]. `latest` is rejected \u2014 spawn behaviour must not drift. To pin an exact image prefer `digest`, which wins over any tag. Surfaces as INGESTOR_IMAGE_TAG."
             },
             "prodDigest": {
               "type": "string",
@@ -485,6 +603,36 @@
               "type": "string",
               "pattern": "^(sha256:[a-f0-9]{64})?$",
               "description": "Optional explicit per-edge pin (sha256:<64 hex>). Empty (default) = let prodPin/CLIENT_ENV decide. When set it wins over `prodDigest` and over `prodPin: false` in ANY environment, and every ingestion Job runs this exact image with imagePullPolicy=IfNotPresent (reproducibility). Must be a multi-arch index (#186). Surfaces as INGESTOR_IMAGE_DIGEST."
+            },
+            "channelTags": {
+              "type": "object",
+              "description": "Per-environment floating tags, keyed on the resolved CLIENT_ENV, used when `tag` is empty. dev/stg track the unsigned internal channels published from the matching data-ingestors branch; prod stays a semver float (no :prod tag is published). backend#1360.",
+              "properties": {
+                "dev": {
+                  "type": "string",
+                  "minLength": 1,
+                  "not": {
+                    "const": "latest"
+                  },
+                  "description": "Tag spawned when CLIENT_ENV resolves to dev."
+                },
+                "stg": {
+                  "type": "string",
+                  "minLength": 1,
+                  "not": {
+                    "const": "latest"
+                  },
+                  "description": "Tag spawned when CLIENT_ENV resolves to stg."
+                },
+                "prod": {
+                  "type": "string",
+                  "minLength": 1,
+                  "not": {
+                    "const": "latest"
+                  },
+                  "description": "Tag spawned when CLIENT_ENV resolves to prod."
+                }
+              }
             }
           }
         },
@@ -493,7 +641,9 @@
           "properties": {
             "tag": {
               "type": "string",
-              "not": { "const": "latest" },
+              "not": {
+                "const": "latest"
+              },
               "description": "Image tag for mysql-client. Empty falls back to env.CLIENT_ENV. Must not be \"latest\"."
             },
             "digest": {
@@ -507,7 +657,9 @@
           "properties": {
             "tag": {
               "type": "string",
-              "not": { "const": "latest" }
+              "not": {
+                "const": "latest"
+              }
             },
             "digest": {
               "type": "string",
@@ -527,16 +679,28 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
-              "description": "CPU limit deliberately omitted in defaults — throttling causes InnoDB lock-wait timeouts.",
+              "description": "CPU limit deliberately omitted in defaults \u2014 throttling causes InnoDB lock-wait timeouts.",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -547,15 +711,27 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -566,15 +742,27 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -585,15 +773,27 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -602,21 +802,42 @@
     },
     "priorityClass": {
       "type": "object",
-      "description": "Cluster-scoped PriorityClass for tracebloc data-plane workloads (mysql). An empty `name` disables the priorityClassName reference on the mysql pod entirely (mysql falls back to default priority 0 — only set this if you explicitly want no OOM protection from the scheduler).",
+      "description": "Cluster-scoped PriorityClass for tracebloc data-plane workloads (mysql). An empty `name` disables the priorityClassName reference on the mysql pod entirely (mysql falls back to default priority 0 \u2014 only set this if you explicitly want no OOM protection from the scheduler).",
       "properties": {
-        "create": { "type": "boolean", "default": true },
-        "name":   { "type": "string", "default": "tracebloc-data-plane" },
-        "value":  { "type": "integer", "minimum": 0, "maximum": 1000000000, "default": 1000000 }
+        "create": {
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "type": "string",
+          "default": "tracebloc-data-plane"
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000000000,
+          "default": 1000000
+        }
       },
       "allOf": [
         {
-          "$comment": "If we are templating the PriorityClass resource, name must not be empty. `required: [create]` is needed because draft-07 `properties` only validates keys that are present — without it, omitting `create` passes the `if` vacuously and unconditionally enforces `then`. Same pattern as dockerRegistry below.",
+          "$comment": "If we are templating the PriorityClass resource, name must not be empty. `required: [create]` is needed because draft-07 `properties` only validates keys that are present \u2014 without it, omitting `create` passes the `if` vacuously and unconditionally enforces `then`. Same pattern as dockerRegistry below.",
           "if": {
-            "properties": { "create": { "const": true } },
-            "required": ["create"]
+            "properties": {
+              "create": {
+                "const": true
+              }
+            },
+            "required": [
+              "create"
+            ]
           },
           "then": {
-            "properties": { "name": { "minLength": 1 } }
+            "properties": {
+              "name": {
+                "minLength": 1
+              }
+            }
           }
         }
       ]
@@ -628,13 +849,19 @@
         "mysql": {
           "type": "object",
           "properties": {
-            "create": { "type": "boolean", "default": true }
+            "create": {
+              "type": "boolean",
+              "default": true
+            }
           }
         },
         "jobsManager": {
           "type": "object",
           "properties": {
-            "create": { "type": "boolean", "default": true }
+            "create": {
+              "type": "boolean",
+              "default": true
+            }
           }
         }
       }
@@ -642,13 +869,17 @@
     "clientId": {
       "type": "string",
       "minLength": 1,
-      "not": { "pattern": "^<.*>$" },
+      "not": {
+        "pattern": "^<.*>$"
+      },
       "description": "Client ID for authentication. Must be a real value, not a placeholder like <CLIENT_ID>."
     },
     "clientPassword": {
       "type": "string",
       "minLength": 1,
-      "not": { "pattern": "^<.*>$" },
+      "not": {
+        "pattern": "^<.*>$"
+      },
       "description": "Client authentication password. Must be a real value, not a placeholder like <CLIENT_PASSWORD>."
     },
     "autoUpgrade": {
@@ -704,18 +935,30 @@
         },
         "image": {
           "type": "object",
-          "required": ["repository", "tag"],
+          "required": [
+            "repository",
+            "tag"
+          ],
           "properties": {
-            "repository": { "type": "string", "minLength": 1 },
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
             "tag": {
               "type": "string",
               "minLength": 1,
-              "not": { "const": "latest" },
-              "description": "Pin the helm version. `latest` is rejected — auto-upgrade behaviour must not drift."
+              "not": {
+                "const": "latest"
+              },
+              "description": "Pin the helm version. `latest` is rejected \u2014 auto-upgrade behaviour must not drift."
             },
             "pullPolicy": {
               "type": "string",
-              "enum": ["Always", "IfNotPresent", "Never"]
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ]
             }
           }
         },
@@ -725,15 +968,27 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -778,18 +1033,30 @@
         },
         "image": {
           "type": "object",
-          "required": ["repository", "tag"],
+          "required": [
+            "repository",
+            "tag"
+          ],
           "properties": {
-            "repository": { "type": "string", "minLength": 1 },
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
             "tag": {
               "type": "string",
               "minLength": 1,
-              "not": { "const": "latest" },
-              "description": "Pin the alpine/k8s version. `latest` is rejected — image-refresh behaviour must not drift."
+              "not": {
+                "const": "latest"
+              },
+              "description": "Pin the alpine/k8s version. `latest` is rejected \u2014 image-refresh behaviour must not drift."
             },
             "pullPolicy": {
               "type": "string",
-              "enum": ["Always", "IfNotPresent", "Never"]
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ]
             }
           }
         },
@@ -799,15 +1066,27 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -815,7 +1094,10 @@
       }
     },
     "dockerRegistry": {
-      "type": ["object", "null"],
+      "type": [
+        "object",
+        "null"
+      ],
       "description": "Optional. Omit entirely or set null for public images (no secret or imagePullSecrets). Only create when set and create is true.",
       "properties": {
         "create": {
@@ -841,12 +1123,21 @@
         {
           "if": {
             "properties": {
-              "create": { "const": true }
+              "create": {
+                "const": true
+              }
             },
-            "required": ["create"]
+            "required": [
+              "create"
+            ]
           },
           "then": {
-            "required": ["server", "username", "password", "email"]
+            "required": [
+              "server",
+              "username",
+              "password",
+              "email"
+            ]
           }
         }
       ]

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -389,7 +389,31 @@ images:
     # newer categories re-opens the submit-vs-run drift bug (categories
     # accepted at submit that the spawned image can't process). See
     # client-runtime#162 discussion.
-    tag: "0.7"
+    # Empty by DEFAULT: the effective tag now comes from `channelTags` below,
+    # keyed on the resolved CLIENT_ENV. Set this to force one tag on an edge
+    # regardless of environment (to pin an exact immutable image, prefer
+    # `digest` — it wins over any tag). backend#1360.
+    tag: ""
+
+    # -- PER-ENVIRONMENT CHANNELS (backend#1360)
+    #
+    # dev and staging edges track the internal channels published from the
+    # matching data-ingestors branch (`publish-images.yml`: develop -> :dev,
+    # staging -> :stg), so an ingestor change can be validated on a real edge
+    # WITHOUT a production release. Before this, the ingestor image existed
+    # only as a byproduct of a prod release, so testing one change cost a prod
+    # PyPI publish plus an FR-gate override (2026-07-30).
+    #
+    # `prod` deliberately stays a semver float, NOT a `:prod` channel — no
+    # such tag is published; prod normally runs `prodDigest` anyway and this is
+    # only the fallback when pinning is disabled. Keep the prod entry tracking
+    # the current release line for the same submit-vs-run reasons noted above.
+    #
+    # These are unsigned internal images. Do not point a prod edge at them.
+    channelTags:
+      dev: "dev"
+      stg: "stg"
+      prod: "0.7"
 
     # -- PROD REPRODUCIBILITY PIN — the digest prod edges run.
     #

--- a/scripts/resolve-ingestor-digest.sh
+++ b/scripts/resolve-ingestor-digest.sh
@@ -42,6 +42,38 @@ write=0
 # Scoped to the images: -> ingestor: block so a sibling image's `tag:`
 # (jobsManager / podsMonitor / requestsProxy / ... each carry their own)
 # can never be picked up by mistake. bash-3.2 / macOS-safe (pure awk).
+# Portable, yq-free reader for images.ingestor.channelTags.prod. Same scoping
+# discipline as read_ingestor_tag: only the 6-space `prod:` leaf inside
+# images: -> ingestor: -> channelTags: can match, so no sibling key can be
+# picked up by mistake. bash-3.2 / macOS-safe.
+read_ingestor_prod_channel() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+  awk '
+    /^images:[[:space:]]*$/ { in_images = 1; next }
+    /^[^[:space:]#]/        { in_images = 0; in_ingestor = 0; in_channels = 0 }
+    in_images {
+      if ($0 ~ /^  [A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$/) {
+        in_ingestor = ($0 ~ /^  ingestor:[[:space:]]*$/) ? 1 : 0
+        in_channels = 0
+        next
+      }
+      if (in_ingestor && $0 ~ /^    [A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$/) {
+        in_channels = ($0 ~ /^    channelTags:[[:space:]]*$/) ? 1 : 0
+        next
+      }
+      if (in_channels && $0 ~ /^      prod:[[:space:]]*/) {
+        line = $0
+        sub(/^      prod:[[:space:]]*/, "", line)
+        gsub(/^["'"'"']|["'"'"']$/, "", line)
+        sub(/[[:space:]]*#.*$/, "", line)
+        gsub(/[[:space:]]*$/, "", line)
+        if (line != "") { print line; exit }
+      }
+    }
+  ' "$file"
+}
+
 read_ingestor_tag() {
   local file="$1"
   [[ -f "$file" ]] || return 1
@@ -79,15 +111,30 @@ if [[ -z "$tag" ]]; then
   # after the chart tag moves (e.g. 0.7 -> 0.8) while appearing to follow the
   # chart. Prefer yq; fall back to the portable yq-free parse above; if
   # neither can determine it, fail loudly rather than guess.
+  # Since backend#1360 `images.ingestor.tag` is an OVERRIDE that is empty by
+  # default, and the prod float lives in `images.ingestor.channelTags.prod`.
+  # This script resolves the PROD pin, so prefer the explicit override when an
+  # operator set one and otherwise read the prod channel. Without this the
+  # documented no-arg / --write path exits on an empty tag -- which is the very
+  # command the chart comments and the ingestor-multiarch CI error tell people
+  # to run (Bugbot, #494).
   if command -v yq >/dev/null 2>&1 && [[ -f "$chart_values" ]]; then
     tag="$(yq -r '.images.ingestor.tag' "$chart_values")"
-    [[ "$tag" == "null" ]] && tag=""   # yq prints literal "null" for a missing key
+    [[ "$tag" == "null" ]] && tag=""
+    if [[ -z "$tag" ]]; then
+      tag="$(yq -r '.images.ingestor.channelTags.prod' "$chart_values")"
+      [[ "$tag" == "null" ]] && tag=""
+    fi
   else
     tag="$(read_ingestor_tag "$chart_values" || true)"
+    if [[ -z "$tag" ]]; then
+      tag="$(read_ingestor_prod_channel "$chart_values" || true)"
+    fi
   fi
   if [[ -z "$tag" ]]; then
     echo "ERROR: could not determine the default ingestor tag from ${chart_values#$here/../}." >&2
-    echo "       (images.ingestor.tag was unreadable: file missing, key absent, or yq not" >&2
+    echo "       (neither images.ingestor.tag nor images.ingestor.channelTags.prod was" >&2
+    echo "        readable: file missing, keys absent, or yq not" >&2
     echo "        installed and the yq-free parse found nothing.)" >&2
     echo "       Fix: pass TAG explicitly — scripts/resolve-ingestor-digest.sh <TAG> [--write] —" >&2
     echo "       or install yq. Refusing to fall back to a hardcoded tag." >&2

--- a/scripts/resolve-ingestor-digest.sh
+++ b/scripts/resolve-ingestor-digest.sh
@@ -42,6 +42,36 @@ write=0
 # Scoped to the images: -> ingestor: block so a sibling image's `tag:`
 # (jobsManager / podsMonitor / requestsProxy / ... each carry their own)
 # can never be picked up by mistake. bash-3.2 / macOS-safe (pure awk).
+read_ingestor_tag() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+  awk '
+    # Enter the top-level images: block.
+    /^images:[[:space:]]*$/ { in_images = 1; next }
+    # Any other top-level key (col 0, not a comment) closes it.
+    /^[^[:space:]#]/        { in_images = 0; in_ingestor = 0 }
+    in_images {
+      # A 2-space sibling key under images: — arm the ingestor scope only
+      # while we are inside ingestor:, disarm on the next sibling.
+      if ($0 ~ /^  [A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$/) {
+        in_ingestor = ($0 ~ /^  ingestor:[[:space:]]*$/) ? 1 : 0
+        next
+      }
+      # The 4-space tag: leaf inside ingestor:.
+      if (in_ingestor && $0 ~ /^    tag:[[:space:]]/) {
+        v = $0
+        sub(/^    tag:[[:space:]]*/, "", v)          # drop the key
+        sub(/[[:space:]]+#.*$/, "", v)               # drop a trailing comment
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)   # trim
+        gsub(/^"|"$/, "", v)                         # unwrap double quotes
+        gsub(/^'\''|'\''$/, "", v)                   # unwrap single quotes
+        print v
+        exit
+      }
+    }
+  ' "$file"
+}
+
 # Portable, yq-free reader for images.ingestor.channelTags.prod. Same scoping
 # discipline as read_ingestor_tag: only the 6-space `prod:` leaf inside
 # images: -> ingestor: -> channelTags: can match, so no sibling key can be
@@ -69,36 +99,6 @@ read_ingestor_prod_channel() {
         sub(/[[:space:]]*#.*$/, "", line)
         gsub(/[[:space:]]*$/, "", line)
         if (line != "") { print line; exit }
-      }
-    }
-  ' "$file"
-}
-
-read_ingestor_tag() {
-  local file="$1"
-  [[ -f "$file" ]] || return 1
-  awk '
-    # Enter the top-level images: block.
-    /^images:[[:space:]]*$/ { in_images = 1; next }
-    # Any other top-level key (col 0, not a comment) closes it.
-    /^[^[:space:]#]/        { in_images = 0; in_ingestor = 0 }
-    in_images {
-      # A 2-space sibling key under images: — arm the ingestor scope only
-      # while we are inside ingestor:, disarm on the next sibling.
-      if ($0 ~ /^  [A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$/) {
-        in_ingestor = ($0 ~ /^  ingestor:[[:space:]]*$/) ? 1 : 0
-        next
-      }
-      # The 4-space tag: leaf inside ingestor:.
-      if (in_ingestor && $0 ~ /^    tag:[[:space:]]/) {
-        v = $0
-        sub(/^    tag:[[:space:]]*/, "", v)          # drop the key
-        sub(/[[:space:]]+#.*$/, "", v)               # drop a trailing comment
-        gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)   # trim
-        gsub(/^"|"$/, "", v)                         # unwrap double quotes
-        gsub(/^'\''|'\''$/, "", v)                   # unwrap single quotes
-        print v
-        exit
       }
     }
   ' "$file"

--- a/scripts/resolve-ingestor-digest.sh
+++ b/scripts/resolve-ingestor-digest.sh
@@ -94,10 +94,11 @@ read_ingestor_prod_channel() {
       }
       if (in_channels && $0 ~ /^      prod:[[:space:]]*/) {
         line = $0
-        sub(/^      prod:[[:space:]]*/, "", line)
-        gsub(/^["'"'"']|["'"'"']$/, "", line)
-        sub(/[[:space:]]*#.*$/, "", line)
-        gsub(/[[:space:]]*$/, "", line)
+        sub(/^      prod:[[:space:]]*/, "", line)     # drop the key
+        sub(/[[:space:]]+#.*$/, "", line)              # drop a trailing comment
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)  # trim
+        gsub(/^"|"$/, "", line)                        # unwrap double quotes
+        gsub(/^'"'"'|'"'"'$/, "", line)                        # unwrap single quotes
         if (line != "") { print line; exit }
       }
     }


### PR DESCRIPTION
**Part 2 of tracebloc/backend#1360.** Draft on purpose — see the sequencing gate below.

Part 1 (tracebloc/data-ingestors#422) publishes `:dev` / `:stg`. This is the half that makes them *consumable*: today `images.ingestor.tag` is a **single** value (`"0.7"`) shared by dev and staging, so the two cannot sit on different channels. Only `prodDigest` is env-aware.

## What changes

| key | before | after |
|---|---|---|
| `images.ingestor.tag` | `"0.7"` (the only float) | **explicit override, empty by default** |
| `images.ingestor.channelTags` | — | `{dev: dev, stg: stg, prod: "0.7"}`, keyed on resolved `CLIENT_ENV` |

New `tracebloc.ingestorTag` helper, mirroring `tracebloc.ingestorDigest`'s precedence: **explicit `tag` > channel for `CLIENT_ENV` > literal `0.7`**. That last fallback matters — a release predating these keys still renders under a plain `--reuse-values` replay.

**`prod` deliberately stays a semver float, not a `:prod` channel** — no such tag is published for the ingestor, and prod normally spawns `prodDigest` anyway (the tag is only the fallback when pinning is disabled).

## Rendered result (verified, not asserted)

```
CLIENT_ENV=dev       INGESTOR_IMAGE_TAG="dev"   DIGEST=""
CLIENT_ENV=stg       INGESTOR_IMAGE_TAG="stg"   DIGEST=""
CLIENT_ENV=prod      INGESTOR_IMAGE_TAG="0.7"   DIGEST="sha256:9098b3c9…"
CLIENT_ENV=<unset>   INGESTOR_IMAGE_TAG="0.7"   DIGEST="sha256:9098b3c9…"
```

## The CI guard had to move with it

`ingestor-multiarch` in `helm-ci.yaml` **hard-failed on an empty tag**, so this change could not land without it. It now validates the explicit override *when set* plus **every** `channelTags` entry — an edge resolves exactly one of them, so a single-arch value in any would break ingestion on arm64 for whichever environment lands on it (client#186 / #160). Part 1's merge job already refuses to publish a single-arch index, so the channels satisfy it by construction.

## ⚠️ Sequencing gate — why this is a draft

`:dev` and `:stg` **do not exist yet**. Merging this before Part 1 has published both would point dev/staging edges at a nonexistent tag → **ImagePullBackOff on the next ingestion**. Also, the `ingestor-multiarch` job on this PR will legitimately fail until then, because it inspects those tags.

**Order:** merge #422 → let a `develop` and a `staging` push publish `:dev` and `:stg` (confirm both carry amd64+arm64) → mark this ready → merge.

## Behavioural change to be deliberate about

Chart defaults propagate through the fleet auto-upgrade (`--reset-then-reuse-values` re-applies user-supplied values but reads **new chart defaults**), and the installer does not pin the tag — so **existing dev/staging edges move onto their channel on the next upgrade**. That is the intent (a staging edge should run staging code, as jobs-manager and the engine already do), but it is a real change in what those edges run. An operator who set `images.ingestor.tag` explicitly keeps it. Prod is untouched.

These channels are **unsigned** internal images (Part 1 keeps one signed trust root at the prod tags) — hence prod is never pointed at them.

## Verification

- **307/307 `helm unittest` across 27 suites**, including 9 new cases: each environment, the explicit override winning over a channel, an unknown `CLIENT_ENV` falling back rather than rendering empty, and a `channelTags: null` replay.
- One **existing** test legitimately changed: `keeps the ingestor floating on dev` asserted tag `0.7` for `CLIENT_ENV=dev`; that is precisely the behaviour this PR changes, so it now asserts `dev` with the rationale inline. The other two tag assertions were checked and remain correct (no-`CLIENT_ENV` → prod float; the explicit `0.4` override case).
- `helm lint --strict` clean on **all four** platform values files (aks/bm/eks/oc).
- Schema: still rejects `latest` in `channelTags`, now accepts the empty override.
- `scripts/gen-manifest.sh` run — no change (no installer script touched).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgraded dev/staging edges will switch ingestor images on the next chart upgrade (intended but operationally significant), and merging before `:dev`/`:stg` exist causes ImagePullBackOff; prod pinning logic was touched but alias handling is tightened.
> 
> **Overview**
> **Spawns ingestion jobs with environment-specific ingestor tags** instead of one shared `images.ingestor.tag` (`0.7`). `tag` is now an optional override (empty by default); defaults live in new `images.ingestor.channelTags` (`dev` → `:dev`, `stg` → `:stg`, `prod` → `0.7`). jobs-manager’s `INGESTOR_IMAGE_TAG` comes from `tracebloc.ingestorTag` (override → channel for resolved env → `0.7` fallback).
> 
> **Shared `tracebloc.clientEnv`** normalizes `CLIENT_ENV` aliases (`staging`/`production`/etc.) so tag selection and the prod `prodDigest` pin stay aligned—fixing the case where `production` got the prod float tag but lost the digest pin.
> 
> **CI and tooling follow the new model:** `ingestor-multiarch` validates every tag an edge might spawn (explicit override plus each `channelTags` entry); `resolve-ingestor-digest.sh` defaults to `channelTags.prod` when `tag` is empty. Chart **1.9.9**; helm unittest coverage for channels, overrides, aliases, and legacy `--reuse-values` without `channelTags`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa74943cb11a6385ce8e4a804fd7be9e39281f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->