### PR TITLE
test(e2e): full seal suite vs the dev backend (backend#1184 fast-follow)

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -276,7 +276,11 @@ jobs:
     # Until the secrets are provisioned the job SKIPS green with a notice —
     # see docs/SEAL-CHECK.md § Full-suite dev harness.
     if: github.event_name != 'pull_request'
-    timeout-minutes: 30
+    # 45m, deliberately above the sibling's 30m: this script stacks a 300s PVC
+    # wait, two 300s rollouts and a 600s unfiltered helm test on top of
+    # create_cluster's 15m bound — a slow-but-healthy run must not be killed
+    # by GHA while inside every one of its own timeouts (Bugbot).
+    timeout-minutes: 45
     # One dev-agent session at a time: two clusters authenticating as the same
     # client id would read as a duplicate/capacity anomaly on the platform.
     concurrency:

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -8,6 +8,8 @@ on:
       - 'ingestor/**'
       - 'scripts/tests/e2e-auto-upgrade.sh'
       - 'scripts/tests/e2e-seal-check.sh'
+      - 'scripts/tests/e2e-full-seal.sh'
+      - 'scripts/tests/lib/e2e-common.sh'
       - 'scripts/lib/**'
       - '.github/workflows/helm-ci.yaml'
   pull_request:
@@ -17,8 +19,13 @@ on:
       - 'ingestor/**'
       - 'scripts/tests/e2e-auto-upgrade.sh'
       - 'scripts/tests/e2e-seal-check.sh'
+      - 'scripts/tests/e2e-full-seal.sh'
+      - 'scripts/tests/lib/e2e-common.sh'
       - 'scripts/lib/**'
       - '.github/workflows/helm-ci.yaml'
+  # Manual runs — mainly to fire full-seal-e2e on demand (e.g. right after the
+  # e2e-test-agent secrets are provisioned, or to re-record a seal run).
+  workflow_dispatch:
 
 concurrency:
   # Cancel superseded runs on PRs — this is the repo's heaviest workflow
@@ -257,6 +264,38 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run the live egress-enforcement seal-check
         run: bash scripts/tests/e2e-seal-check.sh
+
+  full-seal-e2e:
+    # backend#1184 deferred fast-follow: the FULL seal suite — egress-
+    # enforcement + backend-reachability + bound-PVC storage-assertions — on a
+    # real k3d cluster installed against the DEV backend as the dedicated
+    # e2e-test-agent client. Real credentials, so it runs on push/dispatch
+    # only, never on PRs: fork PRs can't read the secrets anyway, and a real
+    # dev-backend login per PR push would be platform churn + runner cost for
+    # no extra signal (the secret-free enforcement probe above covers PRs).
+    # Until the secrets are provisioned the job SKIPS green with a notice —
+    # see docs/SEAL-CHECK.md § Full-suite dev harness.
+    if: github.event_name != 'pull_request'
+    timeout-minutes: 30
+    # One dev-agent session at a time: two clusters authenticating as the same
+    # client id would read as a duplicate/capacity anomaly on the platform.
+    concurrency:
+      group: full-seal-e2e-dev-agent
+      cancel-in-progress: false
+    name: Full seal suite vs dev (e2e-test-agent)
+    runs-on: ubuntu-latest
+    env:
+      TB_E2E_CLIENT_ID: ${{ secrets.TB_E2E_CLIENT_ID }}
+      TB_E2E_CLIENT_PASSWORD: ${{ secrets.TB_E2E_CLIENT_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run the full seal suite (skips until the e2e-test-agent is provisioned)
+        run: |
+          if [ -z "$TB_E2E_CLIENT_ID" ] || [ -z "$TB_E2E_CLIENT_PASSWORD" ]; then
+            echo "::notice::TB_E2E_CLIENT_ID / TB_E2E_CLIENT_PASSWORD are not set — skipping the full seal suite. Provision the dedicated dev e2e-test-agent client and add both repo Actions secrets to activate this job (backend#1184 residual; docs/SEAL-CHECK.md)."
+            exit 0
+          fi
+          bash scripts/tests/e2e-full-seal.sh
 
   # Installer script tests (bats + Pester) + the cross-distro prerequisite matrix
   # live in their own workflow: .github/workflows/installer-tests.yaml

--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -67,11 +67,11 @@ jobs:
           # below for visibility but don't fail the gate.
           shellcheck --severity=error --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/gen-manifest.sh scripts/check-facts.sh scripts/check-style.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
-            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/lib/e2e-common.sh scripts/tests/path-persist.sh
+            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-full-seal.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/lib/e2e-common.sh scripts/tests/path-persist.sh
           echo "── shellcheck warnings (advisory, non-blocking) ──"
           shellcheck --severity=warning --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/gen-manifest.sh scripts/check-facts.sh scripts/check-style.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
-            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/lib/e2e-common.sh scripts/tests/path-persist.sh || true
+            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-full-seal.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/lib/e2e-common.sh scripts/tests/path-persist.sh || true
 
       - name: Installer manifest is current (supply-chain, R8)
         # The bootstrap verifies each sub-script against scripts/manifest.sha256

--- a/docs/SEAL-CHECK.md
+++ b/docs/SEAL-CHECK.md
@@ -237,26 +237,41 @@ the RFC-0003 §8.3 matrix. The **substrate** enforcement it builds on is already
 verified — see the Status note at the top of this section (the single record
 of that run).
 
-## What the suite does not cover yet (follow-ups)
+## CI coverage — what runs where
 
-Tracked under backend#1184 unless noted:
+- **`egress-enforcement`, live on every push/PR** — helm-ci's `seal-check-e2e`
+  job (`scripts/tests/e2e-seal-check.sh`, client#541 + #566): real k3d
+  cluster, lockdown engaged, positive control, then the probe via
+  `helm test --filter`. Zero secrets, so it runs everywhere.
+- **The FULL suite vs the dev backend** — helm-ci's `full-seal-e2e` job
+  (`scripts/tests/e2e-full-seal.sh`, the backend#1184 deferred fast-follow):
+  installs the working-tree chart on k3d **as the dedicated dev
+  `e2e-test-agent` client with real credentials** (`CLIENT_ENV=dev`), waits
+  for every release PVC to Bind and for jobs-manager to hold a real backend
+  session, then runs `helm test` **unfiltered** — `egress-enforcement` +
+  `backend-reachability` + `storage-assertions` in one release, with a
+  guard that all three hooks are present so a regated check can never
+  vanish silently. Push/`workflow_dispatch` only (never PRs), one run at a
+  time (the platform sees one agent session).
 
-- **The live k3d verification run** (§8.4) — the *substrate* enforcement is
-  verified (see the §8.4 Status note for the recorded evidence); the
-  *full-chart* `egress-enforcement` probe run against a deployed release is
-  still pending, and the §8.3 k3d cell reads "substrate verified; full-probe
-  run pending" until it is recorded.
+  **Activation:** the job skips green with a `::notice` until the dev
+  platform has a dedicated `e2e-test-agent` client and the repo carries its
+  two Actions secrets — `TB_E2E_CLIENT_ID` / `TB_E2E_CLIENT_PASSWORD`.
+  Never use a real customer's or a person's shared dev identity (login
+  churn invalidates tokens — the backend#1180 failure class). Record the
+  first green run here, with date + run link.
+
+## What the suite does not cover (by design or elsewhere)
+
 - **A single aggregated sealed/unsealed verdict with per-guarantee detail**
-  — surfaced by the tracebloc CLI on top of this label contract
-  (tracebloc/cli#393). Today the aggregate is `helm test`'s exit status
-  plus per-Job logs.
+  — shipped in the tracebloc CLI on this label contract
+  (tracebloc/cli#393, v0.10.0); `helm test` remains the raw substrate.
 - **`~/.tracebloc` host-tree check** (post-Option-C: nothing of the
   environment left under the operator's home) — host-side by construction,
   not observable from in-cluster; belongs to the CLI/installer offboard
   verification lineage (cli#389), not to a helm-test Job.
-- **Wiring the suite into the e2e harness dev runs.**
-- **Filling the RFC-0003 §8.3 matrix precisely** in the RFC itself — the
-  table above is the chart-side input.
+- **The RFC-0003 §8.3 matrix** is filled in the RFC (tracebloc/cli#449) —
+  the table above remains the chart-side input it is derived from.
 - **The Option C storage flip on local installs** (client#368) — the
   storage-assertions check is forward-compatible either way: it gates on
   `hostPath.enabled` and verifies whichever model the install declares.

--- a/scripts/tests/e2e-full-seal.sh
+++ b/scripts/tests/e2e-full-seal.sh
@@ -57,7 +57,15 @@ source "$LIB/cluster.sh"
 # shellcheck source=/dev/null
 source "$LIB/preflight.sh" # provides _pf_recheck_runtime_mem (called by create_cluster)
 
-cleanup() { k3d cluster delete "$CLUSTER_NAME" >/dev/null 2>&1 || true; }
+# The credentials travel in a mode-0600 values file, never on argv (a shared
+# runner's process list is world-readable, and helm --set mangles commas/
+# braces a password may contain) — same stance as the installer's generated
+# values.yaml. Removed on every exit path together with the cluster.
+CREDS_FILE=""
+cleanup() {
+  [ -n "$CREDS_FILE" ] && rm -f "$CREDS_FILE"
+  k3d cluster delete "$CLUSTER_NAME" >/dev/null 2>&1 || true
+}
 trap cleanup EXIT
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
@@ -78,10 +86,18 @@ echo "── helm install (dev backend, REAL credentials, lockdown ENGAGED — f
 # images, local-path storage, lockdown on with the 240s probe budget), plus the
 # real credentials and CLIENT_ENV=dev: the backend the reachability check must
 # round-trip to, and the login that makes the release come up for real.
+# Single-quoted YAML scalars with the standard '' escape, matching the
+# installer's _yaml_sq_escape treatment of the same two values.
+_sq() { printf %s "$1" | sed "s/'/''/g"; }
+CREDS_FILE="$(mktemp)"
+chmod 600 "$CREDS_FILE"
+{
+  printf "clientId: '%s'\n" "$(_sq "$TB_E2E_CLIENT_ID")"
+  printf "clientPassword: '%s'\n" "$(_sq "$TB_E2E_CLIENT_PASSWORD")"
+} > "$CREDS_FILE"
 helm install "$NS" "$CHART_DIR" --namespace "$NS" --create-namespace \
   -f "$CHART_DIR/tests/values-public-images.yaml" \
-  --set clientId="$TB_E2E_CLIENT_ID" \
-  --set clientPassword="$TB_E2E_CLIENT_PASSWORD" \
+  -f "$CREDS_FILE" \
   --set env.CLIENT_ENV=dev \
   --set storageClass.provisioner=rancher.io/local-path \
   --set networkPolicy.training.allowExternalHttps=false \
@@ -96,8 +112,12 @@ echo "── wait: every release PVC Bound (storage-assertions' precondition, as
 total=0
 deadline=$(( $(date +%s) + 300 ))
 while :; do
-  unbound="$(kubectl --request-timeout=10s get pvc -n "$NS" --no-headers 2>/dev/null | awk '$2 != "Bound" {print $1" ("$2")"}' || true)"
-  total="$(kubectl --request-timeout=10s get pvc -n "$NS" --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  # One guarded fetch per iteration: a transient kubectl failure yields an
+  # empty snapshot (total=0, keep waiting) instead of aborting the script
+  # under set -euo pipefail mid-wait (Bugbot).
+  pvcs="$(kubectl --request-timeout=10s get pvc -n "$NS" --no-headers 2>/dev/null || true)"
+  unbound="$(awk '$2 != "Bound" {print $1" ("$2")"}' <<<"$pvcs")"
+  total="$(grep -c . <<<"$pvcs" || true)"
   [ "$total" -gt 0 ] && [ -z "$unbound" ] && break
   [ "$(date +%s)" -ge "$deadline" ] &&
     fail "release PVCs not all Bound after 300s (total=${total}): ${unbound:-none listed} — storage-assertions would fail; failing here with the crisper reason."

--- a/scripts/tests/e2e-full-seal.sh
+++ b/scripts/tests/e2e-full-seal.sh
@@ -88,6 +88,10 @@ echo "── helm install (dev backend, REAL credentials, lockdown ENGAGED — f
 # round-trip to, and the login that makes the release come up for real.
 # Single-quoted YAML scalars with the standard '' escape, matching the
 # installer's _yaml_sq_escape treatment of the same two values.
+# pvcAccessMode=ReadWriteOnce: the chart's PVC default is ReadWriteMany, which
+# local-path never provisions — claims would sit Pending forever and both the
+# Bound pre-wait and storage-assertions would fail (Bugbot). The installer
+# writes exactly this value for the same storage path.
 _sq() { printf %s "$1" | sed "s/'/''/g"; }
 CREDS_FILE="$(mktemp)"
 chmod 600 "$CREDS_FILE"
@@ -100,6 +104,7 @@ helm install "$NS" "$CHART_DIR" --namespace "$NS" --create-namespace \
   -f "$CREDS_FILE" \
   --set env.CLIENT_ENV=dev \
   --set storageClass.provisioner=rancher.io/local-path \
+  --set pvcAccessMode=ReadWriteOnce \
   --set networkPolicy.training.allowExternalHttps=false \
   --set networkPolicy.training.enforcementProbeHost="$HOST" \
   --set networkPolicy.training.enforcementProbeTimeoutSeconds=240

--- a/scripts/tests/e2e-full-seal.sh
+++ b/scripts/tests/e2e-full-seal.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  e2e-full-seal.sh — the FULL seal suite vs the dev backend (backend#1184 residual)
+# -----------------------------------------------------------------------------
+#  e2e-seal-check.sh proves the egress-enforcement probe alone — deliberately
+#  the one check that needs zero secrets. This script closes the deferred
+#  fast-follow recorded when backend#1184 closed: run the WHOLE conformance
+#  suite — egress-enforcement + backend-reachability + bound-PVC
+#  storage-assertions — on a real k3d cluster installed with the dev-env
+#  e2e-test-agent's REAL credentials, so every `helm.sh/hook: test` seal-check
+#  in the chart is exercised live, not just the secret-free one.
+#
+#  Why real credentials change what is verifiable:
+#    • backend-reachability round-trips to the real dev API from a non-training
+#      pod (the required-egress complement of the enforcement probe).
+#    • jobs-manager genuinely authenticates, consumers start, and the release
+#      PVCs BIND — so storage-assertions verifies bound storage on the expected
+#      class instead of failing on Pending WaitForFirstConsumer claims.
+#
+#  Credentials contract (the CI job provides both from repo Actions secrets,
+#  and skips green with a notice when they are absent):
+#    TB_E2E_CLIENT_ID / TB_E2E_CLIENT_PASSWORD — a DEDICATED dev-platform test
+#    client ("e2e-test-agent"), never a real customer identity. jobs-manager
+#    authenticates against the dev backend as this client for the lifetime of
+#    the run; the cluster is deleted on exit either way.
+#
+#  Usage:
+#    TB_E2E_CLIENT_ID=… TB_E2E_CLIENT_PASSWORD=… bash scripts/tests/e2e-full-seal.sh
+# =============================================================================
+set -euo pipefail
+
+[ -n "${TB_E2E_CLIENT_ID:-}" ] && [ -n "${TB_E2E_CLIENT_PASSWORD:-}" ] || {
+  echo "TB_E2E_CLIENT_ID / TB_E2E_CLIENT_PASSWORD are required (dev e2e-test-agent" >&2
+  echo "credentials; the CI job skips with a notice instead when they are absent)." >&2
+  exit 2
+}
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$HERE/../lib"
+CHART_DIR="$HERE/../../client"
+
+# Shared bring-up contract (isolation env + tool-install prereqs) + the shared
+# egress positive control, same as the sibling e2e-*.sh.
+# shellcheck source=/dev/null
+source "$HERE/lib/e2e-common.sh"
+e2e_isolate_env tbfullseal
+# NS follows CLUSTER_NAME so a CLUSTER_NAME override isolates a whole run under
+# ONE name — cluster + release + namespace move together (same as the sibling).
+NS="$CLUSTER_NAME"
+
+# shellcheck source=/dev/null
+source "$LIB/common.sh"
+# shellcheck source=/dev/null
+source "$LIB/setup-linux.sh"
+# shellcheck source=/dev/null
+source "$LIB/cluster.sh"
+# shellcheck source=/dev/null
+source "$LIB/preflight.sh" # provides _pf_recheck_runtime_mem (called by create_cluster)
+
+cleanup() { k3d cluster delete "$CLUSTER_NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+e2e_install_prereqs
+
+echo "── create_cluster() — real k3d bring-up ──"
+create_cluster
+kubectl wait --for=condition=Ready nodes --all --timeout=180s
+
+# The probe host — pinned on the install so the enforcement probe and the
+# positive control can never target different hosts (same stance as the
+# sibling, from the Saqlain nit on #541).
+HOST=1.1.1.1
+
+echo "── helm install (dev backend, REAL credentials, lockdown ENGAGED — full suite renders) ──"
+# Same base profile as e2e-seal-check.sh (local working-tree chart, public
+# images, local-path storage, lockdown on with the 240s probe budget), plus the
+# real credentials and CLIENT_ENV=dev: the backend the reachability check must
+# round-trip to, and the login that makes the release come up for real.
+helm install "$NS" "$CHART_DIR" --namespace "$NS" --create-namespace \
+  -f "$CHART_DIR/tests/values-public-images.yaml" \
+  --set clientId="$TB_E2E_CLIENT_ID" \
+  --set clientPassword="$TB_E2E_CLIENT_PASSWORD" \
+  --set env.CLIENT_ENV=dev \
+  --set storageClass.provisioner=rancher.io/local-path \
+  --set networkPolicy.training.allowExternalHttps=false \
+  --set networkPolicy.training.enforcementProbeHost="$HOST" \
+  --set networkPolicy.training.enforcementProbeTimeoutSeconds=240
+
+echo "── wait: every release PVC Bound (storage-assertions' precondition, asserted crisply first) ──"
+# storage-assertions itself waits sealCheck.storageAssertions.timeoutSeconds
+# (120s default) — pre-asserting here with a longer budget separates "the
+# cluster was slow to bind" from "the assertions are wrong", and names the
+# offending claim in the failure instead of a generic helm-test error.
+total=0
+deadline=$(( $(date +%s) + 300 ))
+while :; do
+  unbound="$(kubectl --request-timeout=10s get pvc -n "$NS" --no-headers 2>/dev/null | awk '$2 != "Bound" {print $1" ("$2")"}' || true)"
+  total="$(kubectl --request-timeout=10s get pvc -n "$NS" --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  [ "$total" -gt 0 ] && [ -z "$unbound" ] && break
+  [ "$(date +%s)" -ge "$deadline" ] &&
+    fail "release PVCs not all Bound after 300s (total=${total}): ${unbound:-none listed} — storage-assertions would fail; failing here with the crisper reason."
+  sleep 5
+done
+echo "all ${total} release PVCs Bound"
+
+echo "── wait: the deployments that hold the real backend session ──"
+kubectl -n "$NS" rollout status deploy/mysql-client --timeout=300s
+kubectl -n "$NS" rollout status "deploy/${NS}-jobs-manager" --timeout=300s
+
+e2e_egress_positive_control "$HOST"
+
+# Guard the silent-pass trap for the FULL suite: assert every expected hook is
+# in the release BEFORE `helm test`. The sibling guards its single --filter for
+# the same reason — and an UNFILTERED helm test equally "passes" a release
+# whose hooks silently stopped rendering (a regated check just vanishes from
+# the run). The three names below are pinned by the helm-unittest suites.
+echo "── verify all three seal-check hooks are in the release ──"
+hooks="$(helm get hooks "$NS" --namespace "$NS")"
+for check in egress-enforcement-check egress-reachability-check storage-assertions-check; do
+  grep -q "name: ${NS}-${check}" <<<"$hooks" ||
+    fail "expected hook ${NS}-${check} not found in the release — the full suite would run incomplete"
+done
+
+echo "── helm test (unfiltered — the whole seal suite) ──"
+# Drive off the EXIT CODE, not --logs (same rationale as the sibling: hook pods
+# carry generated suffixes and hook-succeeded deletes passing Jobs). On failure
+# the failed Jobs persist — dump every seal-check pod log via the enumeration
+# label contract (RFC-0003 §8.2) for triage.
+if ! helm test "$NS" --namespace "$NS" --timeout 600s; then
+  echo "── seal-check job logs (failed hooks persist) ──"
+  kubectl --request-timeout=10s logs -n "$NS" -l "tracebloc.io/seal-check=true" --tail=-1 --prefix 2>/dev/null || true
+  kubectl --request-timeout=10s get jobs -n "$NS" 2>/dev/null || true
+  fail "helm test reported failure — the full seal suite did NOT pass against the dev backend"
+fi
+
+echo "PASS: full seal suite — egress-enforcement + backend-reachability + storage-assertions all green vs the dev backend."

--- a/scripts/tests/e2e-seal-check.sh
+++ b/scripts/tests/e2e-seal-check.sh
@@ -81,38 +81,9 @@ helm install "$NS" "$CHART_DIR" --namespace "$NS" --create-namespace \
   --set networkPolicy.training.enforcementProbeHost="$HOST" \
   --set networkPolicy.training.enforcementProbeTimeoutSeconds=240
 
-# Positive control (Saqlain review): before trusting a BLOCKED probe result,
-# prove the cluster can actually REACH the probe host. Otherwise egress failing
-# for an unrelated reason (a runner firewall, a target outage, a rate-limit)
-# makes the probe print OK and the seal-check pass green while the NetworkPolicy
-# did nothing. A pod in `default` is governed by NO training-egress policy (the
-# policy is namespace-scoped to the release ns), so if IT reaches the host, the
-# training pod's block below is attributable to the policy, not the environment.
-# Same image + curl invocation as the probe, targeting the SAME $HOST pinned on
-# the install above — so a reachable positive here is attributable to exactly
-# the host the probe is blocked from (no hardcoded-vs-chart-default drift).
-echo "── positive control: a non-policied pod must REACH ${HOST}:443 ──"
-# A fast runner can schedule the pod before the `default` ServiceAccount is
-# created ("serviceaccount default not found"), which aborts under set -e before
-# the attribution failure below. Wait for the SA to exist first (Bugbot).
-for _ in $(seq 1 20); do
-  kubectl --request-timeout=10s get serviceaccount default -n default >/dev/null 2>&1 && break
-  sleep 1
-done
-kubectl --request-timeout=10s run seal-poscheck --namespace default --restart=Never \
-  --image="curlimages/curl:8.20.0" \
-  --command -- curl --noproxy '*' --tlsv1.2 -k -sS -m 15 -o /dev/null "https://${HOST}"
-posphase=""
-for _ in $(seq 1 40); do
-  posphase="$(kubectl --request-timeout=10s get pod seal-poscheck -n default -o jsonpath='{.status.phase}' 2>/dev/null || true)"
-  { [ "$posphase" = "Succeeded" ] || [ "$posphase" = "Failed" ]; } && break
-  sleep 3
-done
-kubectl --request-timeout=10s logs seal-poscheck -n default 2>/dev/null || true
-kubectl --request-timeout=10s delete pod seal-poscheck -n default --ignore-not-found --now >/dev/null 2>&1 || true
-[ "$posphase" = "Succeeded" ] ||
-  fail "positive control FAILED — a non-policied pod could not reach ${HOST}:443 (phase=${posphase:-none}). A blocked training pod would NOT be attributable to the NetworkPolicy (runner egress / target issue), so the seal-check is inconclusive — refusing to report a false PASS."
-echo "positive control OK — ${HOST}:443 reachable; a training-pod block is now attributable to the policy."
+# Positive control — factored into scripts/tests/lib/e2e-common.sh verbatim
+# (shared with e2e-full-seal.sh); rationale + #541 review provenance live there.
+e2e_egress_positive_control "$HOST"
 
 # The one probe we exercise. Its Job is `<release>-egress-enforcement-check`
 # (templates/egress-enforcement-check.yaml). The helm-unittest suite pins this

--- a/scripts/tests/lib/e2e-common.sh
+++ b/scripts/tests/lib/e2e-common.sh
@@ -49,3 +49,43 @@ e2e_install_prereqs() {
   install_k3d
   install_helm
 }
+
+# ── e2e_egress_positive_control <host> ──────────────────────────────────────
+# Positive control for the egress seal-checks (Saqlain review on #541): before
+# trusting a BLOCKED probe result, prove the cluster can actually REACH the
+# probe host. Otherwise egress failing for an unrelated reason (a runner
+# firewall, a target outage, a rate-limit) makes the probe print OK and the
+# seal-check pass green while the NetworkPolicy did nothing. A pod in `default`
+# is governed by NO training-egress policy (the policy is namespace-scoped to
+# the release ns), so if IT reaches the host, a training pod's block is
+# attributable to the policy, not the environment. Same image + curl invocation
+# as the probe, targeting the SAME host pinned on the caller's install — so a
+# reachable positive is attributable to exactly the host the probe is blocked
+# from (no hardcoded-vs-chart-default drift).
+# Moved verbatim from e2e-seal-check.sh (#541) so e2e-full-seal.sh shares the
+# one copy. Contract: the caller defines fail() (every e2e-*.sh does).
+e2e_egress_positive_control() {
+  local host="$1"
+  echo "── positive control: a non-policied pod must REACH ${host}:443 ──"
+  # A fast runner can schedule the pod before the `default` ServiceAccount is
+  # created ("serviceaccount default not found"), which aborts under set -e
+  # before the attribution failure below. Wait for the SA first (Bugbot).
+  for _ in $(seq 1 20); do
+    kubectl --request-timeout=10s get serviceaccount default -n default >/dev/null 2>&1 && break
+    sleep 1
+  done
+  kubectl --request-timeout=10s run seal-poscheck --namespace default --restart=Never \
+    --image="curlimages/curl:8.20.0" \
+    --command -- curl --noproxy '*' --tlsv1.2 -k -sS -m 15 -o /dev/null "https://${host}"
+  local posphase=""
+  for _ in $(seq 1 40); do
+    posphase="$(kubectl --request-timeout=10s get pod seal-poscheck -n default -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+    { [ "$posphase" = "Succeeded" ] || [ "$posphase" = "Failed" ]; } && break
+    sleep 3
+  done
+  kubectl --request-timeout=10s logs seal-poscheck -n default 2>/dev/null || true
+  kubectl --request-timeout=10s delete pod seal-poscheck -n default --ignore-not-found --now >/dev/null 2>&1 || true
+  [ "$posphase" = "Succeeded" ] ||
+    fail "positive control FAILED — a non-policied pod could not reach ${host}:443 (phase=${posphase:-none}). A blocked training pod would NOT be attributable to the NetworkPolicy (runner egress / target issue), so the seal-check is inconclusive — refusing to report a false PASS."
+  echo "positive control OK — ${host}:443 reachable; a training-pod block is now attributable to the policy."
+}


### PR DESCRIPTION
## What (the backend#1184 deferred fast-follow)

backend#1184 closed accepting CI-substrate coverage as v1-sufficient, with one recorded residual: *"the FULL suite (incl. backend-reachability + bound-PVC storage-assertions) on the dev-env e2e-test-agent with real credentials."* This is that harness.

### `scripts/tests/e2e-full-seal.sh` (new)
Real k3d cluster → install the **working-tree chart as the dedicated dev `e2e-test-agent` client** (real creds, `CLIENT_ENV=dev`, lockdown engaged, same base profile as the sibling) → crisp pre-asserts (**every release PVC Bound** within 300s — separates "slow to bind" from "assertions wrong"; mysql + jobs-manager rolled out, i.e. a real backend session) → shared egress positive control → **hook-presence guard for all three checks** (an *unfiltered* `helm test` "passes" a release whose hooks silently stopped rendering — same trap the sibling guards for its `--filter`) → `helm test` unfiltered: `egress-enforcement` + `backend-reachability` + `storage-assertions` in one release. On failure, every seal-check pod log dumps via the §8.2 enumeration label.

### `full-seal-e2e` job (helm-ci)
- **push / `workflow_dispatch` only, never PRs** — fork PRs can't read secrets, and a real dev-backend login per PR is platform churn for no extra signal (the secret-free enforcement probe keeps covering PRs).
- **Skips green with a `::notice` until provisioned** — the job is live the moment the secrets exist, no second PR needed.
- Job-level concurrency (one dev-agent session at a time — two clusters on one client id reads as a capacity anomaly).
- `workflow_dispatch` added to helm-ci for on-demand runs (e.g. right after provisioning).

### Refactor + docs
- The **egress positive control** moved **verbatim** from `e2e-seal-check.sh` into `lib/e2e-common.sh` (provenance + #541 review rationale documented at the function) — one copy, two callers, no drift.
- `SEAL-CHECK.md`: new **CI-coverage map** (what runs where, activation contract, "never a person's shared dev identity — the backend#1180 token-churn failure class"), and the follow-ups list drops three items that shipped since it was written (#541 live probe, cli#393 CLI verdict, cli#449 §8.3 matrix).
- Both `installer-tests.yaml` shellcheck gates now include the new script; helm-ci path filters gain the new script + `lib/e2e-common.sh` (which was already load-bearing for the seal job but absent from the filter).

## ⚠️ Activation — the one human step (not in this PR)
Provision a **dedicated** dev-platform client (`e2e-test-agent`) and add two repo Actions secrets: `TB_E2E_CLIENT_ID`, `TB_E2E_CLIENT_PASSWORD`. Until then the job skips green by design. (Public repo: fork PRs can't read the secrets; the job never runs on PRs anyway.)

## Test plan
- `bash -n` + `shellcheck --severity=error` green on all three touched scripts (both CI shellcheck lists updated).
- Workflow YAML parse-validated; R8 manifest untouched by design (`scripts/tests/` isn't manifest-covered); style guard clean.
- The refactored sibling (`seal-check-e2e`) runs in THIS PR's CI — proving the factored positive control live on k3d.
- The new job's full path can't run pre-provisioning by construction; first green run gets recorded in SEAL-CHECK.md per the doc.

Epic: tracebloc/backend#1151 (workstream G residual) · closes the backend#1184 fast-follow · RFC-CLI-0003 D12 §8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI/e2e harness and documentation only; no chart runtime or production install path. Real credentials stay in Actions secrets and a dedicated dev test client, with PRs excluded from the credentialed job.
> 
> **Overview**
> Adds **`e2e-full-seal.sh`** and a helm-ci **`full-seal-e2e`** job to run the complete chart seal suite (`egress-enforcement`, `backend-reachability`, `storage-assertions`) on k3d against the **dev backend** with dedicated `e2e-test-agent` credentials—not just the secret-free egress probe PRs already get.
> 
> The new script installs the working-tree chart with real creds in a mode-0600 values file, waits for PVCs to bind and for `jobs-manager` rollout, verifies all three test hooks exist (guards against silent empty `helm test`), then runs unfiltered `helm test` with failure log dumps via the seal-check label.
> 
> **CI wiring:** `workflow_dispatch` on helm-ci; path filters include the new script and `e2e-common.sh`; installer shellcheck lists updated. The job runs **only on push/dispatch** (not PRs), uses **45m** timeout and **concurrency** so one dev-agent session runs at a time, and **skips green** with a notice until `TB_E2E_CLIENT_ID` / `TB_E2E_CLIENT_PASSWORD` secrets exist.
> 
> **Refactor:** egress positive-control logic moves from `e2e-seal-check.sh` into **`e2e_egress_positive_control`** in `e2e-common.sh` for both seal e2e scripts.
> 
> **Docs:** `SEAL-CHECK.md` gains a CI coverage map and trims follow-ups that shipped elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d639aca914874e1c21f2db35d82f05d1f7b27df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->