### PR TITLE
docs: BUGBOT.md rule — a secretless code-quality caller is correct (backend#1526)

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -112,6 +112,11 @@ for *what the operator sees and can act on*, not code elegance.
   identifier support needs, not a secret (`scripts/lib/diagnose.sh:13`).
 - Existing `# shellcheck disable=…` lines each carry a stated reason — don't re-litigate them.
 - `docs/`, chart lockfiles, and generated sections of `client/values.schema.json`.
+- A `code-quality-caller.yml` that passes **no `secrets:` line** is correct, not an omission.
+  The shared `code-quality.yml` reusable references no secrets by contract
+  (RFC-BACKEND-1405 Q5, backend#1526): secretless callees get no secrets line, and if the
+  reusable ever gains one, callers switch to explicit per-secret passing — never
+  `secrets: inherit`. Flag the *addition* of `secrets: inherit` on this caller instead.
 
 ## Tone
 


### PR DESCRIPTION
## Summary

Fleet half of the RFC-BACKEND-1405 Q5 unwind (tracebloc/backend#1526). Q5 was answered 2026-08-04 via tracebloc/rfcs#11: the shared `code-quality.yml` reusable references **no** secrets by contract, so secretless callees carry **no** `secrets:` line at all — and if the reusable ever gains a secret, callers switch to explicit per-secret passing, never `secrets: inherit`.

- **`.cursor/BUGBOT.md`** — appended one bullet as the last item of the "Known non-issues — do not flag" section: a `code-quality-caller.yml` that passes no `secrets:` line is correct, not an omission; Bugbot should instead flag the *addition* of `secrets: inherit` on this caller. No other lines touched.

This repo's `code-quality-caller.yml` is already secretless on `develop`, so no workflow change is needed here.

Part of tracebloc/backend#1526

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `.cursor/BUGBOT.md` with no runtime or CI behavior changes.
> 
> **Overview**
> Documents **RFC-BACKEND-1405 Q5** (backend#1526) for automated review: a `code-quality-caller.yml` with **no `secrets:` block** is correct because the shared `code-quality.yml` reusable does not use secrets.
> 
> The new **Known non-issues** bullet tells Bugbot not to flag a missing `secrets:` line as an omission, and to flag **`secrets: inherit`** if someone adds it on this caller. Callers should use explicit per-secret passing if the reusable ever needs secrets.
> 
> No workflow edits in this PR—the repo’s caller is already secretless on `develop`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7004cfe51c5b7396b1559cccd1829898d5771a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->