### PR TITLE
chore: re-baseline the PR template on the org one

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- 1–3 sentences. What does this PR do and why? -->
 
 ## Related
-<!-- Same repo: Closes #123 · Cross-repo: Fixes tracebloc/backend#456 (owner-qualified — a bare backend#456 closes nothing). PRs land on develop, not the default branch, so confirm the issue actually closed. -->
+<!-- Same repo: Closes #123 · Cross-repo: Fixes tracebloc/client-runtime#456 (owner-qualified — a bare client-runtime#456 closes nothing). PRs land on develop, not the default branch, so closing keywords do not fire on merge — confirm the issue actually closed. -->
 
 ## Type of change
 - [ ] Feature
@@ -26,5 +26,6 @@
 - [ ] Docs updated if behavior or config changed
 - [ ] No secrets / credentials in the diff
 - [ ] For security-sensitive paths: appropriate reviewer requested
-- [ ] Terminal output follows [STYLE.md](../STYLE.md) — tone helpers (no hardcoded colour/emoji), "secure environment" not "workspace"; `bash scripts/check-style.sh` passes
 - [ ] Cross-repo issues use `Fixes tracebloc/<repo>#N` — a bare `repo#N` closes nothing
+- [ ] If this depends on a change in another repo: shipped **expand-then-contract** (additive first, consumers adopt later), or **Breaking change** ticked above with the rollout order in *Deployment notes* — repos promote independently, so the other change may not ship with this one
+- [ ] Terminal output follows [STYLE.md](../STYLE.md) — tone helpers (no hardcoded colour/emoji), "secure environment" not "workspace"; `bash scripts/check-style.sh` passes


### PR DESCRIPTION
Re-baselines this repo's `.github/pull_request_template.md` on the **org template**, keeping only the checks that are genuinely specific to this repo. Implements the recommendation on backend#1373.

This repo is one of just two (with the other of `client`/`cli`) that earns its own template — the other eight are being deleted so they inherit the org one, because their copies were byte-identical, strictly older subsets, or differed only in which repo the cross-repo example named.

**What this changes.** The body is now the org template verbatim, plus the repo-specific checklist lines that were already here. Net effect beyond that:

- picks up the **expand-then-contract** line for cross-repo changes (tracebloc/.github#111);
- picks up the note that **closing keywords don't fire on a `develop` merge** (tracebloc/.github#113) — a caveat this repo had locally, now shared with everyone;
- **restores anything this copy had drifted away from** the shared template.

**Ongoing cost, stated plainly:** because this repo keeps its own file, future org-template changes will *not* reach it automatically — it will need re-baselining again. That is the price of the repo-specific lines, and it is why only two repos keep one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only PR template changes with no runtime, security, or deployment behavior impact.
> 
> **Overview**
> **Re-baselines** this repo’s `.github/pull_request_template.md` on the shared org template, **keeping** the checklist lines that are specific to this repo (cross-repo issue syntax, `STYLE.md` / `check-style.sh`, and related guidance).
> 
> The **Related** comment now uses `tracebloc/client-runtime#456` as the cross-repo example and **adds** that closing keywords do not fire when merging to `develop`, so authors must confirm issues actually closed.
> 
> The checklist **gains** the **expand-then-contract** item for cross-repo dependencies (additive ship first, or mark breaking change with rollout in *Deployment notes*), and the **STYLE.md** terminal-output line is **restored** after having been dropped from this copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e43aaa4613627d3cc2b9f3b4ce28b894bf2677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->