### PR TITLE
fix(check-facts,e2e-windows): sed|head pipefail crash + false-PASS pre-clean (Bugbot #542)

### DIFF
--- a/scripts/check-facts.sh
+++ b/scripts/check-facts.sh
@@ -39,8 +39,13 @@ esac
 # Read a bare KEY=value from the spec (comments/blank lines ignored). Fails closed:
 # a missing/empty key is a spec error, not a silent pass.
 _spec_get() {
-  local key="$1" val
-  val="$(sed -n "s/^${key}=\(.*\)$/\1/p" "$SPEC" | head -1)"
+  local key="$1" all val
+  # Capture whole, then take the first line with `%%$'\n'*` — NOT `… | head -1`.
+  # Under `set -o pipefail` a duplicate key makes head close the pipe after line 1,
+  # sed takes SIGPIPE, and the pipeline exits 141 — aborting the facts gate before
+  # any drift message prints (a crash/fail-open on duplicate input).
+  all="$(sed -n "s/^${key}=\(.*\)$/\1/p" "$SPEC")"
+  val="${all%%$'\n'*}"
   [[ -n "$val" ]] || { echo "check-facts: '${key}' missing from ${SPEC}" >&2; exit 2; }
   printf '%s' "$val"
 }
@@ -84,7 +89,9 @@ FACT_REWRITE=(
   's|\(\$ReadyTimeout .*else { "\)[^"]*\(" }\)|\1@@VAL@@\2|'
 )
 
-_extract() { sed -n "$2" "$1" | head -1; }
+# Capture whole, then take the first line with `%%$'\n'*` — NOT `… | head -1`, which
+# SIGPIPEs sed (exit 141) under `set -o pipefail` when a file has a second match.
+_extract() { local all; all="$(sed -n "$2" "$1")"; printf '%s' "${all%%$'\n'*}"; }
 
 drift=0
 i=0

--- a/scripts/tests/check-facts.bats
+++ b/scripts/tests/check-facts.bats
@@ -124,3 +124,35 @@ _set_spec() { local tmp; tmp="$(mktemp)"; sed "s|^$1=.*|$1=$2|" "$REPO/scripts/s
   run _facts --bogus
   [ "$status" -eq 2 ]
 }
+
+# --- pipefail + `sed | head -1` SIGPIPE regressions (#542 Bugbot) -----------
+# Both helpers used to pipe `sed … | head -1` under `set -o pipefail`: on a second
+# match large enough to fill the ~64KB pipe buffer, head closes after line 1, sed takes
+# SIGPIPE, and the pipeline exits 141. In `_extract` the pipeline is the function's
+# terminal command, so that 141 propagates out of `got="$(_extract …)"` and aborts the
+# facts gate BEFORE any drift message prints (a crash / fail-open on duplicate input) —
+# the test below reproduced exactly that on the pre-fix code. In `_spec_get` a trailing
+# `printf` masked the pipeline status on some shells, so it did not always abort there,
+# but the same fragile pipe was present. The fix removes both pipes: capture the whole
+# output, take the first line with `${all%%$'\n'*}`. Each test feeds enough duplicate
+# matches to trip the old pipe; the first value still equals the spec, so --check passes.
+
+@test "check-facts --check: a duplicated spec key returns the first value, no SIGPIPE (#542 Bugbot)" {
+  # A second (identical) K3D_VERSION= line in facts.env, repeated past the pipe buffer.
+  # Locks the contract that _spec_get yields the FIRST value and never aborts the gate —
+  # even if a future edit drops the trailing printf that masked the old pipe's exit code.
+  { i=0; while [ "$i" -lt 20000 ]; do echo "K3D_VERSION=v5.9.0"; i=$((i + 1)); done; } >> "$REPO/scripts/spec/facts.env"
+  run _facts --check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"all installer facts match"* ]]
+}
+
+@test "check-facts --check: a duplicated consumer pin does not SIGPIPE _extract (#542 Bugbot)" {
+  # Many identical K3D_VERSION default lines in common.sh — each matches the extractor,
+  # so the old `sed | head -1` in _extract exited 141 (verified against the pre-fix code)
+  # and aborted the gate. The first line still equals the spec, so drift is zero.
+  { i=0; while [ "$i" -lt 20000 ]; do echo 'K3D_VERSION="${K3D_VERSION:-v5.9.0}"'; i=$((i + 1)); done; } >> "$REPO/scripts/lib/common.sh"
+  run _facts --check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"all installer facts match"* ]]
+}

--- a/scripts/tests/e2e-windows.ps1
+++ b/scripts/tests/e2e-windows.ps1
@@ -95,7 +95,15 @@ try {
   #    still logs 'Creating k3d cluster'), so the copy check + PASS could succeed WITHOUT a
   #    real create. Pre-clean any stale cluster first so every run genuinely creates one
   #    (#436 Bugbot). Bounded so a wedged delete can't hang the runner.
-  Invoke-Bounded 120 "k3d" @("cluster","delete",$env:CLUSTER_NAME) "pre-clean stale cluster" | Out-Null
+  #    The delete's exit code MUST gate the run: `k3d cluster delete` is idempotent (exit 0
+  #    even when no such cluster exists), so a non-zero code means a timeout (124) or a real
+  #    failure that may have LEFT the cluster in place. Swallowing it (the old `| Out-Null`)
+  #    let New-K3dCluster silently reuse the stale cluster and still reach a false PASS — the
+  #    exact false-green this pre-clean exists to prevent. Fail loudly instead (#542 Bugbot).
+  $preclean = Invoke-Bounded 120 "k3d" @("cluster","delete",$env:CLUSTER_NAME) "pre-clean stale cluster"
+  if ($preclean -ne 0) {
+    Stop-E2e ("pre-clean 'k3d cluster delete $env:CLUSTER_NAME' " + $(if ($preclean -eq 124) { "timed out after 120s" } else { "failed (exit $preclean)" }) + " — a stale cluster may remain, which would send New-K3dCluster down its reuse path and yield a false PASS without a real create. Delete it by hand and re-run.")
+  }
   New-K3dCluster
   kubectl wait --for=condition=Ready nodes --all --timeout=180s --request-timeout=30s
   Confirm-NativeOk "nodes did not reach Ready"


### PR DESCRIPTION
Fixes two Cursor Bugbot findings raised on the release-train staging-hop PR **client#542**. Per process, the fix lands on `develop` (not on the promotion branch #542) and rides the normal develop → staging → main promotion.

## Finding 1 — `scripts/check-facts.sh`: pipefail broken by `sed | head -1` (Medium)
`_spec_get` and `_extract` piped `sed -n … | head -1` under `set -o pipefail`. When a file holds a second match large enough to fill the ~64KB pipe buffer, `head` closes after line 1, `sed` takes SIGPIPE, and the pipeline exits 141. In `_extract` the pipeline is the function's terminal command, so that 141 propagates out of `got="$(_extract …)"` and **aborts the facts gate before any drift message prints** — a crash / fail-open on duplicate input. (In `_spec_get` a trailing `printf` masked the status on some shells, but the same fragile pipe was there.)

**Fix:** both helpers now capture the whole `sed` output and take the first line via parameter expansion — `all="$(sed -n … )"` then `${all%%$'\n'*}` — the repo's own house idiom (see `scripts/lib/gpu-nvidia.sh`). No pipe into `head`. An empty (no-match) result still yields empty, so every caller behaves exactly as before. These were the only two `| head -1` occurrences in `check-facts.sh`; the anti-pattern was not spread into unrelated sibling scripts.

**Tests:** two cases added to `scripts/tests/check-facts.bats` feed duplicate matches past the pipe buffer and assert `--check` still passes. The `_extract` case reproduced exit 141 against the pre-fix code; the fixed code is green.

## Finding 2 — `scripts/tests/e2e-windows.ps1`: pre-clean failure allows false PASS (Medium)
The pre-clean `k3d cluster delete` ran via `Invoke-Bounded … | Out-Null`, discarding its exit code. On the persistent Windows runner a timed-out (124) or failed delete leaves the `tbe2ewin` cluster in place; `New-K3dCluster` then takes its **reuse** path — which still logs `Creating k3d cluster` (line 2205, before the exists-check) — so the copy check + PASS succeed **without a real create**, the exact false-green this pre-clean was added to prevent.

**Fix:** the pre-clean now captures the exit code and fails the run (`Stop-E2e`) on non-zero, matching the existing `docker info` bounded-check idiom right above it. `k3d cluster delete` is idempotent — exit 0 when the cluster is absent — so the clean/first-run path is unaffected, while a timeout or real failure aborts instead of falling through to reuse.

**Tests:** `e2e-windows.ps1` has no Pester suite — it is an integration driver that dot-sources the real installer and runs against live Docker/k3d, so it cannot be unit-tested in isolation; it relies on the source-level guarantee. PSScriptAnalyzer lints it on every push (CI `static` job) and still reports no errors.

## Verification (local)
- `bats scripts/tests/*.bats` — **782 pass** (13/13 in check-facts.bats, incl. the 2 new regressions)
- `bash -n scripts/check-facts.sh` + `scripts/check-facts.sh --check` — green
- `pwsh` parse of `e2e-windows.ps1` — OK; PSScriptAnalyzer Error severity — clean (only pre-existing Write-Host/BOM warnings, unchanged)
- Neither file is in `scripts/manifest.sha256`, so no manifest regeneration needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes harden test/CI gates and an e2e driver; no runtime installer behavior for end users beyond more reliable checks.
> 
> **Overview**
> Addresses two Bugbot findings on CI/installer reliability.
> 
> **`check-facts.sh`:** `_spec_get` and `_extract` no longer use `sed … | head -1` under `set -o pipefail`. They capture full `sed` output and take the first line with `${all%%$'\n'*}` (same pattern as `gpu-nvidia.sh`), so duplicate matches past the pipe buffer cannot SIGPIPE the script and abort the facts gate before drift is reported. **`check-facts.bats`** adds two regressions that append ~20k duplicate spec/consumer lines and assert `--check` still succeeds.
> 
> **`e2e-windows.ps1`:** The bounded `k3d cluster delete` pre-clean now honors its exit code and calls `Stop-E2e` on timeout (124) or failure instead of piping to `Out-Null`, so a stale cluster cannot be silently reused and produce a false PASS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 670a6bee0ed61f2cb567abd9b65ce3cf802342c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->