### PR TITLE
fix(chart): requests-proxy honours a pinned digest for imagePullPolicy (#552)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.11
-appVersion: "1.9.11"
+version: 1.9.12
+appVersion: "1.9.12"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -22,8 +22,12 @@ spec:
           type: RuntimeDefault
       containers:
         - name: proxy
-          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" (dig "requestsProxy" "digest" "" .Values.images) "registry" "docker.io") | quote }}
-          imagePullPolicy: Always
+          {{- $rpDigest := (dig "requestsProxy" "digest" "" .Values.images) }}
+          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" $rpDigest "registry" "docker.io") | quote }}
+          # digest set -> repo@digest + IfNotPresent (restart-safe offline); empty ->
+          # repo:tag + Always. Was hardcoded Always, which ignored a pinned digest and
+          # re-pulled on every restart even when the image was already cached (#552).
+          imagePullPolicy: {{ if $rpDigest }}IfNotPresent{{ else }}Always{{ end }}
           workingDir: /app
           command: ["python", "-m", "gunicorn"]
           args:

--- a/client/tests/requests_proxy_test.yaml
+++ b/client/tests/requests_proxy_test.yaml
@@ -79,6 +79,30 @@ tests:
           path: spec.template.spec.containers[0].image
           pattern: "^docker\\.io/tracebloc/jobs-manager[:@]"
 
+  - it: floats on the tag with imagePullPolicy Always when no digest is pinned (default)
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^docker\\.io/tracebloc/jobs-manager:"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: pins repo@digest with imagePullPolicy IfNotPresent when a digest is set (#552)
+    # Was hardcoded Always — a pinned digest was ignored for the pull policy, so a
+    # restart re-pulled instead of using the cached image. Now digest-aware.
+    set:
+      images:
+        requestsProxy:
+          digest: "sha256:dfdaa7e633a8df0f46b403e9422eba5c16bdb7d9c39047e6d3738f9e38fbdba8"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/jobs-manager@sha256:dfdaa7e633a8df0f46b403e9422eba5c16bdb7d9c39047e6d3738f9e38fbdba8
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
   - it: should expose the proxy on container port 8888
     asserts:
       - equal:


### PR DESCRIPTION
## What & why

Narrow, safe part of #552 (control-plane restart resilience). `requests-proxy` **hardcoded `imagePullPolicy: Always`** even though its image line already read `images.requestsProxy.digest` — so a pinned digest was silently ignored for the pull policy, and every pod restart re-pulled the image even when it was already cached in containerd. That's the same offline-restart fragility class as the incident, and it's an outright inconsistency bug (the other control-plane deployments are already digest-aware).

## Change

`client/templates/requests-proxy-deployment.yaml` — pull policy now mirrors jobs-manager / pods-monitor / resource-monitor:

- `images.requestsProxy.digest` **set** → `repo@digest` + `IfNotPresent` (restart-safe offline)
- `images.requestsProxy.digest` **empty** (default) → `repo:tag` + `Always` (**unchanged** default behaviour)

Verified by render: default → `docker.io/tracebloc/jobs-manager:prod` + `Always`; with a digest → `…@sha256:…` + `IfNotPresent`.

## Tests

`client/tests/requests_proxy_test.yaml` — **+2** helm-unittest cases: default floats on the tag with `Always`; a set digest renders `repo@digest` + `IfNotPresent`. Suite green (13/13).

`client/Chart.yaml` 1.9.11 → **1.9.12** (chart-content change requires a bump).

## Scope

This is deliberately only the requests-proxy bug. The **broader** offline-restart update-model change for the always-running images — `jobs-manager`/`pods-monitor` are updated by the image-refresh CronJob via `rollout restart`, which *relies* on `Always`, and `resource-monitor` isn't refreshed at all — is a real design decision (digest-pin à la `ingestor.prodDigest`, vs. digest-on-update in image-refresh) and is tracked in **#569**.

Part of #552.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow Helm template fix with unchanged default behaviour when no digest is set; covered by new unit tests.
> 
> **Overview**
> **requests-proxy** no longer hardcodes `imagePullPolicy: Always` when `images.requestsProxy.digest` is set. Pull policy now matches jobs-manager, pods-monitor, and resource-monitor: pinned digest → `repo@digest` + `IfNotPresent` (restart without registry); no digest → tag + `Always` (unchanged default).
> 
> Helm unittest adds two cases for default vs digest-pinned rendering. Chart version **1.9.11 → 1.9.12**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97611facf42b6c3ba6aef37bc6ed929edacc247d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->