### PR TITLE
fix(release): pin the verify-index checkout to the released tag

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -452,7 +452,17 @@ jobs:
     permissions:
       contents: read   # read index.yaml from gh-pages via the API
     steps:
-      - uses: actions/checkout@v4   # for scripts/index-invariants.sh
+      # Pinned and ref'd exactly like the three sibling jobs in this workflow.
+      # Bare `@v4` with no ref (Bugbot, client#534): on a `release: published` run
+      # github.ref intermittently arrives empty (actions/runner#2788), and checkout
+      # then falls back to the DEFAULT BRANCH -- so this backstop would verify the
+      # published index using whatever index-invariants.sh is on develop, not the
+      # one that shipped. A post-publish check reading a different script than the
+      # release is worse than no check, because it still reports.
+      - name: Check out the released tag (for scripts/index-invariants.sh)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
       - name: Assert the public index holds only stable versions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The bug

`verify-index` (added in #532) checks out with bare `actions/checkout@v4` and **no `ref`**. All three sibling jobs in this same workflow use a SHA-pinned checkout *and* `ref: ${{ github.event.release.tag_name }}`:

| job | pinned | ref |
|---|---|---|
| `verify` | ✅ `34e1148…` | ✅ tag |
| `release` | ✅ `34e1148…` | ✅ tag |
| `sign-installer-manifest` | ✅ `34e1148…` | ✅ tag |
| **`verify-index`** | ❌ `@v4` | ❌ **none** |

On a `release: published` run `github.ref` intermittently arrives empty ([actions/runner#2788](https://github.com/actions/runner/issues/2788), still open — the `release` job's own comment already documents this), and checkout then falls back to the **default branch**. So the post-publish index backstop would verify the published index using whatever `scripts/index-invariants.sh` happens to be on `develop`, not the one that shipped — or fail to find it at all.

That matters more than a normal drift: a backstop reading a different script than the release **still reports**, so it looks like it verified something. Same shape as the SIGPIPE bug in #532 that this very job exists to have fixed.

## Fix

Two lines: same pinned SHA and same `ref` as its three siblings. All four checkouts in the workflow are now identical.

## Why on `develop`

Found by Bugbot on `client#534`, the `develop → staging` promotion PR. At the **staging** hop the policy is fix, not ticket — the fix path is cheap there. Fixes go on the source branch and `stage=prepare` carries them forward; nothing is pushed to the train's mirror.

Note this workflow only runs on `release: published`, so it plays no part in a staging hop — but it is squarely on the **prod** publish path, which is where it would have bitten.

Refs: tracebloc/backend#1426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change on the prod release path; no runtime or customer-facing code changes.
> 
> **Overview**
> Aligns the **`verify-index`** post-publish job with **`verify`**, **`release`**, and **`sign-installer-manifest`**: it now uses the SHA-pinned `actions/checkout` and **`ref: ${{ github.event.release.tag_name }}`** instead of bare `@v4` with no ref.
> 
> That closes a gap where empty **`github.ref`** on `release: published` runs could check out the default branch, so **`scripts/index-invariants.sh`** might not be the version that shipped—while the job still reported success or failure as if it had validated the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cf5e78dc67132f39c9b96c9ea74a1291b8c943c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->