### PR TITLE
test(netpol): characterize the locked-down egress policy (RFC-0003 D6, #199-1)

### DIFF
--- a/client/tests/network_policy_test.yaml
+++ b/client/tests/network_policy_test.yaml
@@ -145,6 +145,7 @@ tests:
       networkPolicy:
         training:
           enabled: true
+          allowExternalHttps: true  # pin the default — this asserts the rule-2 hole
           dnsNamespace: kube-system
           dnsSelector:
             k8s-app: kube-dns
@@ -176,6 +177,7 @@ tests:
       networkPolicy:
         training:
           enabled: true
+          allowExternalHttps: true  # pin: MySQL sits at egress[2] only while rule 2 renders
           dnsNamespace: kube-system
           dnsSelector:
             k8s-app: kube-dns
@@ -199,6 +201,7 @@ tests:
       networkPolicy:
         training:
           enabled: true
+          allowExternalHttps: true  # pin: asserts rule 2's except-block at egress[1]
           dnsNamespace: openshift-dns
           dnsSelector:
             dns.operator.openshift.io/daemonset-dns: default
@@ -221,3 +224,53 @@ tests:
       - contains:
           path: spec.egress[1].to[0].ipBlock.except
           content: 172.30.0.0/16
+
+  # RFC-0003 D6 (#199): characterize the LOCKED-DOWN policy so the default flip
+  # (#199-2) has a regression net. When allowExternalHttps is false the rule-2
+  # external-HTTPS hole drops and the remaining allowlist (MySQL, requests-proxy,
+  # egress-proxy) carries training.
+  - it: locks down external HTTPS — rule-2 hole drops, allowlist survives (allowExternalHttps false)
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          allowExternalHttps: false
+          dnsNamespace: kube-system
+          dnsSelector:
+            k8s-app: kube-dns
+          clusterCidrs:
+            - 10.0.0.0/8
+    asserts:
+      # the 0.0.0.0/0 external rule is gone — MySQL shifts up from egress[2] to egress[1]
+      - equal:
+          path: spec.egress[1].to[0].podSelector.matchLabels.app
+          value: mysql-client
+      # requests-proxy egress is UNCONDITIONAL — pods must still POST results/FLOPs (8888)
+      - equal:
+          path: spec.egress[2].to[0].podSelector.matchLabels.app
+          value: requests-proxy
+      - contains:
+          path: spec.egress[2].ports
+          content:
+            port: 8888
+            protocol: TCP
+
+  - it: locked down — renders the egress-proxy allowlist rule when egressProxy is enabled
+    set:
+      networkPolicy:
+        training:
+          enabled: true
+          allowExternalHttps: false
+          clusterCidrs:
+            - 10.0.0.0/8
+      egressProxy:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.egress[3].to[0].podSelector.matchLabels.app
+          value: egress-proxy
+      - contains:
+          path: spec.egress[3].ports
+          content:
+            port: 3128
+            protocol: TCP


### PR DESCRIPTION
## Summary

**#199, PR 1 of the egress-lockdown work** — test-only, no behavior change. It's the regression net so the actual default flip (#199-2) is a green-to-green change.

The egress mechanism is already fully shipped (squid gateway, the `allowExternalHttps` gate, jobs-manager proxy injection, the seal-check enforcement probe — client-runtime#102 / client#378). #199 is just making deny-by-default the *shipped default*. Flipping `allowExternalHttps` to `false` drops the rule-2 external-HTTPS hole, so the egress rule **indices shift**.

This PR pins the current behavior and characterizes the locked-down state:
- **Pins `allowExternalHttps: true`** in the three cases that assert the rule-2 hole or a rule-2-dependent index (external-443, MySQL, OpenShift) — so they survive the flip.
- **Two new locked-down cases** (`allowExternalHttps: false`): the `0.0.0.0/0` rule is gone (MySQL shifts `egress[2] → egress[1]`); the **unconditional** requests-proxy egress (`8888`) survives so pods still POST results/FLOPs; the egress-proxy allowlist rule (`3128`) renders under `egressProxy.enabled`.

## Tests
**13** network-policy tests (was 11), **322** helm suite green.

Track: #199 — PR-1 (tests) lands anytime · PR-2 (the 4-line flip) is gated on the dev→staging→prod fleet pin-rollout. Epic: backend#1151 (D6).

> Note on assignee: per your epic-ownership call I've assigned this to you; the client-repo convention is `saadqbal` — reassign if you'd rather follow the repo default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Helm unit tests in `network_policy_test.yaml`; no template or runtime behavior changes.
> 
> **Overview**
> **Test-only** prep for RFC-0003 D6 / #199: no chart behavior changes; this is the regression net before `allowExternalHttps` defaults to `false` in a follow-up PR.
> 
> Existing **network-policy** cases that assert the rule-2 external HTTPS hole (`0.0.0.0/0` at `egress[1]`) or rules that sit after it (MySQL at `egress[2]`, OpenShift except blocks) now **explicitly set `allowExternalHttps: true`** so they stay valid when the default changes.
> 
> Two new cases with **`allowExternalHttps: false`** document the locked-down shape: the broad external-443 rule is absent (MySQL moves to `egress[1]`), **requests-proxy** on **8888** remains, and with **`egressProxy.enabled`** the **egress-proxy** rule on **3128** appears at `egress[3]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31325bd5f6955dbf0862d958d23d7bb20e473d25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->