### PR TITLE
test(#537): pin locked-down egress rule count

### DIFF
--- a/client/tests/network_policy_test.yaml
+++ b/client/tests/network_policy_test.yaml
@@ -254,6 +254,15 @@ tests:
           content:
             port: 8888
             protocol: TCP
+      # locked-down egress is exactly 4 rules: DNS + MySQL + requests-proxy +
+      # egress-proxy. NOTE: `egressProxy.enabled` DEFAULTS TRUE (values.yaml —
+      # only `routeWorkloads` defaults false), so the gateway's permit rule
+      # renders here even though this case doesn't set it. The direct length
+      # assertion makes the shape unmissable and catches a stray appended rule
+      # (Saqlain review on #537).
+      - lengthEqual:
+          path: spec.egress
+          count: 4
 
   - it: locked down — renders the egress-proxy allowlist rule when egressProxy is enabled
     set:
@@ -274,3 +283,8 @@ tests:
           content:
             port: 3128
             protocol: TCP
+      # with egressProxy enabled: DNS + MySQL + requests-proxy + egress-proxy
+      # (4 rules) — pin the count so a stray appended rule can't slip in.
+      - lengthEqual:
+          path: spec.egress
+          count: 4


### PR DESCRIPTION
## Fast-follow to [#537](https://github.com/tracebloc/client/pull/537) — @saqlainsyed007's test-robustness nit

Your suggestion on #537: assert the locked-down egress **shape** directly (`lengthEqual` on `spec.egress`) so a stray appended rule is caught, not just an index shift. Applied to both locked-down cases (deferred at merge to keep the approval).

**One correction worth flagging:** you suggested `count: 3` for the pure locked-down case (DNS + MySQL + requests-proxy). It's actually **4** — `egressProxy.enabled` **defaults `true`** in `values.yaml` (only `routeWorkloads` defaults false), so the egress-proxy permit rule renders even when the case doesn't set it: `DNS + MySQL + requests-proxy + egress-proxy`. Both locked-down cases therefore assert `count: 4`, and I added a comment explaining the default so the next reader isn't surprised.

`helm unittest` — netpol suite 13/13, full chart 322/322.

Targets `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to Helm unit tests; no runtime or template behavior is modified.
> 
> **Overview**
> **Helm unittest hardening** for locked-down training `NetworkPolicy` cases: both tests now assert `spec.egress` has **exactly 4 rules** via `lengthEqual`, so an extra egress rule can’t land without failing the suite (follow-up to review on #537).
> 
> Comments document why the count is **4** (DNS, MySQL, requests-proxy, egress-proxy): `egressProxy.enabled` defaults **true** in chart values, so the egress-proxy permit rule is present even when a test case doesn’t set `egressProxy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a18e5c85c670794fc3f32bdfe02e7f8f13b9de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->