### PR TITLE
ci(windows-e2e): stop the teardown net failing open

### DIFF
--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -80,9 +80,28 @@ jobs:
           # net for a driver that died before its finally ran, plus the data-dir cleanup we
           # deliberately deferred so the log survived for the upload above. Bound the delete
           # so a wedged Docker/WSL teardown can't hang the shared runner (#436 Bugbot).
+          # The delete must not fail OPEN. This net exists precisely because a leftover
+          # tbe2ewin cluster on the shared runner sends the NEXT run's New-K3dCluster down
+          # its reuse path and yields a false PASS with no real create (#542 Bugbot). The
+          # old form swallowed everything in an empty catch: Start-Process without
+          # -ErrorAction Stop, and no null-check on $p, so a SPAWN failure left $p null,
+          # $p.HasExited threw, the catch ate it, and the stale cluster survived unseen.
+          $ErrorActionPreference = 'Stop'
+          $deleted = $false
           try {
             $p = Start-Process k3d -ArgumentList "cluster","delete",$env:CLUSTER_NAME -NoNewWindow -PassThru
+            if ($null -eq $p) { throw "k3d cluster delete did not start (Start-Process returned null)" }
             $p | Wait-Process -Timeout 120 -ErrorAction SilentlyContinue
-            if (-not $p.HasExited) { $p | Stop-Process -Force -ErrorAction SilentlyContinue }
-          } catch { }
+            if (-not $p.HasExited) {
+              $p | Stop-Process -Force -ErrorAction SilentlyContinue
+              throw "k3d cluster delete did not finish within 120s and was killed"
+            }
+            if ($p.ExitCode -ne 0) { throw "k3d cluster delete exited $($p.ExitCode)" }
+            $deleted = $true
+          } catch {
+            # always() teardown: the run is already over, so do not fail it here. But a
+            # leftover cluster MUST be visible, or the next run false-passes silently.
+            Write-Host "::warning::teardown safety-net could not confirm '$env:CLUSTER_NAME' was deleted: $_. A stale cluster may remain on this persistent runner and would send the next run's create down the reuse path. Delete it by hand: k3d cluster delete $env:CLUSTER_NAME"
+          }
+          if ($deleted) { Write-Host "teardown: '$env:CLUSTER_NAME' deleted" }
           if ($env:HOST_DATA_DIR) { Remove-Item -Recurse -Force $env:HOST_DATA_DIR -ErrorAction SilentlyContinue }


### PR DESCRIPTION
The `always()` safety-net teardown ran `k3d cluster delete` via `Start-Process` with **no** `-ErrorAction Stop`, **no** null-check on `$p`, inside an **empty catch**, and the step never set `$ErrorActionPreference`.

So a **spawn failure** left `$p` null → `$p.HasExited` threw → the empty catch ate it → the shared runner kept a leftover `tbe2ewin` cluster. That is the exact state this net exists to clear, and the one that sends the next run's `New-K3dCluster` down its reuse path for a **false PASS** with no real create — the same false-green class as `#544`, one layer up in the workflow rather than the driver script.

**Fix:** `$ErrorActionPreference = 'Stop'`, explicit null-check, a timeout-kill that surfaces instead of hiding, and an exit-code check. On failure it does **not** fail the run — this is `always()` teardown and the run is already over — but emits a `::warning::` naming the stale cluster and the manual remedy, so a leftover can never be silent again.

Found by Bugbot on the release-train staging hop (`client#542`), High.

Refs: tracebloc/backend#1426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only PowerShell in an `always()` teardown step; behavior change is better observability and stricter delete validation without altering the main e2e driver or installer.
> 
> **Overview**
> The Windows e2e **`always()` teardown** step no longer **fails open** when `k3d cluster delete` does not actually run or finish.
> 
> It sets **`$ErrorActionPreference = 'Stop'`**, validates that **`Start-Process`** returned a process, treats **120s timeout + kill** and **non-zero exit** as failures instead of swallowing them, and replaces the **empty `catch`** with a **`::warning::`** that names **`tbe2ewin`**, the reuse-path false-pass risk, and the manual delete command. Successful deletes log confirmation; the step still **does not fail the job** on teardown errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9020bbbe0244091fe387ab53284282ce73519375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->