### PR TITLE
refactor(e2e): single-source the k3d bring-up prelude (#541 review)

### DIFF
--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -67,11 +67,11 @@ jobs:
           # below for visibility but don't fail the gate.
           shellcheck --severity=error --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/gen-manifest.sh scripts/check-facts.sh scripts/check-style.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
-            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/path-persist.sh
+            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/lib/e2e-common.sh scripts/tests/path-persist.sh
           echo "── shellcheck warnings (advisory, non-blocking) ──"
           shellcheck --severity=warning --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/gen-manifest.sh scripts/check-facts.sh scripts/check-style.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
-            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/path-persist.sh || true
+            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/lib/e2e-common.sh scripts/tests/path-persist.sh || true
 
       - name: Installer manifest is current (supply-chain, R8)
         # The bootstrap verifies each sub-script against scripts/manifest.sha256

--- a/.github/workflows/standard-checks.yml
+++ b/.github/workflows/standard-checks.yml
@@ -44,7 +44,7 @@ jobs:
           shellcheck --version | grep version
           shellcheck --severity=error --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
-            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh
+            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/lib/e2e-common.sh
 
   unit-tests:
     name: Unit tests

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ eggs/
 .eggs/
 lib/
 !scripts/lib/
+!scripts/tests/lib/
 lib64/
 parts/
 sdist/

--- a/scripts/tests/e2e-auto-upgrade.sh
+++ b/scripts/tests/e2e-auto-upgrade.sh
@@ -46,11 +46,10 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB="$HERE/../lib"
 CHART_DIR="$HERE/../../client"
 
-# Isolated cluster + release so we never touch a real 'tracebloc' install; opt
-# out of autostart so we don't reconfigure docker.service on the host.
-export USER="${USER:-$(id -un)}"
-export CLUSTER_NAME="${CLUSTER_NAME:-tbupg}"
-export TRACEBLOC_NO_AUTOSTART=1
+# Shared bring-up contract (isolation env + tool-install prereqs).
+# shellcheck source=/dev/null
+source "$HERE/lib/e2e-common.sh"
+e2e_isolate_env tbupg
 NS="tbupg"
 REPO_NAME="tracebloc"
 REPO_URL="https://tracebloc.github.io/client"
@@ -103,15 +102,11 @@ echo "════════════════════════�
 echo "  E2E auto-upgrade gate   arch: $(uname -m)   kernel: $(uname -r)"
 echo "═══════════════════════════════════════════════════════════════════════"
 
-has docker || error "Docker is not available on this host."
 # jq reads the baseline release's computed values (BASELINE_PROD_DIGEST).
 # Preinstalled on GitHub-hosted runners; local runs must bring their own —
 # fail fast here instead of a mid-run pipeline abort.
 has jq || error "jq is required (it reads the baseline release's computed values)."
-umask 022
-install_kubectl
-install_k3d
-install_helm
+e2e_install_prereqs
 
 echo "── create_cluster() — the installer's real cluster-bring-up path ──"
 create_cluster

--- a/scripts/tests/e2e-cluster.sh
+++ b/scripts/tests/e2e-cluster.sh
@@ -21,11 +21,10 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB="$HERE/../lib"
 
-# Isolated cluster name so we never touch a real 'tracebloc' cluster; opt out of
-# autostart so we don't reconfigure docker.service / restart policies on the host.
-export USER="${USER:-$(id -un)}"
-export CLUSTER_NAME="${CLUSTER_NAME:-tbe2e}"
-export TRACEBLOC_NO_AUTOSTART=1
+# Shared bring-up contract (isolation env + tool-install prereqs).
+# shellcheck source=/dev/null
+source "$HERE/lib/e2e-common.sh"
+e2e_isolate_env tbe2e
 
 # shellcheck source=/dev/null
 source "$LIB/common.sh"
@@ -45,11 +44,7 @@ echo "════════════════════════�
 
 # Docker is preinstalled + running on the runner; we only need the CLI tools the
 # cluster step uses. (We do NOT run install_docker_engine — no daemon gymnastics.)
-has docker || error "Docker is not available on this host."
-umask 022
-install_kubectl
-install_k3d
-install_helm
+e2e_install_prereqs
 
 echo "── create_cluster() — the installer's real cluster-bring-up path ──"
 create_cluster

--- a/scripts/tests/e2e-journey.sh
+++ b/scripts/tests/e2e-journey.sh
@@ -43,12 +43,10 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB="$HERE/../lib"
 
-# Isolated cluster name so we never touch a real 'tracebloc' cluster; opt out of
-# autostart so we don't reconfigure docker.service / restart policies on the host
-# (identical isolation posture to e2e-cluster.sh).
-export USER="${USER:-$(id -un)}"
-export CLUSTER_NAME="${CLUSTER_NAME:-tbe2e-journey}"
-export TRACEBLOC_NO_AUTOSTART=1
+# Shared bring-up contract (isolation env + tool-install prereqs).
+# shellcheck source=/dev/null
+source "$HERE/lib/e2e-common.sh"
+e2e_isolate_env tbe2e-journey
 
 TB_NAMESPACE="${TB_NAMESPACE:-tracebloc}"
 # Cosmetic stand-ins for the chart's real values — discovery keys off the LABELS
@@ -117,11 +115,7 @@ echo "  install → CLI → cluster info (fresh shell) → dataset push --dry-ru
 echo "═══════════════════════════════════════════════════════════════════════"
 
 # ── Step 1: bring the cluster up via the installer's real path ───────────────
-has docker || error "Docker is not available on this host."
-umask 022
-install_kubectl
-install_k3d
-install_helm
+e2e_install_prereqs
 
 echo ""
 echo "── Step 1: create_cluster() — the installer's real cluster-bring-up ─────"

--- a/scripts/tests/e2e-proxy.sh
+++ b/scripts/tests/e2e-proxy.sh
@@ -23,9 +23,10 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB="$HERE/../lib"
 
-export USER="${USER:-$(id -un)}"
-export CLUSTER_NAME="${CLUSTER_NAME:-tbproxy}"
-export TRACEBLOC_NO_AUTOSTART=1
+# Shared bring-up contract (isolation env + tool-install prereqs).
+# shellcheck source=/dev/null
+source "$HERE/lib/e2e-common.sh"
+e2e_isolate_env tbproxy
 
 PROXY_USER="tbuser"
 PROXY_PASS="tb-Pass.123"          # contains no '@', but the URL form does: user:pass@host
@@ -51,14 +52,9 @@ echo "════════════════════════�
 echo "  Authenticated-proxy E2E   arch: $(uname -m)"
 echo "═══════════════════════════════════════════════════════════════════════"
 
-has docker || error "Docker is not available on this host."
-
-# Install the CLI tools directly (the proxy below is exercised by the cluster
-# NODES, which is where the auth-proxy hardening lives).
-umask 022
-install_kubectl
-install_k3d
-install_helm
+# The proxy below is exercised by the cluster NODES, which is where the
+# auth-proxy hardening lives — so we just need the CLI tools + a cluster.
+e2e_install_prereqs
 
 # ── 1. squid that REQUIRES basic auth ───────────────────────────────────────
 echo "── starting an authenticated squid proxy ──"

--- a/scripts/tests/lib/e2e-common.sh
+++ b/scripts/tests/lib/e2e-common.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  e2e-common.sh — shared bring-up contract for scripts/tests/e2e-*.sh
+# -----------------------------------------------------------------------------
+#  The e2e harnesses (e2e-cluster / e2e-proxy / e2e-journey / e2e-auto-upgrade,
+#  plus the seal-check runner) each bring up a k3d cluster through the same two
+#  blocks, previously copy-pasted near-verbatim: the isolation env (USER +
+#  CLUSTER_NAME default + TRACEBLOC_NO_AUTOSTART) and the tool-install
+#  prerequisites (docker check + umask + install_{kubectl,k3d,helm}). Multiple
+#  Bugbot rounds have changed the install sequence, and every copy had to move
+#  in lockstep or drift (PR #541 review). This single-sources those two blocks.
+#
+#  Deliberately NOT extracted — these legitimately differ per script, so
+#  unifying them would change behavior:
+#    * the sub-lib `source` set — e2e-proxy / e2e-journey source
+#      common+setup-linux+cluster only; e2e-cluster / e2e-auto-upgrade also
+#      source preflight (which has top-level PF_* side effects). (That proxy /
+#      journey call create_cluster without preflight is a pre-existing
+#      inconsistency worth a separate look — NOT changed here.)
+#    * the `cleanup`/`trap` body — each reaps its own extra resources
+#      (a squid container, work dirs) beyond the k3d cluster.
+#    * CHART_DIR — only the chart-installing scripts set it.
+#
+#  Sourcing contract: source this file, then call the functions AFTER
+#  common.sh + setup-linux.sh are sourced (e2e_install_prereqs resolves
+#  `has`/`error` from common.sh and `install_*` from setup-linux.sh at CALL
+#  time). This file defines functions only — no side effects on source.
+# =============================================================================
+
+# Isolate the run: a throwaway CLUSTER_NAME so we never touch a real 'tracebloc'
+# install, and TRACEBLOC_NO_AUTOSTART so create_cluster never reconfigures the
+# host's Docker restart policy / runs `systemctl enable docker`.
+#   $1 — the caller's default CLUSTER_NAME (still overridable via the env).
+e2e_isolate_env() {
+  export USER="${USER:-$(id -un)}"
+  export CLUSTER_NAME="${CLUSTER_NAME:-$1}"
+  export TRACEBLOC_NO_AUTOSTART=1
+}
+
+# Install the CLI prerequisites a k3d bring-up needs. The sourced libs DEFINE
+# install_kubectl/install_k3d/install_helm but do not call them; create_cluster
+# + helm need the binaries on PATH first, and a stock GitHub runner ships none.
+# Callers with extra prerequisites (e.g. e2e-auto-upgrade needs jq) check those
+# alongside this call.
+e2e_install_prereqs() {
+  has docker || error "Docker is not available on this host."
+  umask 022
+  install_kubectl
+  install_k3d
+  install_helm
+}


### PR DESCRIPTION
## Single-source the e2e k3d bring-up prelude

Addresses @saqlainsyed007's review on [#541](https://github.com/tracebloc/client/pull/541) (thread on `scripts/tests/e2e-seal-check.sh:36`): the bring-up prelude was copy-pasted near-verbatim across `scripts/tests/e2e-*.sh`, and multiple Bugbot rounds had to edit every copy in lockstep or they'd drift.

### What's extracted → `scripts/tests/lib/e2e-common.sh`
Two functions — the parts that were **byte-identical** and drift-prone:
- **`e2e_isolate_env <name>`** — `USER` + `CLUSTER_NAME` default + `TRACEBLOC_NO_AUTOSTART` (the distinct default is the arg, still env-overridable).
- **`e2e_install_prereqs`** — `has docker` + `umask 022` + `install_{kubectl,k3d,helm}` (the sequence the Bugbot rounds kept changing).

`e2e-cluster` / `e2e-proxy` / `e2e-journey` / `e2e-auto-upgrade` now source the lib and call these; each keeps its own `CLUSTER_NAME` and test logic. `e2e-auto-upgrade` keeps its extra `has jq` guard right before the call.

### Deliberately **not** unified (unifying would change behavior)
- **The sub-lib `source` set** — `e2e-proxy`/`e2e-journey` source `common`+`setup-linux`+`cluster` only; `e2e-cluster`/`e2e-auto-upgrade` also source `preflight` (which has top-level `PF_*` side effects). ⚠️ *Both proxy and journey call `create_cluster` — which uses `_pf_recheck_runtime_mem`, defined only in `preflight.sh` — without sourcing it. That's a pre-existing inconsistency worth a separate look; I did not change it here.*
- **`cleanup`/`trap` bodies** — each reaps its own extra resources (a squid container, work dirs) beyond the k3d cluster.
- **`CHART_DIR`** — only the chart-installing scripts set it.

### Scope note
`e2e-seal-check.sh` lives on the still-open #541 branch, not `develop`, so it's **not** touched here (keeps this PR non-stacked). It adopts the lib as a fast-follow once both land.

### Verified
- Added the lib to **both** shellcheck gates: `installer-tests.yaml` and the **required** `standard-checks.yml` Lint.
- `shellcheck --severity=error` (the gate) **and** `--severity=warning` clean on all 5 files; `bash -n` ok.
- Net −20 lines of duplication. The live `e2e-cluster` / `e2e-proxy` / `e2e-journey` / `upgrade-e2e` CI jobs exercise the refactored scripts on this PR.

Targets `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness refactor with no production installer behavior change; existing e2e CI jobs exercise the updated scripts.
> 
> **Overview**
> **Centralizes the duplicated k3d e2e bring-up prelude** in `scripts/tests/lib/e2e-common.sh`: `e2e_isolate_env` sets `USER`, a per-script default `CLUSTER_NAME`, and `TRACEBLOC_NO_AUTOSTART`; `e2e_install_prereqs` checks Docker, sets `umask`, and runs `install_kubectl` / `install_k3d` / `install_helm`.
> 
> `e2e-cluster`, `e2e-proxy`, `e2e-journey`, and `e2e-auto-upgrade` now source that lib instead of inlining the same blocks (each still passes its own cluster name; auto-upgrade keeps its separate `jq` check).
> 
> CI **Lint** and **installer-tests** shellcheck steps include the new file. `.gitignore` adds `!scripts/tests/lib/` so the test lib is not swallowed by the existing `lib/` ignore rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b2be37afc04f2a8dbb384206060fa4fca782e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->