### PR TITLE
release-train: develop -> staging

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.11
-appVersion: "1.9.11"
+version: 1.9.12
+appVersion: "1.9.12"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -238,7 +238,13 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 300
+      # MUST exceed imageRefresh.rolloutTimeout (default 10m): a legitimate tick does
+      # `rollout restart` and then waits on `rollout status` for up to that long, so a
+      # deadline below it would kill the wait mid-flight and the post-success digest
+      # annotation would never land, causing later ticks to re-restart forever (#572).
+      # This is only a backstop -- every API call is already --request-timeout-bounded;
+      # it just caps the total wall-clock well above any sane rollout wait.
+      activeDeadlineSeconds: 1800
       template:
         metadata:
           labels:

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -127,9 +127,20 @@ data:
     # because each tick's rollout timed out and the next re-restarted, the digest annotation
     # only landing after a rollout SUCCEEDS). concurrencyPolicy: Forbid stops overlapping
     # JOBS; this stops the SEQUENTIAL restart storm. Retry on the next tick once settled.
-    if ! kubectl rollout status -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" --timeout=10s >/dev/null 2>&1; then
-      log "deployment/${DEPLOYMENT_NAME} not settled (rollout in progress or pod not Ready) -- skipping this refresh tick; will retry when settled"
-      exit 0
+    # A non-zero rollout status is NOT automatically "in progress -- skip" (#571). It is
+    # also NotFound, RBAC denial, and API errors -- treating those as a benign skip
+    # (exit 0) leaves the CronJob GREEN forever while refresh never runs. Only a
+    # genuinely-present-but-unsettled deployment is a legit skip; anything else the job
+    # must SURFACE. --request-timeout bounds each API CALL (not just the rollout wait),
+    # so a wedged API cannot hang the tick with no activeDeadlineSeconds while
+    # concurrencyPolicy: Forbid blocks every later tick.
+    if ! kubectl rollout status -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" --request-timeout=15s --timeout=10s >/dev/null 2>&1; then
+      if kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" --request-timeout=15s >/dev/null 2>&1; then
+        log "deployment/${DEPLOYMENT_NAME} not settled (rollout in progress or pod not Ready) -- skipping this refresh tick; will retry when settled"
+        exit 0
+      fi
+      log "ERROR: cannot read deployment/${DEPLOYMENT_NAME} (NotFound, RBAC denial, or API error) -- not a benign skip; failing the tick so it is visible"
+      exit 1
     fi
 
     # =================================================================
@@ -227,6 +238,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
+      activeDeadlineSeconds: 300
       template:
         metadata:
           labels:


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the image-refresh CronJob fails vs skips, which affects automatic rollout of jobs-manager/pods-monitor; misclassification could either churn restarts or leave stale images until noticed.
> 
> **Overview**
> **Bumps the client Helm chart to 1.9.12** as part of the develop → staging release train.
> 
> **Image-refresh CronJob behavior** is tightened so operational failures are visible instead of silently succeeding:
> 
> - Before rollout checks, **`kubectl rollout status` and `get deployment` use `--request-timeout=15s`** so a wedged API cannot hang a tick indefinitely while `concurrencyPolicy: Forbid` blocks later runs.
> - A failed rollout status is **only treated as a benign skip when the deployment still exists** (rollout in progress / not Ready). **NotFound, RBAC denials, and other API errors now fail the job (`exit 1`)** instead of exiting 0 and leaving the CronJob green while refresh never runs (#571).
> - The Job spec adds **`activeDeadlineSeconds: 1800`** so a legitimate tick is not killed mid-`rollout status` wait (must exceed the default 10m rollout timeout); without it, digest annotations might never land and later ticks could restart forever (#572).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f503d284a529bcbf0ba7df7de6459ced4374ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->