### PR TITLE
fix(ci): bound kubectl/curl in e2e-seal-check.sh + helm-ci.yaml (backend#1497)

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -109,8 +109,10 @@ jobs:
           TARBALL="kubeconform-linux-amd64.tar.gz"
           URL="https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/${TARBALL}"
           # -f so an HTTP error is a curl failure rather than an error page
-          # written to disk and handed to sha256sum.
-          curl -fsSL --retry 3 --retry-delay 2 -o "$RUNNER_TEMP/$TARBALL" "$URL"
+          # written to disk and handed to sha256sum. --connect-timeout/--max-time
+          # bound the download so a stalled endpoint fails the step fast instead of
+          # hanging the template matrix to the GitHub Actions cap (backend#1497).
+          curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 120 -o "$RUNNER_TEMP/$TARBALL" "$URL"
           # Any mismatch exits non-zero here, and `set -e` fails the step before
           # the binary is extracted or placed on PATH.
           echo "${KUBECONFORM_SHA256}  $RUNNER_TEMP/$TARBALL" | sha256sum -c -

--- a/scripts/tests/e2e-seal-check.sh
+++ b/scripts/tests/e2e-seal-check.sh
@@ -96,20 +96,20 @@ echo "── positive control: a non-policied pod must REACH ${HOST}:443 ──"
 # created ("serviceaccount default not found"), which aborts under set -e before
 # the attribution failure below. Wait for the SA to exist first (Bugbot).
 for _ in $(seq 1 20); do
-  kubectl get serviceaccount default -n default >/dev/null 2>&1 && break
+  kubectl --request-timeout=10s get serviceaccount default -n default >/dev/null 2>&1 && break
   sleep 1
 done
-kubectl run seal-poscheck --namespace default --restart=Never \
+kubectl --request-timeout=10s run seal-poscheck --namespace default --restart=Never \
   --image="curlimages/curl:8.20.0" \
   --command -- curl --noproxy '*' --tlsv1.2 -k -sS -m 15 -o /dev/null "https://${HOST}"
 posphase=""
 for _ in $(seq 1 40); do
-  posphase="$(kubectl get pod seal-poscheck -n default -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+  posphase="$(kubectl --request-timeout=10s get pod seal-poscheck -n default -o jsonpath='{.status.phase}' 2>/dev/null || true)"
   { [ "$posphase" = "Succeeded" ] || [ "$posphase" = "Failed" ]; } && break
   sleep 3
 done
-kubectl logs seal-poscheck -n default 2>/dev/null || true
-kubectl delete pod seal-poscheck -n default --ignore-not-found --now >/dev/null 2>&1 || true
+kubectl --request-timeout=10s logs seal-poscheck -n default 2>/dev/null || true
+kubectl --request-timeout=10s delete pod seal-poscheck -n default --ignore-not-found --now >/dev/null 2>&1 || true
 [ "$posphase" = "Succeeded" ] ||
   fail "positive control FAILED — a non-policied pod could not reach ${HOST}:443 (phase=${posphase:-none}). A blocked training pod would NOT be attributable to the NetworkPolicy (runner egress / target issue), so the seal-check is inconclusive — refusing to report a false PASS."
 echo "positive control OK — ${HOST}:443 reachable; a training-pod block is now attributable to the policy."
@@ -140,8 +140,8 @@ echo "── helm test --filter name=${PROBE} ──"
 # pod log for triage.
 if ! helm test "$NS" --namespace "$NS" --filter "name=${PROBE}" --timeout 360s; then
   echo "── probe pod log (Job persists on failure) ──"
-  kubectl logs -n "$NS" -l "job-name=${PROBE}" --tail=-1 2>/dev/null ||
-    kubectl describe job -n "$NS" "${PROBE}" 2>/dev/null || true
+  kubectl --request-timeout=10s logs -n "$NS" -l "job-name=${PROBE}" --tail=-1 2>/dev/null ||
+    kubectl --request-timeout=10s describe job -n "$NS" "${PROBE}" 2>/dev/null || true
   fail "helm test reported failure for ${PROBE} — egress lockdown NOT verified"
 fi
 


### PR DESCRIPTION
Fixes the two Bugbot findings in tracebloc/backend#1497 (from the client#571 prod promotion) — unbounded external calls in CI that can hang a job to the GitHub Actions cap with no useful failure, the same class as the image-refresh fix (#572).

## Changes
- **`scripts/tests/e2e-seal-check.sh`** — `--request-timeout=10s` on the point-in-time kubectl API calls (`get` ×2, `run`, `logs` ×2, `delete`, `describe`) so a wedged API server fails the seal-check fast.
  - **`kubectl wait` (L57) left as-is on purpose:** it's already bounded by `--timeout=180s` (a client-side deadline that fires even against a wedged server), and adding `--request-timeout` to its underlying *watch* would truncate the watch and risk flakes. Flagging since the ticket listed `wait` — happy to add it too if you'd rather, but `--timeout` already covers the hang.
- **`.github/workflows/helm-ci.yaml`** — `--connect-timeout 15 --max-time 120` on the pinned kubeconform download so a stalled endpoint fails the template matrix instead of hanging. `-f` / `--retry` behaviour unchanged; the tarball is small so 120s is generous.

## Notes
- Values mirror the repo's existing bounds (`--request-timeout=5s/10s` in `install-client-helm.sh` / `diagnose.sh` / `storage-assertions-check.yaml`; `--connect-timeout`/`--max-time` in `install.sh` / `setup-linux.sh`).
- **No R8 manifest bump** — neither file is in `scripts/manifest.sha256` (a test script + a workflow).
- Validated locally: `bash -n` on the script, YAML parse on the workflow.

Ref tracebloc/backend#1497 · parent #1405 · siblings #571, #572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and workflow-only timeout additions with no production runtime or security logic changes.
> 
> **Overview**
> Adds **hard time bounds** on external/network calls in CI so wedged API servers or stalled downloads fail fast instead of burning the full GitHub Actions job timeout (backend#1497).
> 
> In **`scripts/tests/e2e-seal-check.sh`**, point-in-time `kubectl` calls (`get`, `run`, `logs`, `delete`, `describe`) now use **`--request-timeout=10s`**. The existing **`kubectl wait`** with `--timeout=180s` is unchanged.
> 
> In **`.github/workflows/helm-ci.yaml`**, the pinned kubeconform tarball download adds **`--connect-timeout 15`** and **`--max-time 120`** on `curl`; retry and checksum verification behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bee53f99d042f31d470b309ce61d32df0a77de3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->