### PR TITLE
docs: retire the fixed-assignee rule (it names a former code owner)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,4 +20,6 @@ Integration branch for this repo (and all tracebloc repos) is `develop`, not `ma
 
 ## PR conventions
 
-Every PR you create must be assigned to `saadqbal` (Asad). Pass `--assignee @me` on `gh pr create`, or `--assignee saadqbal` if running unauthenticated. No exceptions — orphaned PRs without an assignee fall through the review queue.
+Every PR must be assigned to **whoever is doing the work** — the author sets it when opening the PR. Assignee and reviewer are different roles: the assignee owns getting it merged, the reviewer owns judging it. On handover the assignee changes; the author does not (RFC-BACKEND-0008 D31).
+
+Do not default the assignee to one person. This file used to name `saadqbal` unconditionally, from when he was the de-facto code owner here; that is no longer true, and a fixed assignee re-creates exactly the bystander effect the author-picks model was adopted to remove. Reviewer assignment is also the author's call — there is no automation that picks one.


### PR DESCRIPTION
## Summary

`CLAUDE.md` instructed every author to assign **every** PR in this repo to `saadqbal`, unconditionally:

> Every PR you create must be assigned to `saadqbal` (Asad). … No exceptions

That was accurate when Asad was the de-facto code owner here. It is legacy now, and it conflicts with two things that supersede it:

- **RFC-BACKEND-0008 D31** — the assignee is *whoever is doing the work*, set by the author when the PR is opened. Assignee and reviewer are different roles.
- The org-level `CLAUDE.md`, which says the same.

It also has a practical cost: a fixed assignee re-creates the bystander effect the author-picks model was adopted to remove. If every PR is assigned to the same person, nobody owns any of them — which is the opposite of the rule's stated intent ("orphaned PRs fall through the review queue").

Surfaced while an agent working in this repo hit the contradiction directly: repo `CLAUDE.md` said `saadqbal`, the task said the actual worker.

## Change

One paragraph in `CLAUDE.md` → the D31 rule, plus a note on *why* the old line existed so nobody restores it.

## Test plan

Documentation only. No workflow, script, chart or installer file touched.

Refs: tracebloc/backend#1405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor guidance; no workflows, scripts, or runtime behavior.
> 
> **Overview**
> **PR conventions** in `CLAUDE.md` no longer require every PR to be assigned to `saadqbal`. The rule now matches **RFC-BACKEND-0008 D31**: the author assigns **whoever is doing the work**, and assignee (merge ownership) is separate from reviewer.
> 
> A second paragraph explains why the old fixed assignee existed and warns against restoring it, since a single default assignee undermines the author-picks model and recreates bystander effects. Reviewer choice stays with the author; there is no automated reviewer pick.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5865e762605756cdb26b655c9ad91401cc371d8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->