### PR TITLE
fix(chart): jobs-manager Recreate + image-refresh no-restart-storm (RWO-PVC prod incident)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.10
-appVersion: "1.9.10"
+version: 1.9.11
+appVersion: "1.9.11"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -120,6 +120,18 @@ data:
         | jq -r --arg k "$_key" '.metadata.annotations[$k] // empty'
     }
 
+    # Skip the whole tick if the deployment isn't currently SETTLED (#546). A rollout
+    # already in progress, or a pod stuck (e.g. Pending on volume binding), means a restart
+    # can't help — it only churns ReplicaSets, and on a single-node local-path cluster that
+    # churn itself wedges provisioning (incident #545: RWO deadlock produced 19 restarts
+    # because each tick's rollout timed out and the next re-restarted, the digest annotation
+    # only landing after a rollout SUCCEEDS). concurrencyPolicy: Forbid stops overlapping
+    # JOBS; this stops the SEQUENTIAL restart storm. Retry on the next tick once settled.
+    if ! kubectl rollout status -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" --timeout=10s >/dev/null 2>&1; then
+      log "deployment/${DEPLOYMENT_NAME} not settled (rollout in progress or pod not Ready) -- skipping this refresh tick; will retry when settled"
+      exit 0
+    fi
+
     # =================================================================
     # Pass 1 — class-1 images: jobs-manager + pods-monitor.
     # docker.io, floating CLIENT_ENV tag, annotation-based source of

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -15,11 +15,17 @@ spec:
     matchLabels:
       app: manager
   replicas: 1
+  # Recreate, NOT RollingUpdate: jobs-manager mounts ReadWriteOnce PVCs (client-pvc,
+  # client-logs-pvc). RollingUpdate's maxSurge:1 brings up a SECOND pod before the old
+  # one is gone; both then contend for the same RWO volume. On a single-node local-path
+  # (WaitForFirstConsumer) cluster that permanently deadlocks provisioning after a node
+  # restart — two unscheduled consumers → the scheduler's VolumeBinding times out
+  # (context deadline exceeded) — and image-refresh then re-restarts every tick forever
+  # (its digest annotation only lands after a rollout succeeds, which it never does).
+  # Recreate keeps exactly ONE consumer, so provisioning + restarts always converge.
+  # mysql-deployment already uses Recreate for the same RWO-PVC reason.
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
+    type: Recreate
   template:
     metadata:
       labels:

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -132,6 +132,13 @@ tests:
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: "registry-1.docker.io"
+      # Regression guard (#546): the tick MUST skip when the deployment isn't settled,
+      # so a stuck/unschedulable jobs-manager (e.g. the RWO-PVC deadlock #545) can't be
+      # re-restarted every tick into a ReplicaSet storm. The guard runs `rollout status`
+      # and exits early before the digest loop.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "not settled .* skipping this refresh tick"
       # Regression guard: the digest-pinned skip MUST stay in the script.
       - matchRegex:
           path: data["image-refresh.sh"]

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -18,6 +18,19 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-jobs-manager
 
+  # jobs-manager mounts ReadWriteOnce PVCs (client-pvc, client-logs-pvc); it MUST use
+  # Recreate, never RollingUpdate. RollingUpdate's maxSurge brings up a second pod that
+  # contends for the RWO volume and permanently deadlocks WaitForFirstConsumer
+  # provisioning on a single-node local-path cluster after a restart (production incident:
+  # jobs-manager Pending for hours, blocking ingestion). Regression guard for that fix.
+  - it: must use the Recreate strategy (RWO PVC — no surge pod), not RollingUpdate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - notExists:
+          path: spec.strategy.rollingUpdate
+
   - it: should have standard labels
     asserts:
       - exists:


### PR DESCRIPTION
## Fix a production RWO-PVC deadlock: jobs-manager → `Recreate`

**Incident:** a client's `hi-jobs-manager` sat `Pending` for 4+ hours, blocking dataset ingestion. Root cause is entirely ours — the client's command and YAML were correct.

### Root cause
`jobs-manager` mounts two **ReadWriteOnce** PVCs (`client-pvc`, `client-logs-pvc`; `local-path`, `WaitForFirstConsumer`) but used `strategy: RollingUpdate` with `maxSurge: 1` — a **second** pod is created before the old one goes away.
- Healthy single node: works (RWO permits two pods on the same node), so it ran for days.
- After a routine WSL2/Docker restart the PVCs re-provision, and the rollout now presents **two** unscheduled consumers → `WaitForFirstConsumer` can't pick one → scheduler `VolumeBinding` PreBind times out (`context deadline exceeded`) → never schedules.
- **`mysql` already uses `Recreate`** for the identical RWO-PVC reason; `jobs-manager` was an oversight.
- `image-refresh` compounds it: it records its digest annotation only after `rollout status` succeeds — which now never happens — so it re-restarts every 15 min forever (19 revisions), starving `mysql` too. jobs-manager never Ready → Service has no endpoints → ingestor `curl jobs-manager:8080` fails → ingestion post-hook fails.

### Fix
- **`jobs-manager` → `strategy: Recreate`** (drop `maxSurge`): exactly one RWO consumer at a time, so provisioning + restarts always converge, even after a node restart.
- **Regression guard:** `jobs_manager_test.yaml` now asserts `strategy.type == Recreate` and no `rollingUpdate` block.
- **Chart 1.9.10 → 1.9.11** (content change must bump to reach installs).

### Validation
- `helm unittest ./client -f tests/jobs_manager_test.yaml` → **28/28 pass** (incl. the new Recreate guard); `helm template` renders `type: Recreate`.
- (4 unrelated suites fail on my local **helm v4.2.0** — stricter `values.schema.json` than CI's pinned **v3.15.4** — confirmed identical on clean develop, not from this change.)

### Follow-ups (compounding factors, filed separately)
- #546 — image-refresh restart-forever loop when a rollout can't complete
- #547 — K8S version pin reaching clients (this client was on unpinned k3s v1.35.5)
- #548 — cluster surviving a laptop/WSL2 restart (local-path PVCs stranded Pending)

Closes #545

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout behavior for the core jobs-manager Deployment and image-refresh on every install; low blast radius for multi-node clusters but high operational impact where RWO + image-refresh loops were failing ingestion.
> 
> **Overview**
> Fixes a production RWO-PVC deadlock by changing **jobs-manager** from `RollingUpdate` (with `maxSurge: 1`) to **`strategy: Recreate`**, so only one pod mounts the ReadWriteOnce `client-pvc` / `client-logs-pvc` at a time—matching **mysql** and avoiding two consumers wedging `WaitForFirstConsumer` volume binding on single-node local-path clusters.
> 
> The **image-refresh** script now **skips a tick** when `kubectl rollout status` does not succeed within 10s (rollout in progress or pod not Ready), preventing repeated `rollout restart` storms while the deployment is stuck.
> 
> Chart version **1.9.10 → 1.9.11**. **Helm unittest** regression guards lock Recreate on jobs-manager and the “not settled … skipping” path in image-refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8ffc533f7140df818fd92d88ffa606fb93d57ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->