### PR TITLE
feat(#436): real Windows installer e2e on a self-hosted nested-virt runner (RFC D5)

### DIFF
--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -104,10 +104,12 @@ jobs:
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
           Install-Module PSScriptAnalyzer -Force -SkipPublisherCheck -Scope CurrentUser
-          # Both PowerShell entrypoints: the bootstrap (install.ps1, R8 trust root)
-          # and the main installer (install-k8s.ps1).
+          # Both PowerShell entrypoints (the bootstrap install.ps1, R8 trust root, and the
+          # main installer install-k8s.ps1) plus the Windows e2e driver (#436) — the driver
+          # only RUNS on the self-hosted nested-virt runner, but lint it here on every push
+          # so a syntax/verb regression fails fast instead of at the nightly run.
           $issues = @()
-          foreach ($p in 'scripts/install.ps1', 'scripts/install-k8s.ps1') {
+          foreach ($p in 'scripts/install.ps1', 'scripts/install-k8s.ps1', 'scripts/tests/e2e-windows.ps1') {
             $issues += Invoke-ScriptAnalyzer -Path $p -Severity Error,Warning
           }
           if ($issues) { $issues | Format-Table -AutoSize }

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -56,8 +56,11 @@ jobs:
         shell: pwsh
         run: pwsh -NoProfile -File scripts/tests/e2e-windows.ps1
 
-      - name: Upload install log on failure
-        if: failure()
+      - name: Upload install log on any non-success
+        # NOT just failure(): a timeout-minutes hit CANCELS the job (failure() is false), yet
+        # that's exactly when the log matters most. !success() covers failed + cancelled/timed
+        # out; this runs before the teardown below so the log survives the data-dir cleanup.
+        if: ${{ !success() }}
         uses: actions/upload-artifact@v4
         with:
           name: windows-e2e-install-log
@@ -71,6 +74,11 @@ jobs:
         run: |
           # The driver already deletes the cluster in its finally; this is a belt-and-braces
           # net for a driver that died before its finally ran, plus the data-dir cleanup we
-          # deliberately deferred so the log survived for the upload above.
-          try { k3d cluster delete $env:CLUSTER_NAME 2>$null } catch { }
+          # deliberately deferred so the log survived for the upload above. Bound the delete
+          # so a wedged Docker/WSL teardown can't hang the shared runner (#436 Bugbot).
+          try {
+            $p = Start-Process k3d -ArgumentList "cluster","delete",$env:CLUSTER_NAME -NoNewWindow -PassThru
+            $p | Wait-Process -Timeout 120 -ErrorAction SilentlyContinue
+            if (-not $p.HasExited) { $p | Stop-Process -Force -ErrorAction SilentlyContinue }
+          } catch { }
           if ($env:HOST_DATA_DIR) { Remove-Item -Recurse -Force $env:HOST_DATA_DIR -ErrorAction SilentlyContinue }

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -1,0 +1,76 @@
+name: Windows e2e (self-hosted)
+
+# Real end-to-end exercise of the Windows installer (install-k8s.ps1) on a self-hosted
+# runner with NESTED VIRTUALIZATION — the coverage GitHub's windows-latest runners can't
+# give (they can't nest virt, so the PS installer otherwise has only mocked Pester). This
+# is decision D5 of RFC-CLIENT-0003 (#436).
+#
+# SCHEDULE-ONLY (nightly) + manual dispatch — NOT per-PR: the run provisions a real k3d
+# cluster inside WSL2/Docker on a shared, persistent box, so it must not contend with every
+# push. Cost is bounded by being schedule-only + tearing the cluster down every run.
+#
+# ── Runner prerequisites (one-time; see docs/WINDOWS-E2E.md) ───────────────────────────
+#   • a self-hosted Windows runner registered with the labels:  self-hosted, windows, nested-virt
+#   • WSL2 enabled + a nested-virt-capable host (bare metal, or a VM with nested virt on)
+#   • Docker Desktop installed and running (WSL2 backend)
+#   • the runner service account may install user-space tools (kubectl/k3d/helm) + create k3d clusters
+# The e2e VERIFIES Docker is up (it does not reinstall Docker Desktop per run — a persistent
+# runner must not reboot itself nightly).
+
+on:
+  schedule:
+    - cron: '0 4 * * *'      # nightly 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # One Windows e2e at a time per ref — the k3d cluster + WSL state on the shared runner
+  # are not safe to run concurrently. Never cancel a run mid-teardown.
+  group: windows-e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  windows-e2e:
+    name: Windows installer e2e (nested-virt)
+    runs-on: [self-hosted, windows, nested-virt]
+    timeout-minutes: 45
+    env:
+      # Isolated from any real install on the box. HOST_DATA_DIR is resolved in the first
+      # step below (it MUST live under %USERPROFILE% — Confirm-DataDir rejects anything
+      # else — and $USERPROFILE isn't available in the ${{ env }} context, only at runtime).
+      CLUSTER_NAME: tbe2ewin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve isolated data dir (under %USERPROFILE%, per Confirm-DataDir)
+        shell: pwsh
+        run: |
+          # Publish it to $GITHUB_ENV so the driver inherits it AND the artifact/teardown
+          # steps can reference ${{ env.HOST_DATA_DIR }} — all in lockstep with the driver's
+          # own default of $USERPROFILE\.tracebloc-e2e.
+          Add-Content -Path $env:GITHUB_ENV -Value "HOST_DATA_DIR=$env:USERPROFILE\.tracebloc-e2e"
+
+      - name: Run the real installer e2e (credential-free)
+        shell: pwsh
+        run: pwsh -NoProfile -File scripts/tests/e2e-windows.ps1
+
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-e2e-install-log
+          path: ${{ env.HOST_DATA_DIR }}\install-*.log
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Teardown (safety net)
+        if: always()
+        shell: pwsh
+        run: |
+          # The driver already deletes the cluster in its finally; this is a belt-and-braces
+          # net for a driver that died before its finally ran, plus the data-dir cleanup we
+          # deliberately deferred so the log survived for the upload above.
+          try { k3d cluster delete $env:CLUSTER_NAME 2>$null } catch { }
+          if ($env:HOST_DATA_DIR) { Remove-Item -Recurse -Force $env:HOST_DATA_DIR -ErrorAction SilentlyContinue }

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -44,13 +44,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Resolve isolated data dir (under %USERPROFILE%, per Confirm-DataDir)
+      - name: Resolve isolated data dir + tool PATH
         shell: pwsh
         run: |
-          # Publish it to $GITHUB_ENV so the driver inherits it AND the artifact/teardown
-          # steps can reference ${{ env.HOST_DATA_DIR }} — all in lockstep with the driver's
-          # own default of $USERPROFILE\.tracebloc-e2e.
+          # Publish HOST_DATA_DIR to $GITHUB_ENV so the driver inherits it AND the artifact/
+          # teardown steps can reference ${{ env.HOST_DATA_DIR }} — in lockstep with the
+          # driver's own default of $USERPROFILE\.tracebloc-e2e.
           Add-Content -Path $env:GITHUB_ENV -Value "HOST_DATA_DIR=$env:USERPROFILE\.tracebloc-e2e"
+          # Put the installer's tool dir on PATH for LATER steps (the safety-net teardown's
+          # bare `k3d`). Initialize-ToolDir writes the MACHINE PATH, which a fresh step
+          # process doesn't pick up mid-job; GITHUB_PATH does prepend it for later steps (#436 Bugbot).
+          Add-Content -Path $env:GITHUB_PATH -Value "$env:ProgramFiles\tracebloc\bin"
 
       - name: Run the real installer e2e (credential-free)
         shell: pwsh

--- a/docs/WINDOWS-E2E.md
+++ b/docs/WINDOWS-E2E.md
@@ -1,0 +1,32 @@
+# Windows installer e2e — self-hosted runner setup
+
+The nightly **Windows e2e** (`.github/workflows/windows-e2e.yaml`, issue #436 / RFC-CLIENT-0003 **D5**) runs the *real* `install-k8s.ps1` end-to-end on a self-hosted runner. GitHub's `windows-latest` runners can't nest virtualization, so the PowerShell installer otherwise has only mocked Pester coverage — regressions and never-ported behaviors stay green. This job closes that gap: bootstrap → verify Docker/WSL up → install tools → `New-K3dCluster` → credential-free stub discovery → teardown, uploading the install log on failure.
+
+It is **schedule-only** (nightly + manual `workflow_dispatch`), not per-PR, and tears the k3d cluster down every run so the box stays reusable.
+
+## One-time runner setup
+
+1. **A nested-virt-capable Windows host** — bare metal, or a VM with nested virtualization enabled (e.g. Hyper-V "expose virtualization extensions", VMware "Virtualize Intel VT-x/EPT", or a cloud VM SKU that supports nested virt). GitHub-hosted `windows-latest` will **not** work.
+
+2. **WSL2 + Docker Desktop (WSL2 backend), running.** The e2e *verifies* Docker is up; it deliberately does **not** reinstall Docker Desktop or toggle WSL features per run (a persistent runner must not reboot itself nightly). Set Docker Desktop to start on login so the runner always has it available.
+
+3. **Register the runner with these labels** (Settings → Actions → Runners → New self-hosted runner, Windows):
+
+   ```
+   self-hosted, windows, nested-virt
+   ```
+
+   The workflow targets `runs-on: [self-hosted, windows, nested-virt]` — all three labels must be present.
+
+4. **Runner account rights:** the runner service account must be able to install user-space tools (`kubectl` / `k3d` / `helm`) and create k3d clusters (Docker access). Running the runner as a user in the `docker-users` group with Docker Desktop available is sufficient.
+
+## What "green" means
+
+- **PASS:** the installer brought up a real k3d cluster and the credential-free stub is discovery-shaped (the `client`-labelled `*-jobs-manager` Deployment + the `ingestor` ServiceAccount exist).
+- **RED (the point of the job):** a broken installer commit turns the run red, and the install log (`%USERPROFILE%\.tracebloc-e2e\install-*.log`, uploaded as the `windows-e2e-install-log` artifact) shows where it failed.
+
+Credentials are **not** used — the run stops before `Invoke-ProvisionClient` (Steps 5–6 mint a real machine credential against the backend), exactly as the bash `e2e-journey.sh` stops before the CLI connects. No secrets are required.
+
+## Scope note (WSL adapter, D2)
+
+The job runs whichever Windows path is current — the PowerShell monolith today. If RFC-CLIENT-0003 **D2** later replaces it with a WSL adapter, point the driver (`scripts/tests/e2e-windows.ps1`) at the new entrypoint; the runner setup and workflow are unchanged.

--- a/docs/WINDOWS-E2E.md
+++ b/docs/WINDOWS-E2E.md
@@ -18,7 +18,7 @@ It is **schedule-only** (nightly + manual `workflow_dispatch`), not per-PR, and 
 
    The workflow targets `runs-on: [self-hosted, windows, nested-virt]` — all three labels must be present.
 
-4. **Runner account rights:** the runner service account must be able to install user-space tools (`kubectl` / `k3d` / `helm`) and create k3d clusters (Docker access). Running the runner as a user in the `docker-users` group with Docker Desktop available is sufficient.
+4. **The runner must run as Administrator.** The Windows installer is inherently elevated — it creates `%ProgramFiles%\tracebloc\bin`, writes the **Machine** `PATH`, and (in a full install) installs Docker Desktop. Register/run the self-hosted runner service under an account with Administrator rights (or configure the runner service to run elevated). The e2e asserts elevation up front and fails fast with a pointer if it isn't. The account also needs Docker access (member of `docker-users`, Docker Desktop running).
 
 ## What "green" means
 

--- a/scripts/tests/e2e-windows.ps1
+++ b/scripts/tests/e2e-windows.ps1
@@ -30,6 +30,21 @@ function Write-E2e([string]$Message) { Write-Host "[e2e-windows] $Message" }
 function Stop-E2e([string]$Message)  { Write-Host "[e2e-windows] FAIL: $Message" -ForegroundColor Red; exit 1 }
 function Confirm-NativeOk([string]$What) { if ($LASTEXITCODE -ne 0) { Stop-E2e "$What (exit $LASTEXITCODE)" } }
 
+# Run a native command under a KILLING deadline (Wait-ProcessWithDeadline, dot-sourced from
+# the installer, kills on timeout). Returns the exit code, or 124 if the deadline fired.
+# Used for docker info + k3d teardown so a wedged Docker/WSL or a stuck delete fails fast
+# instead of hanging the shared runner to the 45-min job cap (#436 Bugbot).
+function Invoke-Bounded([int]$TimeoutSec, [string]$File, [string[]]$CmdArgs, [string]$Label) {
+  $o = Join-Path $env:TEMP ("e2e-win-{0}-{1}.log" -f $Label, (Get-Random))
+  $e = "$o.err"
+  $p = Start-Process -FilePath $File -ArgumentList $CmdArgs -NoNewWindow -PassThru `
+        -RedirectStandardOutput $o -RedirectStandardError $e
+  $done = Wait-ProcessWithDeadline -Process $p -Deadline (Get-Date).AddSeconds($TimeoutSec) -Message $Label
+  Remove-Item $o, $e -Force -ErrorAction SilentlyContinue
+  if (-not $done) { return 124 }
+  return $p.ExitCode
+}
+
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repo = (Resolve-Path (Join-Path $here '..\..')).Path
 
@@ -66,9 +81,8 @@ try {
 
   # 1. Docker/WSL must be UP. Docker Desktop + WSL2 + nested virt are runner prerequisites
   #    (docs/WINDOWS-E2E.md) — we verify, we do NOT reinstall Docker Desktop per run.
-  docker info *> $null
-  if ($LASTEXITCODE -ne 0) {
-    Stop-E2e "Docker isn't running on this runner. Docker Desktop + WSL2 + nested virtualization are self-hosted-runner prerequisites for the Windows e2e (see docs/WINDOWS-E2E.md)."
+  if ((Invoke-Bounded 30 "docker" @("info") "checking Docker") -ne 0) {
+    Stop-E2e "Docker isn't running (or didn't respond within 30s) on this runner. Docker Desktop + WSL2 + nested virtualization are self-hosted-runner prerequisites for the Windows e2e (see docs/WINDOWS-E2E.md)."
   }
   Write-E2e "Docker is up."
 
@@ -121,9 +135,12 @@ spec:
   $stub | kubectl apply --request-timeout=30s -f -
   Confirm-NativeOk "stub release apply"
 
-  # 5. Assert the discovery-shaped state exists (what DiscoverParentRelease selects on).
-  $dep = (kubectl get deploy -n $stubNs -l app.kubernetes.io/name=client -o name --request-timeout=30s) -join ''
-  if (-not $dep) { Stop-E2e "stub discovery: no client-labelled Deployment found" }
+  # 5. Assert the FULL discovery selector DiscoverParentRelease uses (#436 Bugbot): labels
+  #    name=client AND managed-by=Helm, AND the Deployment name is (or ends in) -jobs-manager
+  #    — not just the name label, or a stub missing the discovery keys would reach PASS.
+  $dep = (kubectl get deploy -n $stubNs -l 'app.kubernetes.io/name=client,app.kubernetes.io/managed-by=Helm' -o name --request-timeout=30s) -join "`n"
+  if (-not $dep) { Stop-E2e "stub discovery: no Deployment matches the CLI's label selector (name=client, managed-by=Helm)" }
+  if ($dep -notmatch '(/|-)jobs-manager$') { Stop-E2e "stub discovery: Deployment name doesn't end in -jobs-manager (got '$dep')" }
   kubectl get serviceaccount ingestor -n $stubNs --request-timeout=30s *> $null
   Confirm-NativeOk "stub discovery: 'ingestor' ServiceAccount missing"
   Write-E2e "Stub parent release is present and discovery-shaped ($dep)."
@@ -146,5 +163,5 @@ finally {
   # Teardown so the PERSISTENT runner is reusable (there is no per-run VM to destroy here).
   # Cluster only — leave $HOST_DATA_DIR\install-*.log for the workflow to upload on failure;
   # the workflow's always() step removes the data dir after the upload. Best-effort.
-  try { k3d cluster delete $env:CLUSTER_NAME 2>$null | Out-Null } catch { }
+  try { Invoke-Bounded 120 "k3d" @("cluster","delete",$env:CLUSTER_NAME) "cluster teardown" | Out-Null } catch { }
 }

--- a/scripts/tests/e2e-windows.ps1
+++ b/scripts/tests/e2e-windows.ps1
@@ -1,0 +1,136 @@
+#Requires -Version 5.1
+<#
+  e2e-windows.ps1 — real Windows installer e2e (self-hosted runner; #436 / RFC-CLIENT-0003 D5)
+  ---------------------------------------------------------------------------------------------
+  GitHub's `windows-latest` runners cannot nest virtualization, so install-k8s.ps1 is covered
+  only by mocked Pester — while the bash installer gets a 9-distro prereq matrix + real-k3d
+  e2e on every push. This driver exercises the REAL Windows installer, credential-free, on a
+  SELF-HOSTED runner that DOES support nested virtualization (Docker Desktop + WSL2 are runner
+  prerequisites — see docs/WINDOWS-E2E.md). It mirrors the credential-free shape of
+  scripts/tests/e2e-journey.sh:
+
+      Docker/WSL up  ->  install tools  ->  New-K3dCluster  ->  credential-free stub
+      discovery  ->  assert the installer's copy on the way  ->  teardown
+
+  It dot-sources install-k8s.ps1 with $env:TB_PESTER=1 so the installer's main() does NOT run,
+  then calls the same functions the installer's Steps 2-3 use. Steps 5-6 (Invoke-ProvisionClient
+  / Install-ClientHelm) mint a real machine credential against the backend and are out of scope
+  here — exactly as e2e-journey stops before the CLI connects.
+
+  It does NOT reinstall Docker Desktop / enable WSL features per run: those are one-time runner
+  setup (a persistent runner must not reboot itself nightly). We verify Docker is up and fail
+  loudly with a pointer if it isn't.
+
+  Usage:  pwsh -NoProfile -File scripts/tests/e2e-windows.ps1   (run by .github/workflows/windows-e2e.yaml)
+#>
+
+$ErrorActionPreference = 'Stop'
+
+function Write-E2e([string]$Message) { Write-Host "[e2e-windows] $Message" }
+function Stop-E2e([string]$Message)  { Write-Host "[e2e-windows] FAIL: $Message" -ForegroundColor Red; exit 1 }
+function Confirm-NativeOk([string]$What) { if ($LASTEXITCODE -ne 0) { Stop-E2e "$What (exit $LASTEXITCODE)" } }
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repo = (Resolve-Path (Join-Path $here '..\..')).Path
+
+# Isolated config, set BEFORE the dot-source (install-k8s.ps1 reads these at top level):
+#   • a throwaway cluster name so we never touch a real 'tracebloc' cluster
+#   • a throwaway HOST_DATA_DIR so the install log + any data land in a temp dir
+#     ($HOST_DATA_DIR\install-*.log is what the workflow uploads on failure)
+#   • opt out of autostart so we don't reconfigure the host's boot state
+if (-not $env:CLUSTER_NAME)  { $env:CLUSTER_NAME = 'tbe2ewin' }
+if (-not $env:HOST_DATA_DIR) { $env:HOST_DATA_DIR = Join-Path $env:USERPROFILE '.tracebloc-e2e' }
+$env:TRACEBLOC_NO_AUTOSTART = '1'
+$env:TB_PESTER = '1'   # load the installer's functions WITHOUT running its main()
+
+$stubNs = if ($env:TB_NAMESPACE) { $env:TB_NAMESPACE } else { 'tracebloc' }
+
+# Load the REAL installer functions (Install-Kubectl / Install-K3dAndHelm / New-K3dCluster / …).
+. (Join-Path $repo 'scripts\install-k8s.ps1')
+
+try {
+  Write-E2e "cluster=$env:CLUSTER_NAME  data=$env:HOST_DATA_DIR  ns=$stubNs"
+  Confirm-Config          # validates CLUSTER_NAME / HOST_DATA_DIR (no credentials involved)
+  Initialize-ToolDir
+  Start-InstallLog        # -> $HOST_DATA_DIR\install-<ts>.log (uploaded on failure)
+
+  # 1. Docker/WSL must be UP. Docker Desktop + WSL2 + nested virt are runner prerequisites
+  #    (docs/WINDOWS-E2E.md) — we verify, we do NOT reinstall Docker Desktop per run.
+  docker info *> $null
+  if ($LASTEXITCODE -ne 0) {
+    Stop-E2e "Docker isn't running on this runner. Docker Desktop + WSL2 + nested virtualization are self-hosted-runner prerequisites for the Windows e2e (see docs/WINDOWS-E2E.md)."
+  }
+  Write-E2e "Docker is up."
+
+  # 2. System tools (idempotent) — the same functions the installer's Step 2 uses.
+  Install-Kubectl
+  Install-K3dAndHelm
+
+  # 3. Cluster — the installer's REAL bring-up path (Step 3).
+  New-K3dCluster
+  kubectl wait --for=condition=Ready nodes --all --timeout=180s
+  Confirm-NativeOk "nodes did not reach Ready"
+  Write-E2e "Cluster is up and all nodes are Ready."
+
+  # 4. Credential-free stub the CLI's discovery keys off (LABELS, not values) — mirrors
+  #    e2e-journey.sh Step 3. No private image needed; pause is plenty (the pod never has to
+  #    go Ready — discovery reads the Deployment's labels + the 'ingestor' ServiceAccount).
+  kubectl create namespace $stubNs 2>$null | Out-Null
+  $stub = @"
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ingestor
+  namespace: $stubNs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${stubNs}-jobs-manager
+  namespace: $stubNs
+  labels:
+    app.kubernetes.io/name: client
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: tbe2e-win
+    app.kubernetes.io/version: 0.0.0-e2e
+    helm.sh/chart: client-0.0.0-e2e
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: client
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: client
+    spec:
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+"@
+  $stub | kubectl apply -f -
+  Confirm-NativeOk "stub release apply"
+
+  # 5. Assert the discovery-shaped state exists (what DiscoverParentRelease selects on).
+  $dep = (kubectl get deploy -n $stubNs -l app.kubernetes.io/name=client -o name) -join ''
+  if (-not $dep) { Stop-E2e "stub discovery: no client-labelled Deployment found" }
+  kubectl get serviceaccount ingestor -n $stubNs *> $null
+  Confirm-NativeOk "stub discovery: 'ingestor' ServiceAccount missing"
+  Write-E2e "Stub parent release is present and discovery-shaped ($dep)."
+
+  # 6. "Copy catalog on the way" — assert the installer emitted its expected copy into the
+  #    transcript (a smoke check that the installer output didn't silently drift/regress).
+  if ($script:LOG_FILE -and (Test-Path $script:LOG_FILE)) {
+    if ((Get-Content -Raw $script:LOG_FILE) -notmatch 'Creating k3d cluster') {
+      Stop-E2e "install log is missing the expected 'Creating k3d cluster' copy — installer output drifted"
+    }
+  }
+
+  Write-E2e "PASS: bootstrap -> Docker up -> tools -> cluster -> credential-free stub discovery."
+}
+finally {
+  # Teardown so the PERSISTENT runner is reusable (there is no per-run VM to destroy here).
+  # Cluster only — leave $HOST_DATA_DIR\install-*.log for the workflow to upload on failure;
+  # the workflow's always() step removes the data dir after the upload. Best-effort.
+  try { k3d cluster delete $env:CLUSTER_NAME 2>$null | Out-Null } catch { }
+}

--- a/scripts/tests/e2e-windows.ps1
+++ b/scripts/tests/e2e-windows.ps1
@@ -90,7 +90,12 @@ try {
   Install-Kubectl
   Install-K3dAndHelm
 
-  # 3. Cluster — the installer's REAL bring-up path (Step 3).
+  # 3. Cluster — the installer's REAL bring-up path (Step 3). On this PERSISTENT runner a
+  #    leftover cluster from a prior run would send New-K3dCluster down its reuse path (which
+  #    still logs 'Creating k3d cluster'), so the copy check + PASS could succeed WITHOUT a
+  #    real create. Pre-clean any stale cluster first so every run genuinely creates one
+  #    (#436 Bugbot). Bounded so a wedged delete can't hang the runner.
+  Invoke-Bounded 120 "k3d" @("cluster","delete",$env:CLUSTER_NAME) "pre-clean stale cluster" | Out-Null
   New-K3dCluster
   kubectl wait --for=condition=Ready nodes --all --timeout=180s --request-timeout=30s
   Confirm-NativeOk "nodes did not reach Ready"

--- a/scripts/tests/e2e-windows.ps1
+++ b/scripts/tests/e2e-windows.ps1
@@ -50,6 +50,16 @@ $stubNs = if ($env:TB_NAMESPACE) { $env:TB_NAMESPACE } else { 'tracebloc' }
 
 try {
   Write-E2e "cluster=$env:CLUSTER_NAME  data=$env:HOST_DATA_DIR  ns=$stubNs"
+  # The Windows installer is inherently ADMIN: Initialize-ToolDir creates
+  # %ProgramFiles%\tracebloc\bin and writes the MACHINE PATH, and the tool installs land
+  # there. TB_PESTER=1 skips the installer's own self-elevation gate, so assert elevation
+  # here — fail fast with a clear pointer instead of a confusing mid-run failure at tool
+  # setup (#436 Bugbot; the runner must run as Administrator — see docs/WINDOWS-E2E.md).
+  $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+  if (-not $isAdmin) {
+    Stop-E2e "the self-hosted runner must run as Administrator — the Windows installer creates %ProgramFiles%\tracebloc\bin and writes the Machine PATH (see docs/WINDOWS-E2E.md)."
+  }
+
   Confirm-Config          # validates CLUSTER_NAME / HOST_DATA_DIR (no credentials involved)
   Initialize-ToolDir
   Start-InstallLog        # -> $HOST_DATA_DIR\install-<ts>.log (uploaded on failure)
@@ -68,14 +78,14 @@ try {
 
   # 3. Cluster — the installer's REAL bring-up path (Step 3).
   New-K3dCluster
-  kubectl wait --for=condition=Ready nodes --all --timeout=180s
+  kubectl wait --for=condition=Ready nodes --all --timeout=180s --request-timeout=30s
   Confirm-NativeOk "nodes did not reach Ready"
   Write-E2e "Cluster is up and all nodes are Ready."
 
   # 4. Credential-free stub the CLI's discovery keys off (LABELS, not values) — mirrors
   #    e2e-journey.sh Step 3. No private image needed; pause is plenty (the pod never has to
   #    go Ready — discovery reads the Deployment's labels + the 'ingestor' ServiceAccount).
-  kubectl create namespace $stubNs 2>$null | Out-Null
+  kubectl create namespace $stubNs --request-timeout=30s 2>$null | Out-Null
   $stub = @"
 apiVersion: v1
 kind: ServiceAccount
@@ -108,22 +118,26 @@ spec:
         - name: pause
           image: registry.k8s.io/pause:3.9
 "@
-  $stub | kubectl apply -f -
+  $stub | kubectl apply --request-timeout=30s -f -
   Confirm-NativeOk "stub release apply"
 
   # 5. Assert the discovery-shaped state exists (what DiscoverParentRelease selects on).
-  $dep = (kubectl get deploy -n $stubNs -l app.kubernetes.io/name=client -o name) -join ''
+  $dep = (kubectl get deploy -n $stubNs -l app.kubernetes.io/name=client -o name --request-timeout=30s) -join ''
   if (-not $dep) { Stop-E2e "stub discovery: no client-labelled Deployment found" }
-  kubectl get serviceaccount ingestor -n $stubNs *> $null
+  kubectl get serviceaccount ingestor -n $stubNs --request-timeout=30s *> $null
   Confirm-NativeOk "stub discovery: 'ingestor' ServiceAccount missing"
   Write-E2e "Stub parent release is present and discovery-shaped ($dep)."
 
   # 6. "Copy catalog on the way" — assert the installer emitted its expected copy into the
   #    transcript (a smoke check that the installer output didn't silently drift/regress).
-  if ($script:LOG_FILE -and (Test-Path $script:LOG_FILE)) {
-    if ((Get-Content -Raw $script:LOG_FILE) -notmatch 'Creating k3d cluster') {
-      Stop-E2e "install log is missing the expected 'Creating k3d cluster' copy — installer output drifted"
-    }
+  # Fail if the log is missing — never report PASS on an unverified copy check (seal-check
+  # rule: unsealed, never SILENTLY sealed; #436 Bugbot). Start-InstallLog set $LOG_FILE, so
+  # its absence means the installer never got that far.
+  if (-not ($script:LOG_FILE -and (Test-Path $script:LOG_FILE))) {
+    Stop-E2e "install log not found ($($script:LOG_FILE)) — cannot verify the installer's copy; refusing to report PASS."
+  }
+  if ((Get-Content -Raw $script:LOG_FILE) -notmatch 'Creating k3d cluster') {
+    Stop-E2e "install log is missing the expected 'Creating k3d cluster' copy — installer output drifted"
   }
 
   Write-E2e "PASS: bootstrap -> Docker up -> tools -> cluster -> credential-free stub discovery."


### PR DESCRIPTION
## #436 — real Windows installer e2e (self-hosted runner, RFC-CLIENT-0003 D5)

GitHub's `windows-latest` runners can't nest virtualization, so `install-k8s.ps1` has only **mocked Pester** coverage — while the bash installer gets a 9-distro prereq matrix + real-k3d e2e on every push. Regressions and never-ported behaviors stay green on Windows. This adds the missing e2e leg on a **self-hosted runner** that supports nested virt.

> **Provisioning decision:** self-hosted Windows runner (Azure isn't available to us).

## What's here
- **`.github/workflows/windows-e2e.yaml`** — `schedule` (nightly) + `workflow_dispatch`, **not per-PR**; `runs-on: [self-hosted, windows, nested-virt]`; concurrency-guarded; 45-min cap; uploads the install log artifact **on failure**; tears the cluster down every run.
- **`scripts/tests/e2e-windows.ps1`** — the credential-free driver, mirroring `e2e-journey.sh`: dot-sources `install-k8s.ps1` with `TB_PESTER=1` (main() doesn't run) → verifies Docker/WSL up (runner prereqs; it does **not** reinstall Docker Desktop per run) → installs tools → runs the installer's real `New-K3dCluster` → applies a credential-free stub the CLI discovery keys off (labels + `ingestor` SA) → asserts the discovery-shaped state → checks the installer's cluster-create copy reached the log → tears down. Stops before `Invoke-ProvisionClient` (Steps 5–6 mint a real backend credential — out of scope), exactly as `e2e-journey` stops before the CLI connects.
- **`docs/WINDOWS-E2E.md`** — one-time runner setup (labels, WSL2 + Docker Desktop + nested virt, account rights) + what green/red means.
- **`installer-tests.yaml`** — `e2e-windows.ps1` added to the PSScriptAnalyzer step so a syntax/verb regression fails fast on every push, not at the nightly run.

## Acceptance criteria
- ✅ A deliberately broken installer commit turns the job red with the install log attached (`windows-e2e-install-log` artifact).
- ✅ Covers whichever Windows path is current (the PS monolith today; if D2 lands a WSL adapter, point the driver at the new entrypoint — runner setup unchanged).

## Validation — please read
This is greenfield CI infra I **cannot execute here** (no Windows / WSL / nested-virt host). Validated locally: YAML parses; **PSScriptAnalyzer clean (0 errors** — the Write-Host / empty-catch / non-BOM-unicode warnings match `install-k8s.ps1`'s own tolerated set); check-style clean. The **first scheduled run on the registered runner** is what shakes it out — that's inherent to this issue, and it's the acceptance test.

## Before it can run (one-time, needs you/IT)
Register a self-hosted Windows runner with labels `self-hosted, windows, nested-virt`, WSL2 + Docker Desktop (WSL2 backend) running, on a nested-virt-capable host — see `docs/WINDOWS-E2E.md`.

Closes #436

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test infrastructure only; no production installer behavior changes, though the job mutates Machine PATH and k3d state on the dedicated self-hosted runner.
> 
> **Overview**
> Adds **real end-to-end coverage** for the Windows PowerShell installer where GitHub-hosted runners cannot nest virtualization—parity with the bash installer’s real-k3d path, scoped to **RFC D5 (#436)**.
> 
> A new **nightly + `workflow_dispatch`** workflow (`.github/workflows/windows-e2e.yaml`) runs on `[self-hosted, windows, nested-virt]`, with concurrency limits, a 45-minute cap, install-log upload on **any non-success** (`!success()`), and an **always** teardown safety net (bounded `k3d` delete + data-dir cleanup).
> 
> **`scripts/tests/e2e-windows.ps1`** dot-sources `install-k8s.ps1` with `TB_PESTER=1`, then runs the credential-free path: admin + Docker checks, tool install, pre-clean + `New-K3dCluster`, discovery-shaped stub assertions, install-log copy smoke check, and bounded teardown—stopping before backend provisioning like `e2e-journey.sh`.
> 
> **`docs/WINDOWS-E2E.md`** documents one-time runner setup (labels, WSL2/Docker, Administrator). **`installer-tests.yaml`** now PSScriptAnalyzes `e2e-windows.ps1` on every push so regressions fail fast before the nightly job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37a6716a5adcb2fac246a8ea07d1d1c58a0c62fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->