### PR TITLE
feat(chart): perDatasetPvcs — RBAC + env knob for per-dataset PVC mounts (RFC-0003 D9 Track B)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.12
-appVersion: "1.9.12"
+version: 1.9.13
+appVersion: "1.9.13"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -113,6 +113,17 @@ spec:
         - name: PER_INGESTION_TABLES
           value: "1"
         {{- end }}
+        {{- if .Values.perDatasetPvcs }}
+        # RFC-0003 D9 Track B (client-runtime#203 / #261): per-dataset
+        # hostPath PV/PVCs. When on, jobs-manager mounts each training pod's
+        # dataset(s) as dedicated read-only dataset-<handle> PVCs instead of
+        # a subPath view of the shared data PVC (single-node/hostPath
+        # clusters only — elastic clusters log a warning and fall back to
+        # subPath). Needs the flag-gated PV/PVC grants in rbac.yaml. Rendered
+        # only when enabled so default installs stay byte-identical.
+        - name: PER_DATASET_PVCS
+          value: "1"
+        {{- end }}
         {{- if .Values.perExperimentDbCreds }}
         # RFC-0003 D10 (backend#1181): per-experiment MySQL credentials. When
         # on, jobs-manager mints a short-lived MySQL user per experiment scoped

--- a/client/templates/rbac.yaml
+++ b/client/templates/rbac.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.perDatasetPvcs (eq .Values.clusterScope false) }}
+{{- fail "perDatasetPvcs requires clusterScope: PersistentVolumes are cluster-scoped, so the namespaced Role cannot grant the PV provisioning/GC verbs jobs-manager needs — Job spawns would 403 at runtime. Set clusterScope: true (the default) or disable perDatasetPvcs." }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -58,6 +61,22 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["delete"]
+{{- end }}
+{{- if .Values.perDatasetPvcs }}
+  # Per-dataset PVCs only (RFC-0003 D9 Track B, client-runtime#203/#261):
+  # jobs-manager provisions one static hostPath PV + pre-bound PVC per
+  # dataset handle before spawning a training Job (`create`; PV `get`/`patch`
+  # to recover a Released PV's claimRef for reuse) and garbage-collects
+  # PV/PVCs no live Job references (`list` + `delete`). Cluster-scope only:
+  # PVs cannot be granted by a namespace Role, so the Role branch below
+  # omits this and rendering fails on the combination (guard at the top).
+  # Flag-gated so a default install grants nothing extra — least privilege.
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["create", "get", "list", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["create", "list", "delete"]
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -361,6 +361,24 @@ tests:
             name: PER_INGESTION_TABLES
             value: "1"
 
+  - it: does not render PER_DATASET_PVCS by default (RFC-0003 D9 Track B knob off)
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PER_DATASET_PVCS
+            value: "1"
+
+  - it: renders PER_DATASET_PVCS=1 when perDatasetPvcs is enabled
+    set:
+      perDatasetPvcs: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PER_DATASET_PVCS
+            value: "1"
+
   - it: does not render per-experiment DB-cred env by default (RFC-0003 D10 knob off)
     asserts:
       - notContains:

--- a/client/tests/rbac_test.yaml
+++ b/client/tests/rbac_test.yaml
@@ -128,3 +128,50 @@ tests:
             apiGroups: [""]
             resources: ["secrets"]
             verbs: ["delete"]
+
+  # RFC-0003 D9 Track B (client-runtime#203/#261): the PV/PVC provisioning +
+  # GC verbs jobs-manager needs are flag-gated and cluster-scope-only.
+  - it: default-off grants nothing on persistentvolumes/persistentvolumeclaims (byte-for-byte)
+    set:
+      clusterScope: true
+    documentIndex: 1
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["persistentvolumes"]
+            verbs: ["create", "get", "list", "patch", "delete"]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["persistentvolumeclaims"]
+            verbs: ["create", "list", "delete"]
+
+  - it: perDatasetPvcs adds PV provisioning/GC + PVC grants (ClusterRole)
+    set:
+      clusterScope: true
+      perDatasetPvcs: true
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["persistentvolumes"]
+            verbs: ["create", "get", "list", "patch", "delete"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["persistentvolumeclaims"]
+            verbs: ["create", "list", "delete"]
+
+  - it: perDatasetPvcs with clusterScope false fails the render (PVs not grantable by a namespace Role)
+    set:
+      clusterScope: false
+      perDatasetPvcs: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "perDatasetPvcs requires clusterScope"

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -299,6 +299,10 @@
       "type": "boolean",
       "description": "RFC-0003 D16 (backend#1204/#1205): stamp PER_INGESTION_TABLES=1 into every ingestion Job. Flip per environment, dev first; file-bearing categories are refused under the flag until client-runtime#203 phase 2."
     },
+    "perDatasetPvcs": {
+      "type": "boolean",
+      "description": "RFC-0003 D9 Track B (client-runtime#203/#261): stamp PER_DATASET_PVCS=1 into jobs-manager — training pods get one read-only hostPath PV/PVC per dataset handle instead of a subPath view of the shared PVC. Single-node/hostPath clusters only; requires clusterScope (PVs are cluster-scoped)."
+    },
     "ingestionAuthz": {
       "type": "object",
       "description": "Authorization policy for POST /internal/submit-ingestion-run on jobs-manager (client-runtime#21). Rendered into the ingestion-authz ConfigMap.",

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -790,6 +790,27 @@ imageRefresh:
 perIngestionTables: false
 
 # ============================================================
+# Per-dataset PVC mounts (RFC-0003 D9 Track B — client-runtime#203 / #261)
+# ============================================================
+# When true, jobs-manager stamps PER_DATASET_PVCS=1 into its own environment:
+# each spawned training pod then gets one dedicated READ-ONLY hostPath PV/PVC
+# per dataset handle, mounted at /data/shared/<handle>, and the shared data
+# volume is removed from the pod entirely — the mount table references only
+# the pod's own dataset(s), so no other dataset on the edge is even nameable.
+# Off (default), training pods keep the subPath-scoped view of the shared PVC
+# (Track A) — that is also the rollback: flip off and pods revert on the next
+# spawn; the static PV/PVCs left behind are garbage-collected by jobs-manager.
+#
+# Effective only on single-node/hostPath clusters (node-local Option C,
+# client#368): on elastic clusters the runtime logs a warning and falls back
+# to subPath scoping. Requires clusterScope (the default): PersistentVolumes
+# are cluster-scoped, so the namespaced Role cannot grant them — rendering
+# fails on the invalid combination rather than letting Job spawns 403.
+# Grants jobs-manager PV/PVC provisioning + GC verbs only while on (see
+# templates/rbac.yaml). Default false: byte-for-byte identical rendering.
+perDatasetPvcs: false
+
+# ============================================================
 # Per-experiment DB credentials (RFC-0003 D10 — backend#1181)
 # ============================================================
 # When true, jobs-manager mints a short-lived MySQL user for each experiment


### PR DESCRIPTION
## What

Chart-side companion to **tracebloc/client-runtime#261** (RFC-0003 **D9 Track B**, client-runtime#203): the runtime PR ships the per-dataset PV/PVC mount path **default-off and inert** — this PR adds the two things the chart must provide before the feature can be *enabled* on an edge:

1. **`perDatasetPvcs` value** (default `false`) → stamps **`PER_DATASET_PVCS=1`** into the jobs-manager environment (same pattern as `perIngestionTables` / `perExperimentDbCreds`). Truthy per the runtime's parse (`{"1","true","yes","on"}`).
2. **Flag-gated RBAC** for the jobs-manager ClusterRole, exactly the verbs the runtime path uses (from the #261 diff):
   - `persistentvolumes`: `create` (static hostPath PV), `get`+`patch` (recover a `Released` PV's `claimRef` for reuse), `list`+`delete` (orphan GC)
   - `persistentvolumeclaims`: `create` (pre-bound PVC), `list`+`delete` (orphan GC)

## Guard: clusterScope

PersistentVolumes are cluster-scoped — a namespaced Role **cannot** grant them, so under `clusterScope: false` the feature would 403 at Job-spawn time. Rendering now **fails loudly** on `perDatasetPvcs: true` + `clusterScope: false` (precedent: the TokenReview note in `rbac.yaml`, the netpol empty-CIDR `fail` — "silent non-protection is worse than explicit disabling").

## Default posture

- `perDatasetPvcs: false` → **byte-identical rendering** (verified: `helm template` diff vs `develop` shows only the chart-version labels and the per-render generated signing secret; RBAC gains nothing, env gains nothing).
- Chart `1.9.12 → 1.9.13` (publishes only on a version change).

## Test plan

- helm-unittest **330/330 green** (+5 new):
  - RBAC: default grants nothing on PV/PVC (`notContains`), flag adds exactly the two rules, `clusterScope: false` + flag → `failedTemplate` on the guard message
  - jobs-manager: `PER_DATASET_PVCS` absent by default, `=1` when enabled
- Manual renders: enabled path shows the two RBAC rules + env; guard fires with the actionable message; default render functionally identical to `develop`.

## Sequencing

Mergeable independently of client-runtime#261 (both sides default-off; either order is safe). Enabling on an edge needs **both** landed + `perDatasetPvcs: true` + a single-node/hostPath (node-local Option C) cluster — on elastic clusters the runtime logs a warning and falls back to subPath scoping (Track A, unchanged default).

Epic: tracebloc/backend#1151 (workstream C) · RFC-CLI-0003 D9 · runtime: tracebloc/client-runtime#261

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands jobs-manager cluster RBAC and changes how dataset storage can be wired when enabled; default-off limits blast radius, but misconfiguration (e.g. clusterScope false) is now a hard render failure instead of a runtime 403.
> 
> **Overview**
> Adds a **default-off** `perDatasetPvcs` chart value so edges can enable RFC-0003 **D9 Track B** (per-dataset hostPath PV/PVC mounts for training pods) once client-runtime#261 is deployed.
> 
> When `perDatasetPvcs: true`, jobs-manager gets **`PER_DATASET_PVCS=1`** (same pattern as `perIngestionTables` / `perExperimentDbCreds`). The jobs-manager **ClusterRole** gains flag-gated rules for **`persistentvolumes`** (`create`, `get`, `list`, `patch`, `delete`) and **`persistentvolumeclaims`** (`create`, `list`, `delete`) so the runtime can provision and GC per-dataset static PV/PVCs before spawning training Jobs.
> 
> Rendering **fails** if `perDatasetPvcs` is enabled with **`clusterScope: false`**, because PV grants require a ClusterRole. With the flag off, RBAC and env stay **byte-identical** to prior releases.
> 
> Chart version **1.9.12 → 1.9.13**; helm-unittest covers default-off behavior, enabled RBAC/env, and the clusterScope guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afb00e63b6500d4ca8c6e00874efa26fc0244d9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->