### PR TITLE
chore(release): bump chart to 1.9.10 after the v1.9.9 release

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.9
-appVersion: "1.9.9"
+version: 1.9.10
+appVersion: "1.9.10"
 keywords:
   - tracebloc
   - kubernetes


### PR DESCRIPTION
## Why

`v1.9.9` shipped to `main` this morning — tag, GitHub Release, and the Helm chart published to the public index. `client/Chart.yaml` still said `1.9.9`, so **the next `develop → staging` hop would have refused before merging anything**:

```
NOT tagged - v1.9.9 already exists (bump client/Chart.yaml on develop before the next release)
```

Same refusal `data-ingestors`, `design-system` and `tracebloc-py-package` hit in today's prod hop. Correct behaviour — the train will not mint a duplicate tag — but avoidable here.

For this repo it matters more than most: a Helm repo only ever publishes a **new** version, so an unbumped chart edit either reaches no install at all or silently overwrites an already-published one. Both have happened here (`#472`'s dark ship; `ingestor-0.2.0.tgz` overwritten 5×).

## Scope

`version` and `appVersion` move together, as they have for every release in this repo. No chart content touched, so `chart-version-guard` reports N/A.

`1.9.10` is a **floor**, not a judgement about what comes next — raise it to `1.10.0` if the next release carries features.

Refs: tracebloc/backend#1405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no chart logic or deployment behavior changes.
> 
> **Overview**
> Bumps **`client/Chart.yaml`** **`version`** and **`appVersion`** from **1.9.9** to **1.9.10** so the next release train can tag and publish without colliding with the shipped **v1.9.9** chart. No templates, values, or other chart content changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9d379c654d3644aac4f07a075d46065f06e2b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->