### PR TITLE
test(seal-check): run the egress-enforcement probe live in k3d CI (#1184)

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -233,6 +233,21 @@ jobs:
       - name: Upgrade from last published release through both flag paths
         run: bash scripts/tests/e2e-auto-upgrade.sh
 
+  seal-check-e2e:
+    timeout-minutes: 20
+    # RFC-0003 D12 (backend#1184): run the egress-enforcement seal-check LIVE on
+    # a real k3d cluster with the lockdown engaged, closing the SEAL-CHECK §8.4
+    # "full-chart probe run pending" gap (the k3s netpol substrate was verified
+    # in #504). Zero secrets — a public curl image vs 1.1.1.1; no private images,
+    # no backend. Proves the probe fires and the CNI actually blocks a
+    # training-labelled pod's egress once allowExternalHttps=false.
+    name: Seal-check egress-enforcement (k3d)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run the live egress-enforcement seal-check
+        run: bash scripts/tests/e2e-seal-check.sh
+
   # Installer script tests (bats + Pester) + the cross-distro prerequisite matrix
   # live in their own workflow: .github/workflows/installer-tests.yaml
   # (triggered on scripts/** changes).

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -236,7 +236,11 @@ jobs:
         run: bash scripts/tests/e2e-auto-upgrade.sh
 
   seal-check-e2e:
-    timeout-minutes: 20
+    # 30m to match the sibling k3d job (upgrade-e2e): the script's own bounds
+    # (create_cluster up to 15m + helm test 360s + tool install + install)
+    # can exceed a 20m GHA cap on a slow cluster bring-up and false-fail even
+    # while every component is still inside its own timeout (Bugbot).
+    timeout-minutes: 30
     # RFC-0003 D12 (backend#1184): run the egress-enforcement seal-check LIVE on
     # a real k3d cluster with the lockdown engaged, closing the SEAL-CHECK §8.4
     # "full-chart probe run pending" gap (the k3s netpol substrate was verified

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -7,6 +7,7 @@ on:
       - 'client/**'
       - 'ingestor/**'
       - 'scripts/tests/e2e-auto-upgrade.sh'
+      - 'scripts/tests/e2e-seal-check.sh'
       - '.github/workflows/helm-ci.yaml'
   pull_request:
     branches: [main, develop, openshift]
@@ -14,6 +15,7 @@ on:
       - 'client/**'
       - 'ingestor/**'
       - 'scripts/tests/e2e-auto-upgrade.sh'
+      - 'scripts/tests/e2e-seal-check.sh'
       - '.github/workflows/helm-ci.yaml'
 
 concurrency:

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -8,6 +8,7 @@ on:
       - 'ingestor/**'
       - 'scripts/tests/e2e-auto-upgrade.sh'
       - 'scripts/tests/e2e-seal-check.sh'
+      - 'scripts/lib/**'
       - '.github/workflows/helm-ci.yaml'
   pull_request:
     branches: [main, develop, openshift]
@@ -16,6 +17,7 @@ on:
       - 'ingestor/**'
       - 'scripts/tests/e2e-auto-upgrade.sh'
       - 'scripts/tests/e2e-seal-check.sh'
+      - 'scripts/lib/**'
       - '.github/workflows/helm-ci.yaml'
 
 concurrency:

--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -67,11 +67,11 @@ jobs:
           # below for visibility but don't fail the gate.
           shellcheck --severity=error --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/gen-manifest.sh scripts/check-facts.sh scripts/check-style.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
-            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/path-persist.sh
+            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/path-persist.sh
           echo "── shellcheck warnings (advisory, non-blocking) ──"
           shellcheck --severity=warning --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/gen-manifest.sh scripts/check-facts.sh scripts/check-style.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
-            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/path-persist.sh || true
+            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/path-persist.sh || true
 
       - name: Installer manifest is current (supply-chain, R8)
         # The bootstrap verifies each sub-script against scripts/manifest.sha256

--- a/.github/workflows/standard-checks.yml
+++ b/.github/workflows/standard-checks.yml
@@ -44,7 +44,7 @@ jobs:
           shellcheck --version | grep version
           shellcheck --severity=error --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
-            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh scripts/tests/e2e-auto-upgrade.sh
+            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh
 
   unit-tests:
     name: Unit tests

--- a/client/tests/egress_enforcement_check_test.yaml
+++ b/client/tests/egress_enforcement_check_test.yaml
@@ -44,6 +44,13 @@ tests:
           count: 1
       - isKind:
           of: Job
+      # The live e2e seal-check (scripts/tests/e2e-seal-check.sh) selects this
+      # Job via `helm test --filter name=<release>-egress-enforcement-check`.
+      # Pin the name so the filter can never silently drift off it — a wrong
+      # name makes --filter match nothing and helm test falsely exit 0.
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-egress-enforcement-check
       - equal:
           path: metadata.annotations["helm.sh/hook"]
           value: test

--- a/scripts/tests/e2e-seal-check.sh
+++ b/scripts/tests/e2e-seal-check.sh
@@ -25,8 +25,11 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB="$HERE/../lib"
 CHART_DIR="$HERE/../../client"
 
-# Isolated cluster + release so we never touch a real 'tracebloc' install.
+# Isolated cluster + release so we never touch a real 'tracebloc' install, and
+# opt out of autostart so create_cluster never reconfigures the host's Docker
+# restart policy / runs `systemctl enable docker` (matches the sibling e2e-*.sh).
 export CLUSTER_NAME="${CLUSTER_NAME:-tbseal}"
+export TRACEBLOC_NO_AUTOSTART=1
 NS="tbseal"
 
 # shellcheck source=/dev/null

--- a/scripts/tests/e2e-seal-check.sh
+++ b/scripts/tests/e2e-seal-check.sh
@@ -73,17 +73,26 @@ helm install "$NS" "$CHART_DIR" --namespace "$NS" --create-namespace \
 # exact name so the --filter below can never silently drift off it.
 PROBE="${NS}-egress-enforcement-check"
 
+# Guard the silent-pass trap FIRST: `helm test --filter` exits 0 when the filter
+# matches NOTHING (no test runs). So confirm the probe hook is actually in the
+# release before testing — a renamed/ungated probe fails here, loudly, instead
+# of passing vacuously.
+echo "── verify the probe hook is in the release ──"
+helm get hooks "$NS" --namespace "$NS" | grep -q "name: ${PROBE}" ||
+  fail "probe hook ${PROBE} not found in release hooks — --filter would match nothing"
+
 echo "── helm test --filter name=${PROBE} ──"
-# `helm test --filter` exits 0 when the filter matches NOTHING (no test runs) —
-# a silent false-pass. So success requires BOTH a zero exit AND the probe's own
-# marker in the logs; either one missing is a hard failure.
-LOG="$(mktemp)"
-if ! helm test "$NS" --namespace "$NS" --filter "name=${PROBE}" --logs >"$LOG" 2>&1; then
-  cat "$LOG"
+# Drive off the EXIT CODE, not --logs. The probe Job exits 0 ONLY when egress is
+# verified blocked, so a passing `helm test` == the lockdown is enforced. --logs
+# is unreliable for a Job-type hook: it looks up the pod by the Job's bare name
+# (the pod carries a generated suffix → "pods not found"), and hook-succeeded
+# deletes the Job on success anyway. On FAILURE the Job persists, so dump its
+# pod log for triage.
+if ! helm test "$NS" --namespace "$NS" --filter "name=${PROBE}" --timeout 360s; then
+  echo "── probe pod log (Job persists on failure) ──"
+  kubectl logs -n "$NS" -l "job-name=${PROBE}" --tail=-1 2>/dev/null ||
+    kubectl describe job -n "$NS" "${PROBE}" 2>/dev/null || true
   fail "helm test reported failure for ${PROBE} — egress lockdown NOT verified"
 fi
-cat "$LOG"
-grep -q "OK  egress lockdown verified" "$LOG" ||
-  fail "no egress-enforcement success marker in helm-test logs — did --filter match the probe? (guards the filter-silent-pass trap)"
 
-echo "PASS: live seal-check — egress-enforcement probe fired and verified the lockdown."
+echo "PASS: live seal-check — egress-enforcement probe passed; the CNI enforced the egress lockdown."

--- a/scripts/tests/e2e-seal-check.sh
+++ b/scripts/tests/e2e-seal-check.sh
@@ -30,7 +30,10 @@ CHART_DIR="$HERE/../../client"
 # restart policy / runs `systemctl enable docker` (matches the sibling e2e-*.sh).
 export CLUSTER_NAME="${CLUSTER_NAME:-tbseal}"
 export TRACEBLOC_NO_AUTOSTART=1
-NS="tbseal"
+# Derive NS from CLUSTER_NAME so `CLUSTER_NAME=foo bash ...` isolates a second
+# run under ONE name — cluster + release + namespace move together instead of
+# splitting the run's identity across two names (Saqlain review).
+NS="$CLUSTER_NAME"
 
 # shellcheck source=/dev/null
 source "$LIB/common.sh"
@@ -64,12 +67,44 @@ echo "── helm install (public images, egress lockdown ENGAGED) ──"
 # storage, and allowExternalHttps=false so the training-egress NetworkPolicy is
 # rendered and the egress-enforcement-check Job renders (it is gated on the
 # lockdown flag + a non-empty enforcementProbeHost, chart default 1.1.1.1).
+# enforcementProbeTimeoutSeconds is bumped from the 60s chart default to 240s:
+# on a cold GHA runner k3s's kube-router can take >60s to program the pod's
+# iptables while the chart is still installing, and the probe is single-shot
+# (backoffLimit 0) — 240s is well inside the 360s helm-test budget so a slow
+# reconcile no longer false-fails on a cluster that DOES enforce (Saqlain review).
 helm install "$NS" "$CHART_DIR" --namespace "$NS" --create-namespace \
   -f "$CHART_DIR/tests/values-public-images.yaml" \
   --set clientId=ci-e2e-seal \
   --set clientPassword=ci-e2e-seal \
   --set storageClass.provisioner=rancher.io/local-path \
-  --set networkPolicy.training.allowExternalHttps=false
+  --set networkPolicy.training.allowExternalHttps=false \
+  --set networkPolicy.training.enforcementProbeTimeoutSeconds=240
+
+# Positive control (Saqlain review): before trusting a BLOCKED probe result,
+# prove the cluster can actually REACH the probe host. Otherwise egress failing
+# for an unrelated reason (a runner firewall, a target outage, a rate-limit)
+# makes the probe print OK and the seal-check pass green while the NetworkPolicy
+# did nothing. A pod in `default` is governed by NO training-egress policy (the
+# policy is namespace-scoped to the release ns), so if IT reaches the host, the
+# training pod's block below is attributable to the policy, not the environment.
+# Same image + curl invocation as the probe; HOST matches the chart default the
+# install leaves in place.
+HOST=1.1.1.1
+echo "── positive control: a non-policied pod must REACH ${HOST}:443 ──"
+kubectl run seal-poscheck --namespace default --restart=Never \
+  --image="curlimages/curl:8.20.0" \
+  --command -- curl --noproxy '*' -k -sS -m 15 -o /dev/null "https://${HOST}"
+posphase=""
+for _ in $(seq 1 40); do
+  posphase="$(kubectl get pod seal-poscheck -n default -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+  { [ "$posphase" = "Succeeded" ] || [ "$posphase" = "Failed" ]; } && break
+  sleep 3
+done
+kubectl logs seal-poscheck -n default 2>/dev/null || true
+kubectl delete pod seal-poscheck -n default --ignore-not-found --now >/dev/null 2>&1 || true
+[ "$posphase" = "Succeeded" ] ||
+  fail "positive control FAILED — a non-policied pod could not reach ${HOST}:443 (phase=${posphase:-none}). A blocked training pod would NOT be attributable to the NetworkPolicy (runner egress / target issue), so the seal-check is inconclusive — refusing to report a false PASS."
+echo "positive control OK — ${HOST}:443 reachable; a training-pod block is now attributable to the policy."
 
 # The one probe we exercise. Its Job is `<release>-egress-enforcement-check`
 # (templates/egress-enforcement-check.yaml). The helm-unittest suite pins this

--- a/scripts/tests/e2e-seal-check.sh
+++ b/scripts/tests/e2e-seal-check.sh
@@ -43,8 +43,18 @@ trap cleanup EXIT
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
+# Prerequisites. The sourced libs DEFINE these installers but do not call them;
+# create_cluster + helm need the binaries on PATH first, and a stock GitHub
+# runner ships none of k3d/helm/kubectl. Mirror e2e-auto-upgrade.sh exactly.
+has docker || fail "Docker is not available on this host."
+umask 022
+install_kubectl
+install_k3d
+install_helm
+
 echo "── create_cluster() — real k3d bring-up (k3s enforces egress NetworkPolicy) ──"
 create_cluster
+kubectl wait --for=condition=Ready nodes --all --timeout=180s
 
 echo "── helm install (public images, egress lockdown ENGAGED) ──"
 # Local working-tree chart, public images (no registry secret), local-path

--- a/scripts/tests/e2e-seal-check.sh
+++ b/scripts/tests/e2e-seal-check.sh
@@ -81,7 +81,11 @@ PROBE="${NS}-egress-enforcement-check"
 # release before testing — a renamed/ungated probe fails here, loudly, instead
 # of passing vacuously.
 echo "── verify the probe hook is in the release ──"
-helm get hooks "$NS" --namespace "$NS" | grep -q "name: ${PROBE}" ||
+# Capture first, then grep a here-string — piping `helm get hooks | grep -q`
+# lets grep close the pipe on its first match, which SIGPIPEs helm mid-write and
+# (under `set -o pipefail`) false-fails this guard even though the hook exists.
+hooks="$(helm get hooks "$NS" --namespace "$NS")"
+grep -q "name: ${PROBE}" <<<"$hooks" ||
   fail "probe hook ${PROBE} not found in release hooks — --filter would match nothing"
 
 echo "── helm test --filter name=${PROBE} ──"

--- a/scripts/tests/e2e-seal-check.sh
+++ b/scripts/tests/e2e-seal-check.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  e2e-seal-check.sh — live seal-check conformance probe (RFC-0003 D12, #1184)
+# -----------------------------------------------------------------------------
+#  The chart ships its enforcement probes as `helm.sh/hook: test` Jobs, but
+#  until now `helm test` ran NOWHERE in CI. The SEAL-CHECK §8.4 status recorded
+#  the k3d/k3s NetworkPolicy *substrate* as verified (client#504) while the
+#  full-chart egress-enforcement probe run stayed "pending". This closes that
+#  gap: install the local chart on a real k3d cluster with the egress lockdown
+#  engaged, run ONLY the egress-enforcement seal-check via `helm test`, and
+#  prove the probe actually fires and passes — a training-labelled pod's direct
+#  TCP egress to the probe host is blocked by the CNI.
+#
+#  egress-enforcement is the one seal-check that needs ZERO secrets: a public
+#  curl image against 1.1.1.1, no backend, no private images — so it runs on a
+#  stock GitHub runner. The other probes (backend-reachability, bound-PVC
+#  storage-assertions) need the dev harness with real credentials and are out
+#  of scope here.
+#
+#  Usage:  bash scripts/tests/e2e-seal-check.sh
+# =============================================================================
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$HERE/../lib"
+CHART_DIR="$HERE/../../client"
+
+# Isolated cluster + release so we never touch a real 'tracebloc' install.
+export CLUSTER_NAME="${CLUSTER_NAME:-tbseal}"
+NS="tbseal"
+
+# shellcheck source=/dev/null
+source "$LIB/common.sh"
+# shellcheck source=/dev/null
+source "$LIB/setup-linux.sh"
+# shellcheck source=/dev/null
+source "$LIB/cluster.sh"
+# shellcheck source=/dev/null
+source "$LIB/preflight.sh" # provides _pf_recheck_runtime_mem (called by create_cluster)
+
+cleanup() { k3d cluster delete "$CLUSTER_NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+echo "── create_cluster() — real k3d bring-up (k3s enforces egress NetworkPolicy) ──"
+create_cluster
+
+echo "── helm install (public images, egress lockdown ENGAGED) ──"
+# Local working-tree chart, public images (no registry secret), local-path
+# storage, and allowExternalHttps=false so the training-egress NetworkPolicy is
+# rendered and the egress-enforcement-check Job renders (it is gated on the
+# lockdown flag + a non-empty enforcementProbeHost, chart default 1.1.1.1).
+helm install "$NS" "$CHART_DIR" --namespace "$NS" --create-namespace \
+  -f "$CHART_DIR/tests/values-public-images.yaml" \
+  --set clientId=ci-e2e-seal \
+  --set clientPassword=ci-e2e-seal \
+  --set storageClass.provisioner=rancher.io/local-path \
+  --set networkPolicy.training.allowExternalHttps=false
+
+# The one probe we exercise. Its Job is `<release>-egress-enforcement-check`
+# (templates/egress-enforcement-check.yaml). The helm-unittest suite pins this
+# exact name so the --filter below can never silently drift off it.
+PROBE="${NS}-egress-enforcement-check"
+
+echo "── helm test --filter name=${PROBE} ──"
+# `helm test --filter` exits 0 when the filter matches NOTHING (no test runs) —
+# a silent false-pass. So success requires BOTH a zero exit AND the probe's own
+# marker in the logs; either one missing is a hard failure.
+LOG="$(mktemp)"
+if ! helm test "$NS" --namespace "$NS" --filter "name=${PROBE}" --logs >"$LOG" 2>&1; then
+  cat "$LOG"
+  fail "helm test reported failure for ${PROBE} — egress lockdown NOT verified"
+fi
+cat "$LOG"
+grep -q "OK  egress lockdown verified" "$LOG" ||
+  fail "no egress-enforcement success marker in helm-test logs — did --filter match the probe? (guards the filter-silent-pass trap)"
+
+echo "PASS: live seal-check — egress-enforcement probe fired and verified the lockdown."

--- a/scripts/tests/e2e-seal-check.sh
+++ b/scripts/tests/e2e-seal-check.sh
@@ -91,9 +91,16 @@ helm install "$NS" "$CHART_DIR" --namespace "$NS" --create-namespace \
 # install leaves in place.
 HOST=1.1.1.1
 echo "── positive control: a non-policied pod must REACH ${HOST}:443 ──"
+# A fast runner can schedule the pod before the `default` ServiceAccount is
+# created ("serviceaccount default not found"), which aborts under set -e before
+# the attribution failure below. Wait for the SA to exist first (Bugbot).
+for _ in $(seq 1 20); do
+  kubectl get serviceaccount default -n default >/dev/null 2>&1 && break
+  sleep 1
+done
 kubectl run seal-poscheck --namespace default --restart=Never \
   --image="curlimages/curl:8.20.0" \
-  --command -- curl --noproxy '*' -k -sS -m 15 -o /dev/null "https://${HOST}"
+  --command -- curl --noproxy '*' --tlsv1.2 -k -sS -m 15 -o /dev/null "https://${HOST}"
 posphase=""
 for _ in $(seq 1 40); do
   posphase="$(kubectl get pod seal-poscheck -n default -o jsonpath='{.status.phase}' 2>/dev/null || true)"


### PR DESCRIPTION
## What & why — RFC-0003 D12 seal check (backend#1184)

The chart already ships its enforcement probes as `helm.sh/hook: test` Jobs (egress-enforcement, backend-reachability, storage-assertions), but **`helm test` runs nowhere in CI** — so the probes have never actually *executed* in a pipeline. SEAL-CHECK §8.4 records the k3s NetworkPolicy **substrate** as verified (#504, a manual throwaway-cluster check) while the **full-chart egress-enforcement probe run** is still marked *pending*.

This PR makes that probe run for real, on every CI push.

### Changes
- **`scripts/tests/e2e-seal-check.sh`** — installs the local working-tree chart on a real k3d cluster (reusing the installer's `create_cluster` path) with public images and the egress lockdown **engaged** (`allowExternalHttps=false`), then runs *only* the egress-enforcement seal-check via `helm test --filter`. A training-labelled pod's direct TCP egress to `1.1.1.1:443` must be blocked by k3s's CNI.
- **`.github/workflows/helm-ci.yaml`** — a `seal-check-e2e` job mirroring `upgrade-e2e`: stock `ubuntu-latest`, **zero secrets** (public `curl` image, no backend, no private images).
- **`client/tests/egress_enforcement_check_test.yaml`** — pins the probe Job's `metadata.name` so the e2e `--filter` can never silently drift off it.

### The subtleties worth a reviewer's eye
- `helm test --filter` **exits 0 when the filter matches nothing** — a silent false-pass. The script guards this by asserting the probe hook is in `helm get hooks` *before* testing, then drives the verdict off `helm test`'s **exit code** (the probe Job exits 0 only when egress is verified blocked). It does **not** grep `--logs` (unreliable for Job hooks). The name-pin unittest is belt-and-braces on the filter name.
- **Positive control**: a pass is only trusted if a non-policied pod first proves the host is reachable — so a block is attributable to the NetworkPolicy, not a runner/target issue.

### Why only egress-enforcement
It's the single seal-check that needs no credentials. `backend-reachability` needs a real backend + proxy, and a bound-PVC `storage-assertions` pass needs the dev harness — both belong to the dev-environment e2e run (the remaining #1184 subtask), not a stock runner.

### Verified locally
`shellcheck` clean · `helm template` renders the probe Job as `<release>-egress-enforcement-check` · `helm unittest` 27 suites / 320 tests green. The live k3d run is exercised by the new CI job itself (like the other e2e scripts, it isn't runnable on a dev laptop without docker+k3d).

## Notes
- Targets `develop`.
- Advances backend#1184 (consolidate/execute the seal-check); the §8.3 matrix fill is the sibling [cli#449](https://github.com/tracebloc/cli/pull/449). Epic #1151 — Lukas drives, Saqlain reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI, test automation, and a helm-unittest assertion; they do not alter runtime chart behavior or production install paths.
> 
> **Overview**
> Adds **live CI coverage** for the chart’s egress-enforcement `helm test` hook, closing the SEAL-CHECK gap where probes existed but **`helm test` never ran in the pipeline**.
> 
> A new **`scripts/tests/e2e-seal-check.sh`** brings up an isolated k3d cluster, installs the local chart with **`allowExternalHttps=false`** (and a longer enforcement probe timeout for slow CNI reconcile on GHA), runs a **positive control** curl from an unpolicy’d pod to `1.1.1.1`, then asserts the probe hook is present and runs **`helm test --filter`** on `<release>-egress-enforcement-check`, failing on exit code (not vacuous filter matches or unreliable `--logs`).
> 
> **`.github/workflows/helm-ci.yaml`** gains a **`seal-check-e2e`** job (30m timeout, no secrets). Path filters and **shellcheck** lists in **helm-ci**, **installer-tests**, and **standard-checks** include the new script (and `scripts/lib/**` for helm-ci triggers).
> 
> **`client/tests/egress_enforcement_check_test.yaml`** pins the probe Job **`metadata.name`** to `RELEASE-NAME-egress-enforcement-check` so the e2e filter cannot silently match nothing and pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 068bd9f207bc42504f334c7a82aa7212810f3260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->