### PR TITLE
chore(ci): enable Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot config — security updates only.
+# `open-pull-requests-limit: 0` disables version updates; security updates have a separate
+# (built-in) limit of 10 and continue to fire when an advisory drops.
+# Labels and grouping defined here apply to security-update PRs.
+# Every group splits by update-type so a grouped PR never mixes patch with minor/major —
+# the auto-merge workflow gates on the PR-wide update-type (patch only).
+#
+# Mirrors the backend pilot (backend#577), which ran 2026-07-23 -> 2026-07-31 and produced
+# exactly one PR. Ecosystems and directories here come from a scan of this repo's tree.
+
+version: 2
+updates:
+  # GitHub Actions used in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "work-type:tech-debt"
+      - "dependencies"
+    groups:
+      actions-patches:
+        applies-to: security-updates
+        update-types: ["patch"]
+      actions-minor:
+        applies-to: security-updates
+        update-types: ["minor"]


### PR DESCRIPTION
Rolls the Dependabot pilot out to this repo. Part of standardising every repo on the same pipeline.

**Why now.** The pilot landed on `backend` (backend#577) on 2026-07-23 with an explicit condition: roll out to the rest if the noise is acceptable after a week. Measured 2026-07-31 — `backend` opened **1** Dependabot PR in that window (merged), `cli` opened **1**. That is not a noise problem.

Meanwhile only 2 of 10 repos had any Dependabot config at all, so security advisories on the other eight went unattended. `design-system` currently carries 4 open alerts (1 critical, 3 high) that nothing was going to surface.

**What this is.** Security updates only, identical in shape to the backend pilot:

- `open-pull-requests-limit: 0` disables *version* updates; security updates have their own built-in limit and still fire when an advisory drops.
- Grouped per ecosystem, and every group splits by update-type so a grouped PR never mixes patch with minor/major.
- Labelled `work-type:tech-debt` + `dependencies`.

**Ecosystems** come from a scan of this repo's tree, not from assumption — see the comments in the file for what was found and where.

**Deliberately not included: the auto-merge workflow.** `allow_auto_merge` is `false` on this repo (it is `true` only on `backend`), so shipping `dependabot-auto-merge.yml` here would be inert. Auto-merge needs two repo settings flipped first — *Allow auto-merge* and *Allow GitHub Actions to create and approve pull requests* — which is Lukas's call, per repo. Until then Dependabot PRs simply queue for a human, which is the safe default.

Context: backend#1371 §5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Dependabot configuration with no application runtime or auth changes.
> 
> **Overview**
> Introduces **`.github/dependabot.yml`** so security advisories on workflow dependencies can open PRs here, aligned with the backend pilot.
> 
> **Security updates only:** `open-pull-requests-limit: 0` turns off routine version bumps; Dependabot still opens security-update PRs (separate built-in cap). Weekly schedule on **`github-actions`** at repo root.
> 
> PRs get labels **`work-type:tech-debt`** and **`dependencies`**. Security updates are **grouped by patch vs minor** so a single PR does not mix update types (intended to pair with patch-only auto-merge elsewhere).
> 
> No auto-merge workflow is added in this PR; that depends on repo settings not enabled here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4036415da937f757816ea7750b2a768bee1e5dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->