### PR TITLE
fix(chart): image-refresh CronJob must not treat every error as a benign skip (#571)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.11
-appVersion: "1.9.11"
+version: 1.9.12
+appVersion: "1.9.12"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -238,7 +238,13 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 300
+      # MUST exceed imageRefresh.rolloutTimeout (default 10m): a legitimate tick does
+      # `rollout restart` and then waits on `rollout status` for up to that long, so a
+      # deadline below it would kill the wait mid-flight and the post-success digest
+      # annotation would never land, causing later ticks to re-restart forever (#572).
+      # This is only a backstop -- every API call is already --request-timeout-bounded;
+      # it just caps the total wall-clock well above any sane rollout wait.
+      activeDeadlineSeconds: 1800
       template:
         metadata:
           labels:

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -127,9 +127,20 @@ data:
     # because each tick's rollout timed out and the next re-restarted, the digest annotation
     # only landing after a rollout SUCCEEDS). concurrencyPolicy: Forbid stops overlapping
     # JOBS; this stops the SEQUENTIAL restart storm. Retry on the next tick once settled.
-    if ! kubectl rollout status -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" --timeout=10s >/dev/null 2>&1; then
-      log "deployment/${DEPLOYMENT_NAME} not settled (rollout in progress or pod not Ready) -- skipping this refresh tick; will retry when settled"
-      exit 0
+    # A non-zero rollout status is NOT automatically "in progress -- skip" (#571). It is
+    # also NotFound, RBAC denial, and API errors -- treating those as a benign skip
+    # (exit 0) leaves the CronJob GREEN forever while refresh never runs. Only a
+    # genuinely-present-but-unsettled deployment is a legit skip; anything else the job
+    # must SURFACE. --request-timeout bounds each API CALL (not just the rollout wait),
+    # so a wedged API cannot hang the tick with no activeDeadlineSeconds while
+    # concurrencyPolicy: Forbid blocks every later tick.
+    if ! kubectl rollout status -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" --request-timeout=15s --timeout=10s >/dev/null 2>&1; then
+      if kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" --request-timeout=15s >/dev/null 2>&1; then
+        log "deployment/${DEPLOYMENT_NAME} not settled (rollout in progress or pod not Ready) -- skipping this refresh tick; will retry when settled"
+        exit 0
+      fi
+      log "ERROR: cannot read deployment/${DEPLOYMENT_NAME} (NotFound, RBAC denial, or API error) -- not a benign skip; failing the tick so it is visible"
+      exit 1
     fi
 
     # =================================================================
@@ -227,6 +238,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
+      activeDeadlineSeconds: 300
       template:
         metadata:
           labels:


### PR DESCRIPTION
## The bug (Medium)

The image-refresh CronJob's settled-gate ran `kubectl rollout status` and treated **any** non-zero as *"rollout in progress — skip this tick"* (`exit 0`). But non-zero is also **NotFound, RBAC denial, and API errors** — so a misconfigured or unreachable deployment left the CronJob **green forever while refresh never ran**.

Second issue: the call had no `--request-timeout` (only `--timeout`, which is the *rollout wait*, not the API-call bound). With `concurrencyPolicy: Forbid` and no `activeDeadlineSeconds`, a wedged API could hang the tick and block every later tick.

## Fix

- **Disambiguate non-zero:** if `kubectl get deployment` still succeeds, it's genuinely present-but-unsettled → legit skip (`exit 0`). Otherwise it's surfaced (`exit 1`) so the CronJob shows failed instead of green.
- **`--request-timeout=15s`** on both calls — bounds each API request, so a wedged server can't hang the tick.
- **`activeDeadlineSeconds: 300`** on the Job — caps the whole run as a backstop.

Found by Bugbot on the prod promotion PR (`client#571`). Fixed on develop; it reaches prod via the normal develop → staging → prod path.

## Note

The first commit on this branch mistakenly committed the file unmodified (a patch anchor mismatched the real 4-space indentation); the second commit is the actual fix. Net diff is the fix only.

Refs: tracebloc/backend#1426

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operational behavior of a cluster CronJob that restarts jobs-manager; misclassification fixes reduce silent outage risk but failed ticks may now alert where skips were previously hidden.
> 
> **Overview**
> **Fixes silent failure and hang risk in the image-refresh CronJob** when the jobs-manager deployment cannot be reconciled normally.
> 
> The **settled-gate** no longer treats every failed `kubectl rollout status` as a benign skip. It now confirms the deployment still exists with `kubectl get deployment`; only then does it skip the tick (`exit 0`). **NotFound, RBAC, or API errors** fail the job (`exit 1`) so the CronJob shows failed instead of staying green while refresh never runs.
> 
> Both kubectl calls in that gate use **`--request-timeout=15s`** so a wedged API cannot block the tick indefinitely under `concurrencyPolicy: Forbid`.
> 
> The Job spec adds **`activeDeadlineSeconds: 1800`** as a wall-clock backstop sized above the default **`rolloutTimeout` (10m)** so legitimate rollout waits are not killed mid-flight (which would prevent digest annotations and cause repeat restarts, #572).
> 
> Chart version bumps to **1.9.12**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6bdb381aef3de762370e2e1000054562ebd7251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->