### PR TITLE
fix(chart-guard): cover every published chart, not just client (#519 finding)

### DIFF
--- a/.github/workflows/chart-version-guard.yml
+++ b/.github/workflows/chart-version-guard.yml
@@ -4,6 +4,12 @@
 # staging but never rendered: PR #472 changed the template without bumping
 # Chart.yaml, so the published 1.9.7 stayed stale). This gate makes the bump
 # non-optional.
+#
+# The logic lives in scripts/chart-version-guard.sh so that it can be TESTED:
+# scripts/tests/chart-version-guard.bats runs under the required `Unit tests`
+# check, which this workflow is not. Keeping it inline is why the guard's own
+# coverage gap went unnoticed (client#519 — it classified only client/**, while
+# release-helm-chart.yaml also packages ./ingestor into the same index.yaml).
 name: Chart version guard
 
 on:
@@ -22,59 +28,7 @@ jobs:
           fetch-depth: 0
       - name: Require a Chart.yaml version bump when chart content changes
         env:
+          # A SHA, not attacker-controlled text — and read via env, never
+          # interpolated into the run: body.
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          set -euo pipefail
-
-          # Fail CLOSED on an unusable base: without a diff we cannot know whether
-          # chart content changed, and "don't know" must never read as "nothing
-          # changed" — that is the same dark ship the gate exists to stop.
-          if [[ -z "${BASE_SHA:-}" ]]; then
-            echo "::error::Chart version guard could not determine the PR base SHA — refusing to report N/A without checking."
-            exit 1
-          fi
-          if ! changed="$(git diff --name-only "${BASE_SHA}...HEAD")"; then
-            echo "::error::Chart version guard could not diff ${BASE_SHA}...HEAD — refusing to report N/A without checking."
-            exit 1
-          fi
-
-          # Classify with bash builtins — NOT `printf … | grep -q`. Under the
-          # `set -o pipefail` above, `grep -q` closes the pipe on its FIRST match,
-          # so once the changed-file list passes the ~64KB pipe buffer `printf`
-          # takes SIGPIPE, the pipeline exits 141, and `if ! <pipeline>` reads a
-          # REAL client/templates/** change as "guard N/A" — silently skipping the
-          # bump check. Measured on ubuntu-24.04 (bash 5.2.21 / GNU grep 3.11):
-          # 65,622 bytes of paths already flips it. The mirror case is just as bad:
-          # a SIGPIPE on the `grep -qx 'client/Chart.yaml'` MATCH short-circuits the
-          # `&&` and fails a PR that did bump the version. No pipe here ⇒ neither is
-          # reachable, and no `|| true` (which would re-introduce a fail-open).
-          chart_content=0
-          chart_yaml=0
-          while IFS= read -r path; do
-            # Disjoint patterns, so one `case` covers both and always exits 0 —
-            # a `[[ … ]] && var=1` tail would itself trip `set -e` on a non-match.
-            case "$path" in
-              client/templates/*|client/values.yaml*) chart_content=1 ;;
-              client/Chart.yaml)                      chart_yaml=1 ;;
-            esac
-          done <<< "$changed"
-
-          if (( ! chart_content )); then
-            echo "No chart template/values change in this PR — guard N/A."
-            exit 0
-          fi
-          if (( chart_yaml )); then
-            if ! chart_diff="$(git diff "${BASE_SHA}...HEAD" -- client/Chart.yaml)"; then
-              echo "::error::Chart version guard could not diff client/Chart.yaml — refusing to pass without checking."
-              exit 1
-            fi
-            while IFS= read -r line; do
-              case "$line" in
-                '+version:'*)
-                  echo "Chart content changed and client/Chart.yaml 'version:' was bumped. ✓"
-                  exit 0 ;;
-              esac
-            done <<< "$chart_diff"
-          fi
-          echo "::error::client/templates/** or client/values.yaml changed, but client/Chart.yaml 'version:' was NOT bumped. A Helm chart repo publishes only on a version change, so an unbumped edit reaches no installs (this is how the perIngestionTables flag block shipped dark — PR #472). Bump client/Chart.yaml version in this PR."
-          exit 1
+        run: bash scripts/chart-version-guard.sh

--- a/scripts/chart-version-guard.sh
+++ b/scripts/chart-version-guard.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+#  chart-version-guard.sh — chart content ⇒ Chart.yaml version bump
+#
+#  Chart content can only reach installs via a NEW chart version: a Helm repo
+#  publishes on version change, so an unbumped template/values edit reaches
+#  nobody. This is exactly how the perIngestionTables flag block shipped to
+#  staging but never rendered — PR #472 changed the template without bumping
+#  Chart.yaml, so the published 1.9.7 stayed stale. This guard makes the bump
+#  non-optional.
+#
+#  THIS REPO PUBLISHES TWO CHARTS, and they are not symmetric:
+#
+#    • client   — packaged as `helm package ./client --version "${TAG#v}"`, so
+#                 its published version comes from the release TAG, which the
+#                 release train derives from client/Chart.yaml `version:`.
+#                 Bumping Chart.yaml is what moves the tag.
+#    • ingestor — packaged as `helm package ./ingestor` with NO --version, so
+#                 its published version IS ingestor/Chart.yaml `version:`. An
+#                 unbumped edit therefore does NOT go nowhere: it OVERWRITES an
+#                 already-published version. `git add ingestor-*.tgz` replaces
+#                 the tarball at the same filename and `helm repo index --merge`
+#                 refreshes that version's digest in place, so 0.2.0 becomes a
+#                 mutable, drifting version. Measured 2026-07-31: 6 of 9 commits
+#                 touching ingestor chart content never bumped Chart.yaml, and
+#                 ingestor-0.2.0.tgz has been overwritten 5× since the last bump
+#                 on 2026-05-20. Two installs of "0.2.0" months apart are not
+#                 the same chart, and Helm caches by version, so an existing
+#                 client may never pick the change up at all.
+#
+#  Both .tgz files land in ONE shared index.yaml, so both need the guard. The
+#  chart list is DERIVED from release-helm-chart.yaml rather than hardcoded:
+#  the first version of this guard hardcoded only `client` and therefore missed
+#  every ingestor/** change (client#519). Deriving it from the workflow that
+#  actually packages means a third chart is guarded the day it is published.
+#
+#  Usage: BASE_SHA=<pr base sha> bash scripts/chart-version-guard.sh
+#
+set -euo pipefail
+
+RELEASE_WORKFLOW="${RELEASE_WORKFLOW:-.github/workflows/release-helm-chart.yaml}"
+
+# Fail CLOSED on an unusable base: without a diff we cannot know whether chart
+# content changed, and "don't know" must never read as "nothing changed" — that
+# is the same dark ship the guard exists to stop.
+if [[ -z "${BASE_SHA:-}" ]]; then
+  echo "::error::Chart version guard could not determine the PR base SHA — refusing to report N/A without checking."
+  exit 1
+fi
+if ! changed="$(git diff --name-only "${BASE_SHA}...HEAD")"; then
+  echo "::error::Chart version guard could not diff ${BASE_SHA}...HEAD — refusing to report N/A without checking."
+  exit 1
+fi
+
+# Which charts does the release actually package? Fail closed on an empty or
+# unreadable parse — a guard that cannot tell what is published must not claim
+# the PR is clean.
+if ! charts="$(grep -oE 'helm package \./[A-Za-z0-9_.-]+' "$RELEASE_WORKFLOW" \
+                 | sed -E 's|.*\./||' | sort -u)" || [[ -z "$charts" ]]; then
+  echo "::error::Chart version guard could not read the packaged chart list from ${RELEASE_WORKFLOW} — refusing to pass without checking. If the release workflow moved, update RELEASE_WORKFLOW in scripts/chart-version-guard.sh."
+  exit 1
+fi
+for chart in $charts; do
+  if [[ ! -f "$chart/Chart.yaml" ]]; then
+    echo "::error::${RELEASE_WORKFLOW} packages ./${chart} but ${chart}/Chart.yaml does not exist — refusing to guess which version file governs it."
+    exit 1
+  fi
+done
+
+# Does this path change what an install renders or validates?
+#
+# .helmignore in both charts excludes only editor/VCS junk, so everything else
+# in the chart dir is packaged. Only these paths change install behaviour:
+#   templates/**        rendered manifests
+#   values.yaml         defaults
+#   values.schema.json  Helm validates user values against the PACKAGED schema
+#   charts/**, crds/**  subcharts and CRDs (none today; covered pre-emptively so
+#                       adding one is not a fresh hole)
+# Deliberately NOT content: ci/** and tests/** (chart-testing inputs — packaged
+# but never rendered by an install) and *.md.
+is_chart_content() { # $1 = chart, $2 = path
+  case "$2" in
+    "$1"/templates/*|"$1"/charts/*|"$1"/crds/*|"$1"/values.yaml|"$1"/values.schema.json) return 0 ;;
+  esac
+  return 1
+}
+
+# Did this PR change the chart's `version:` line?
+#
+# Read with bash builtins over a captured diff — NOT `printf … | grep -q`. Under
+# `set -o pipefail`, `grep -q` closes the pipe on its FIRST match, so once the
+# input passes the ~64KB pipe buffer `printf` takes SIGPIPE, the pipeline exits
+# 141, and `if ! <pipeline>` reads a REAL change as "guard N/A" — silently
+# skipping the bump check. Measured on ubuntu-24.04 (bash 5.2.21 / GNU grep
+# 3.11): 65,622 bytes of paths already flips it. The mirror case is just as bad:
+# a SIGPIPE on the MATCH short-circuits and fails a PR that DID bump. No pipe
+# here ⇒ neither is reachable, and no `|| true` (which would re-introduce a
+# fail-open).
+version_bumped() { # $1 = chart
+  local file="$1/Chart.yaml"
+  local file_diff line
+  if ! file_diff="$(git diff "${BASE_SHA}...HEAD" -- "$file")"; then
+    echo "::error::Chart version guard could not diff ${file} — refusing to pass without checking."
+    exit 1
+  fi
+  while IFS= read -r line; do
+    case "$line" in
+      '+version:'*) return 0 ;;
+    esac
+  done <<< "$file_diff"
+  return 1
+}
+
+# Classify every changed path per chart. One `case` per chart, and `case` with no
+# matching pattern exits 0 — a `[[ … ]] && var=1` tail would itself trip `set -e`
+# on a non-match.
+touched=''
+while IFS= read -r path; do
+  for chart in $charts; do
+    if is_chart_content "$chart" "$path"; then
+      case " $touched " in
+        *" $chart "*) ;;
+        *) touched="${touched}${chart} " ;;
+      esac
+    fi
+  done
+done <<< "$changed"
+
+if [[ -z "${touched// /}" ]]; then
+  echo "No packaged chart content changed in this PR — guard N/A."
+  exit 0
+fi
+
+# Report EVERY unbumped chart, not just the first: a PR touching both charts
+# should see both in one run rather than one per push.
+rc=0
+for chart in $touched; do
+  if version_bumped "$chart"; then
+    echo "${chart} chart content changed and ${chart}/Chart.yaml 'version:' was bumped. ✓"
+  else
+    echo "::error::${chart}/templates/**, ${chart}/values.yaml or ${chart}/values.schema.json changed, but ${chart}/Chart.yaml 'version:' was NOT bumped. ${RELEASE_WORKFLOW} packages ./${chart} into the shared index.yaml, and a Helm repo only ever publishes a NEW version — so an unbumped edit either reaches no install at all or silently overwrites an already-published one. Both have happened in this repo: the perIngestionTables block shipped dark (PR #472), and ingestor-0.2.0.tgz was overwritten 5× between 2026-05-20 and 2026-07-29. Bump ${chart}/Chart.yaml 'version:' in this PR."
+    rc=1
+  fi
+done
+exit "$rc"

--- a/scripts/tests/chart-version-guard.bats
+++ b/scripts/tests/chart-version-guard.bats
@@ -1,0 +1,272 @@
+#!/usr/bin/env bats
+# Tests for scripts/chart-version-guard.sh — "chart content ⇒ Chart.yaml version
+# bump". Covers BOTH published charts (client#519: the first version of the guard
+# classified only client/** and therefore let every unbumped ingestor/** edit
+# through, which is the same dark ship it was written to stop — PR #472), the
+# derived chart list, and every fail-closed read.
+#
+# These run against a REAL throwaway git repo, not a stubbed `git`: the guard's
+# whole job is reading a diff correctly, so stubbing the diff would test the stub.
+
+GUARD_SH=""
+BASE=""
+
+setup() {
+  GUARD_SH="${BATS_TEST_DIRNAME}/../chart-version-guard.sh"
+  cd "$BATS_TEST_TMPDIR" || return 1
+  rm -rf repo && mkdir repo && cd repo || return 1
+
+  git init -q -b main .
+  git config user.email guard@test.local
+  git config user.name  guard-test
+
+  mkdir -p .github/workflows client/templates client/ci client/tests ingestor/templates
+  seed_workflow './client --version "${TAG#v}" --app-version "${TAG#v}"' './ingestor'
+  printf 'name: client\nversion: 1.9.9\nappVersion: "1.9.9"\n'   >client/Chart.yaml
+  printf 'name: ingestor\nversion: 0.2.0\nappVersion: "0.3.0"\n' >ingestor/Chart.yaml
+  printf 'replicas: 1\n'  >client/values.yaml
+  printf 'replicas: 1\n'  >ingestor/values.yaml
+  printf '{"type":"object"}\n' >client/values.schema.json
+  printf 'kind: Deployment\n' >client/templates/app.yaml
+  printf 'kind: Job\n'        >ingestor/templates/job.yaml
+  printf 'aks: true\n'        >client/ci/aks-values.yaml
+  printf 'public: true\n'     >client/tests/values-public-images.yaml
+  printf '# migration notes\n' >client/MIGRATION.md
+  git add -A && git commit -qm base
+  BASE="$(git rev-parse HEAD)"
+}
+
+# Write a release workflow whose `helm package` lines name the given charts.
+seed_workflow() {
+  {
+    printf 'name: Release helm chart\njobs:\n  release:\n    steps:\n      - run: |\n'
+    for spec in "$@"; do printf '          helm package %s\n' "$spec"; done
+  } >.github/workflows/release-helm-chart.yaml
+}
+
+commit()  { git add -A && git commit -qm change; }
+bump()    { sed -i.bak 's/^version: .*/version: 99.0.0/' "$1/Chart.yaml" && rm -f "$1/Chart.yaml.bak"; }
+guard()   { run env BASE_SHA="$BASE" bash "$GUARD_SH"; }
+
+# ── the client#519 regression: ingestor is a published chart too ─────────────
+
+@test "ingestor/templates change without a bump is REJECTED (client#519)" {
+  printf 'kind: Job\nnew: true\n' >ingestor/templates/job.yaml
+  commit
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ingestor/Chart.yaml 'version:' was NOT bumped"* ]]
+}
+
+@test "ingestor/templates change WITH an ingestor bump passes" {
+  printf 'kind: Job\nnew: true\n' >ingestor/templates/job.yaml
+  bump ingestor
+  commit
+  guard
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ingestor chart content changed and ingestor/Chart.yaml 'version:' was bumped"* ]]
+}
+
+@test "ingestor/values.yaml change without a bump is REJECTED" {
+  printf 'replicas: 3\n' >ingestor/values.yaml
+  commit
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ingestor/Chart.yaml"* ]]
+}
+
+@test "deleting an ingestor template without a bump is REJECTED" {
+  git rm -q ingestor/templates/job.yaml
+  commit
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ingestor/Chart.yaml"* ]]
+}
+
+@test "bumping the WRONG chart does not satisfy the other chart" {
+  printf 'kind: Job\nnew: true\n' >ingestor/templates/job.yaml
+  bump client            # client bumped, ingestor is the one that changed
+  commit
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ingestor/Chart.yaml 'version:' was NOT bumped"* ]]
+}
+
+# ── client chart: preserved behaviour + the newly covered schema ─────────────
+
+@test "client/templates change without a bump is REJECTED" {
+  printf 'kind: Deployment\nnew: true\n' >client/templates/app.yaml
+  commit
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"client/Chart.yaml 'version:' was NOT bumped"* ]]
+}
+
+@test "client/templates change WITH a client bump passes" {
+  printf 'kind: Deployment\nnew: true\n' >client/templates/app.yaml
+  bump client
+  commit
+  guard
+  [ "$status" -eq 0 ]
+}
+
+@test "client/values.schema.json change without a bump is REJECTED" {
+  printf '{"type":"object","required":["x"]}\n' >client/values.schema.json
+  commit
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"client/Chart.yaml 'version:' was NOT bumped"* ]]
+}
+
+@test "an appVersion-only edit is NOT a version bump" {
+  printf 'kind: Deployment\nnew: true\n' >client/templates/app.yaml
+  sed -i.bak 's/^appVersion: .*/appVersion: "2.0.0"/' client/Chart.yaml && rm -f client/Chart.yaml.bak
+  commit
+  guard
+  [ "$status" -eq 1 ]
+}
+
+# ── both charts in one PR ────────────────────────────────────────────────────
+
+@test "both charts changed, neither bumped: BOTH are reported in one run" {
+  printf 'kind: Deployment\nnew: true\n' >client/templates/app.yaml
+  printf 'kind: Job\nnew: true\n'        >ingestor/templates/job.yaml
+  commit
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"client/Chart.yaml 'version:' was NOT bumped"*   ]]
+  [[ "$output" == *"ingestor/Chart.yaml 'version:' was NOT bumped"* ]]
+}
+
+@test "both charts changed, only one bumped: fails naming just the unbumped one" {
+  printf 'kind: Deployment\nnew: true\n' >client/templates/app.yaml
+  printf 'kind: Job\nnew: true\n'        >ingestor/templates/job.yaml
+  bump client
+  commit
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"client chart content changed and client/Chart.yaml 'version:' was bumped"* ]]
+  [[ "$output" == *"ingestor/Chart.yaml 'version:' was NOT bumped"* ]]
+}
+
+@test "both charts changed and both bumped passes" {
+  printf 'kind: Deployment\nnew: true\n' >client/templates/app.yaml
+  printf 'kind: Job\nnew: true\n'        >ingestor/templates/job.yaml
+  bump client
+  bump ingestor
+  commit
+  guard
+  [ "$status" -eq 0 ]
+}
+
+# ── not chart content ────────────────────────────────────────────────────────
+
+@test "docs-only change is N/A" {
+  printf '# migration notes\nmore\n' >client/MIGRATION.md
+  commit
+  guard
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"guard N/A"* ]]
+}
+
+@test "ci/ and tests/ values are packaged but never rendered: N/A" {
+  printf 'aks: false\n'    >client/ci/aks-values.yaml
+  printf 'public: false\n' >client/tests/values-public-images.yaml
+  commit
+  guard
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"guard N/A"* ]]
+}
+
+@test "a Chart.yaml bump with no content change is N/A, not an error" {
+  bump client
+  commit
+  guard
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"guard N/A"* ]]
+}
+
+# ── the chart list is DERIVED, so a new published chart is guarded on day one ─
+
+@test "a third packaged chart is guarded without touching the guard" {
+  mkdir -p extra/templates
+  printf 'name: extra\nversion: 0.1.0\n' >extra/Chart.yaml
+  printf 'kind: ConfigMap\n'             >extra/templates/cm.yaml
+  seed_workflow './client' './ingestor' './extra'
+  commit
+  BASE="$(git rev-parse HEAD)"          # the chart now exists on both sides
+
+  printf 'kind: ConfigMap\nnew: true\n' >extra/templates/cm.yaml
+  commit
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"extra/Chart.yaml 'version:' was NOT bumped"* ]]
+}
+
+@test "a chart removed from the release workflow stops being guarded" {
+  seed_workflow './client'              # ingestor no longer published
+  printf 'kind: Job\nnew: true\n' >ingestor/templates/job.yaml
+  commit
+  guard
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"guard N/A"* ]]
+}
+
+# ── fail closed: a guard that cannot verify must not claim it did ────────────
+
+@test "missing BASE_SHA fails closed" {
+  run env -u BASE_SHA bash "$GUARD_SH"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"could not determine the PR base SHA"* ]]
+}
+
+@test "unusable BASE_SHA fails closed" {
+  run env BASE_SHA=0000000000000000000000000000000000000000 bash "$GUARD_SH"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"refusing to report N/A without checking"* ]]
+}
+
+@test "an absent release workflow fails closed" {
+  git rm -q .github/workflows/release-helm-chart.yaml
+  printf 'kind: Job\nnew: true\n' >ingestor/templates/job.yaml
+  commit
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"could not read the packaged chart list"* ]]
+}
+
+@test "a release workflow that packages nothing fails closed" {
+  printf 'name: Release\njobs: {}\n' >.github/workflows/release-helm-chart.yaml
+  printf 'kind: Job\nnew: true\n'    >ingestor/templates/job.yaml
+  commit
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"could not read the packaged chart list"* ]]
+}
+
+@test "a packaged chart with no Chart.yaml fails closed" {
+  seed_workflow './client' './ingestor' './ghost'
+  commit
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ghost/Chart.yaml does not exist"* ]]
+}
+
+# ── the SIGPIPE class this guard must never regress into ────────────────────
+
+@test "a changed-file list past the 64KB pipe buffer still catches the bump" {
+  mkdir -p docs/filler
+  i=0
+  while [ "$i" -lt 2200 ]; do
+    : >"docs/filler/padding-file-with-a-deliberately-long-name-${i}.md"
+    i=$((i + 1))
+  done
+  printf 'kind: Job\nnew: true\n' >ingestor/templates/job.yaml
+  commit
+  # Prove the list really is past the buffer that flipped the old pipeline.
+  bytes="$(git diff --name-only "${BASE}...HEAD" | wc -c)"
+  [ "$bytes" -gt 65622 ]
+  guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ingestor/Chart.yaml 'version:' was NOT bumped"* ]]
+}


### PR DESCRIPTION
## Summary

Bugbot flagged on the develop→staging promotion PR #519 that the new chart
version guard classifies only `client/templates/*` and `client/values.yaml*`,
while `release-helm-chart.yaml` also packages `./ingestor`. The finding is
correct, and the gap is worse than "an edit is unguarded".

`helm package ./client --version "${TAG#v}"` overrides client's version from the
release tag, but `helm package ./ingestor` (line 132) has **no override** — so
ingestor's published version *is* `ingestor/Chart.yaml` `version:`.

Measured on `develop` today:

| fact | value |
|---|---|
| commits touching `ingestor/templates` or `ingestor/values.yaml` | 9 |
| of those, commits that never bumped `ingestor/Chart.yaml` | **6** |
| `ingestor/Chart.yaml` `version:` | `0.2.0` on develop, staging **and** main |
| last bump | 2026-05-20 |
| times `ingestor-0.2.0.tgz` was overwritten on `gh-pages` since | **5** (07-14, 07-16, 07-27, 07-29 ×2) |
| index digest vs live tarball | matches (`81162cd5…`, `created: 2026-07-29`) |

So the unbumped edits did not vanish — `git add ingestor-*.tgz` replaced the
tarball at the same filename and `helm repo index --merge` refreshed that
version's digest in place. **`0.2.0` is a mutable, drifting version:** two
installs of "ingestor 0.2.0" months apart are not the same chart, nobody can
reproduce an install from a version number, and because Helm caches by version
an existing client may never pick the change up at all. Four content changes
since the last bump are affected, including "move the prod ingestor pin into
chart defaults" (2026-07-27).

## What changed

- **The chart list is derived, not hardcoded.** It is parsed from the release
  workflow's `helm package ./X` lines — hardcoding one chart is precisely how
  this gap happened, so a third published chart is now guarded on day one.
- **Each chart requires a bump of its own `Chart.yaml`.** Bumping `client` no
  longer satisfies an `ingestor` change.
- **`client/values.schema.json` is now content** — it is packaged, and Helm
  validates user values against the *packaged* schema at install time. `charts/**`
  and `crds/**` are covered pre-emptively so adding a subchart isn't a new hole.
- **Every unbumped chart is reported in one run**, not one per push.
- **Fails closed** when the chart list can't be read, or a packaged chart has no
  `Chart.yaml`.
- Deliberately *not* content: `ci/**` and `tests/**` (chart-testing inputs —
  packaged but never rendered by an install) and `*.md`.

## Why it moved to a script

`scripts/tests/chart-version-guard.bats` runs under the **required `Unit tests`**
check. The `Chart version guard` workflow itself is **not** a required check on
`develop`, so inline logic could not be covered by any gate — which is why its
own coverage gap went unnoticed.

## Test plan

- `bats scripts/tests/chart-version-guard.bats` → **23/23 pass**. Real throwaway
  git repo, no stubbed `git`: the guard's whole job is reading a diff correctly,
  so stubbing the diff would only test the stub.
- **13 of the 23 fail against the previous inline logic** (reconstructed and run
  side by side): every ingestor case, the schema case, the derived-list cases and
  the workflow-parse fail-closed reads. The 10 that pass on both are the
  client-side semantics, deliberately unchanged.
- Includes a >64KB changed-file list case asserting the SIGPIPE class this guard
  must never regress into (`bytes > 65622`, the measured flip point).
- Full repo suite: **713 tests, 0 failures**. `bash -n` clean, `shellcheck
  --severity=warning` clean, `scripts/check-style.sh` clean, `actionlint` clean.

## Follow-ups (not in this PR)

1. **`ingestor 0.2.0` is already drifted.** This guard prevents the next
   occurrence; it does not make current content addressable. A bump to `0.3.0`
   would give today's chart a version of its own.
2. **`Chart version guard` is armed but not enrolled** — not a required check on
   `develop`, so an unbumped edit can still merge. Same class as `quality /
   format`. Branch protection is an admin change.
3. The guard accepts any `version:` change, including a **downgrade**. Related to
   backend#1312.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI merge gates for Helm releases; impact is limited by fail-closed behavior and broad bats coverage, but a bug could block valid PRs or miss unbumped chart edits.
> 
> **Overview**
> Fixes **client#519** by moving the PR chart version guard out of the workflow into **`scripts/chart-version-guard.sh`** and widening what it enforces.
> 
> The guard no longer assumes only **`client`**: it **parses `helm package ./…` from the release workflow** so **`ingestor`** (and any future packaged chart) gets the same rule. Chart content now includes **`values.schema.json`** plus **`charts/**` and `crds/**`**, each chart must bump **its own** `Chart.yaml` `version:` (not `appVersion`), and a PR that touches multiple charts gets **every** missing bump reported in one run. Unparseable release config or missing `Chart.yaml` **fails closed** instead of skipping the check.
> 
> The GitHub workflow only sets **`BASE_SHA`** and runs the script. **`scripts/tests/chart-version-guard.bats`** adds regression coverage (ingestor, derived chart list, SIGPIPE on huge diffs, fail-closed paths) under the required unit-test gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 243711171019e0c2bc305561ce919494a20ceeb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->