### PR TITLE
sec(ci): pin third-party action refs to commit SHAs (backend#1490, D10)

### DIFF
--- a/.github/workflows/drift-checks.yaml
+++ b/.github/workflows/drift-checks.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.15.4
       - name: check-drift

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.15.4
 
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.15.4
 
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.15.4
 

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -92,7 +92,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.15.4
 


### PR DESCRIPTION
Mechanical half of the D10 supply-chain sweep (RFC-BACKEND-1405): every third-party action ref in `.github/workflows` is pinned to the full 40-character commit SHA it already resolves to today, with a trailing exact-version comment. Behaviour-preserving — the same code runs; only silent tag mutation is removed. No upgrades.

| action | old ref | new sha | version comment |
|---|---|---|---|
| `azure/setup-helm` | `@v4` | `1a275c3b69536ee54be43f2070a358922e12c8d4` | `# v4.3.1` |

- 5 call site(s) pinned across 3 file(s).
- SHAs resolved via the GitHub API (`git/ref/tags`, annotated tags dereferenced through `git/tags` to the commit), cross-checked against the exact release tag named in the comment.
- `actionlint`: no new findings vs base.
- `tracebloc/*` refs (stay `@main` per D10) and `actions/*` refs (split to backend#1491) deliberately untouched.

Part of tracebloc/backend#1490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only pinning with no Helm version or chart logic changes; reduces supply-chain risk without altering runtime behavior.
> 
> **Overview**
> Pins **`azure/setup-helm`** from the mutable **`@v4`** tag to commit **`1a275c3b69536ee54be43f2070a358922e12c8d4`** (`# v4.3.1`) at every Helm setup step in drift-checks, helm-ci, and release-helm-chart workflows.
> 
> This is a **behavior-preserving** supply-chain change: Helm is still installed at **`v3.15.4`** via `with.version`; only the action ref is immutable so a retagged **`v4`** cannot silently change what CI runs. **`actions/*`** and other third-party refs are intentionally left for separate work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac49622e8f6b8e1a03276da4a53562c9e0a3982d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->