### PR TITLE
fix(ci): verify-index must read the authoritative index, not the raw CDN

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -449,11 +449,28 @@ jobs:
     env:
       TAG: ${{ github.event.release.tag_name }}
       PRERELEASE: ${{ needs.verify.outputs.prerelease }}
+    permissions:
+      contents: read   # read index.yaml from gh-pages via the API
     steps:
       - name: Assert the public index holds only stable versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          idx=$(curl -fsSL --retry 3 "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/gh-pages/index.yaml?nocache=$GITHUB_RUN_ID")
+
+          # Read the blob through the CONTENTS API, not raw.githubusercontent.com.
+          # raw.* is CDN-fronted and serves a stale copy for a while after a
+          # gh-pages push; `?nocache=` does not reliably bust it (Bugbot on
+          # client#495). This job runs seconds after `release` may have pushed,
+          # so a stale read could show a clean index while the customer-facing
+          # one is already polluted -- greening the exact backstop this job
+          # exists to be. The API is read-after-write consistent for a ref.
+          idx=$(gh api "repos/$GITHUB_REPOSITORY/contents/index.yaml?ref=gh-pages" \
+                  -H "Accept: application/vnd.github.raw+json")
+          if [ -z "$idx" ]; then
+            echo "::error::could not read index.yaml from gh-pages - refusing to report the invariants as holding on an empty read." >&2
+            exit 1
+          fi
           # No prerelease-shaped chart version may ever be indexed.
           if printf '%s\n' "$idx" | grep -E '^[[:space:]]+version:' | grep -- '-'; then
             echo "::error::public helm index contains prerelease-shaped versions (above) - customer surface polluted."

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -468,7 +468,10 @@ jobs:
           idx=$(gh api "repos/$GITHUB_REPOSITORY/contents/index.yaml?ref=gh-pages" \
                   -H "Accept: application/vnd.github.raw+json")
           if [ -z "$idx" ]; then
-            echo "::error::could not read index.yaml from gh-pages - refusing to report the invariants as holding on an empty read." >&2
+            # stdout, not stderr: Actions parses workflow commands from stdout
+            # only, so an ::error:: on stderr fails the step with no annotation
+            # (Bugbot, client#497). Every sibling ::error:: here uses stdout.
+            echo "::error::could not read index.yaml from gh-pages - refusing to report the invariants as holding on an empty read."
             exit 1
           fi
           # No prerelease-shaped chart version may ever be indexed.


### PR DESCRIPTION
Bugbot flagged this on the `staging -> main` promotion (client#495) and it's a fair hit on a guard **I added yesterday** in #467 — the finding is that the guard can pass while the thing it guards is already broken.

## The problem

`verify-index` ran:

```bash
curl -fsSL "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/gh-pages/index.yaml?nocache=$GITHUB_RUN_ID"
```

`raw.githubusercontent.com` is CDN-fronted and serves a stale copy for some time after a `gh-pages` push, and a `?nocache=` query parameter does **not** reliably bust it. This job runs seconds after the `release` job may have pushed, so it could read a pre-push index, see no prerelease versions, and go green **while the customer-facing index was already polluted** — precisely the leak it was written to catch (the 1.9.7-rc published-as-stable incident).

## The fix

Read the blob through the **contents API** at `?ref=gh-pages`, which is read-after-write consistent for a ref rather than CDN-cached:

```bash
idx=$(gh api "repos/$GITHUB_REPOSITORY/contents/index.yaml?ref=gh-pages" \
        -H "Accept: application/vnd.github.raw+json")
```

Plus an explicit **empty-read guard**: an unreadable index now fails the job instead of letting the invariant checks trivially "hold" against no data. That is the same failure shape as the empty-index commit I made during the gh-pages surgery — a critical read that silently returns nothing must never look like success.

Adds a job-scoped `permissions: contents: read`.

## Verification

- `actionlint` + `shellcheck` at CI-pinned versions: **6 findings before, 6 after** — my change adds none (all six are pre-existing, in unrelated steps).
- Exercised the new read against the live repo: the API returns the index with **36** chart versions and **0** prerelease-shaped entries, matching the current CDN copy (they agree when there has been no recent push — the divergence only appears in the window this job actually runs in).

## Note on the promotion

client was correctly **held** out of today's prod hop by this finding. It should stay held until the `1.9.8` chart bump reaches staging: promoting now would put 17 commits of chart changes on `main` while `Chart.yaml` still reads `1.9.7`, so `main` would no longer match the published 1.9.7 artifact. With this fix plus the bump on staging, the next prod hop promotes **and** cuts `v1.9.8` with content that matches its version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to a release guard; no runtime or customer install path behavior changes beyond making the backstop read the current index.
> 
> **Overview**
> The post-publish **`verify-index`** job no longer fetches `index.yaml` from `raw.githubusercontent.com` (CDN can lag right after `gh-pages` pushes, so checks could pass on a stale file while the public index was already wrong). It now loads the blob with **`gh api`** on `contents/index.yaml?ref=gh-pages`, which is treated as authoritative for that ref.
> 
> The job also **fails if the read is empty** instead of running invariant grep on no data, and grants **`contents: read`** for that API call. Workflow error annotations stay on **stdout** so Actions surfaces them reliably.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1bf131ab4fb629d03efec10ebd48df379fcc89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->