### PR TITLE
fix(installer): lowercase 'tracebloc' in user-facing copy + drift guard (#586)

### DIFF
--- a/scripts/check-style.sh
+++ b/scripts/check-style.sh
@@ -101,6 +101,19 @@ report "bare 'curl' — call curl_secure() from ${ENGINE} so the TLS floor and t
       | grep -vE '(has curl|command -v curl)' \
       | grep -vE 'curl[^|]*\|[[:space:]]*(sh|bash)' || true)"
 
+# 4) Product name is lowercase 'tracebloc' in user-facing text — never capital-T
+#    'Tracebloc'. The installer copy must feel one-to-one across platforms; the
+#    bash script is the gold standard (#576). Exempt: comments, and PascalCase code
+#    identifiers — function names (Get-Tracebloc… , matched by a leading '-') and
+#    the 'TraceblocInstallerResume' resume key (matched by a following uppercase
+#    letter). Opt out a real edge with a trailing `# style-guard: allow`.
+scan 'Tracebloc'
+report "capital-T 'Tracebloc' in user-facing text — the product name is lowercase 'tracebloc' (see STYLE.md)" \
+  "$(printf '%s' "$hits" \
+      | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
+      | grep -vE 'Tracebloc[A-Z]' \
+      | grep -vE '[-]Tracebloc' || true)"
+
 if [[ "$guard_error" -ne 0 ]]; then
   echo "  [!] the guard hit an internal error — failing closed (exit 2)" >&2
   exit 2

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -415,7 +415,7 @@ function Invoke-Bootstrap {
   }
   New-Item -ItemType Directory -Path $tmpDir | Out-Null
   try {
-    Info "Downloading Tracebloc client installer (ref: $ref)..."
+    Info "Downloading tracebloc client installer (ref: $ref)..."
 
     # ── Fetch the sub-scripts from the immutable tag tree ──
     foreach ($f in $Files) {
@@ -443,7 +443,7 @@ function Invoke-Bootstrap {
 
     # ── Run the verified main installer ──
     $k8s = Join-Path $tmpDir "install-k8s.ps1"
-    Info "Running Tracebloc environment setup..."
+    Info "Running tracebloc environment setup..."
     if ($ChildArgs -and $ChildArgs.Count -gt 0) {
       & powershell.exe -ExecutionPolicy Bypass -File $k8s @ChildArgs
     } else {


### PR DESCRIPTION
Closes #586. House-style alignment from the #576 review.

## Problem
The installer copy should feel one-to-one across platforms, with the product name **lowercase `tracebloc`, always** (the bash script is the gold standard). PowerShell had capital-T **"Tracebloc"** in two user-facing lines while the rest of its copy is lowercase — a per-platform drift.

## Change
- **`install.ps1`**: `"Downloading Tracebloc client installer"` / `"Running Tracebloc environment setup"` → lowercase `tracebloc`.
- **`check-style.sh`** (the "Static analysis" CI gate): a new guard that fails on capital-T `Tracebloc` in user-facing text, so the casing can't drift again — same spirit as the #435 single-source installer-facts guard. It exempts **comments** and **PascalCase code identifiers** (`Get-Tracebloc…` function names, the `TraceblocInstallerResume` resume key), and honours the `# style-guard: allow` opt-out.

## Verified
`check-style.sh` clean; the guard flags a real `"Tracebloc client"` line and excludes identifiers/comments; `shellcheck` + PS parse clean. No behaviour change — user-facing copy only.

## Follow-up (not here)
A fuller shared cross-platform message catalog is a larger refactor; this guard already enforces the product-name consistency the drift caused.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing installer copy only plus a static style guard; no runtime, auth, or install logic changes.
> 
> **Overview**
> Aligns Windows bootstrap **user-facing** strings with house style: the product name is always lowercase **`tracebloc`** (bash installer is the reference). **`install.ps1`** now says “Downloading tracebloc client installer…” and “Running tracebloc environment setup…” instead of capital-T **Tracebloc**.
> 
> **`check-style.sh`** gains a fourth CI check that fails on capital-T `Tracebloc` in `scripts/*.sh` and `*.ps1`, with the same opt-out pattern as other guards. Comments, PascalCase identifiers (`Get-Tracebloc…`, `TraceblocInstallerResume`), and `# style-guard: allow` lines are exempt so legitimate code names are not flagged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd62a81418c7fa27a079eda4a3b424cdf28fb164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->