### PR TITLE
refactor(installer): scrub remaining internal identifiers from bootstrap messages (#581)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -116,7 +116,7 @@ function Resolve-InstallRef {
       Warn "production box. A moved ref here can run arbitrary privileged code."
       Warn "============================================================================"
     } else {
-      throw "'$ref' is not an immutable release tag (expected vX.Y.Z). The bootstrap only trusts content-addressable release tags so a moved branch ref can't change what runs as Administrator on your box (RFC-0001 R8). Use a release tag, or for local dev set `$env:TRACEBLOC_ALLOW_UNVERIFIED = '1'`."
+      throw "'$ref' is not an immutable release tag (expected vX.Y.Z). The bootstrap only trusts content-addressable release tags so a moved branch ref can't change what runs as Administrator on your box. Use a release tag, or for local dev set `$env:TRACEBLOC_ALLOW_UNVERIFIED = '1'`."
     }
   }
 
@@ -125,7 +125,7 @@ function Resolve-InstallRef {
   # A '/' or '..' here is a path-traversal lever (it could escape the pinned tag
   # onto a mutable branch) — independent of which branch above let it through.
   if ($ref -match '/' -or $ref -match '\.\.') {
-    throw "Ref '$ref' contains a path separator or '..' -- refusing to build a fetch URL from it (path-traversal guard, RFC-0001 R8)."
+    throw "Ref '$ref' contains a path separator or '..' -- refusing to build a fetch URL from it (path-traversal guard)."
   }
 
   return $ref
@@ -343,7 +343,7 @@ function Confirm-ManifestSignature {
       Warn "Proceeding on checksum-only integrity. Not for production."
       return
     }
-    throw "cosign is required to verify the installer's signed manifest and couldn't be found or bootstrapped. Refusing to fall back to an unauthenticated, same-channel checksum (RFC-0001 R8). Fix: install cosign (https://docs.sigstore.dev/cosign/installation/) and re-run, or for local development only set `$env:TRACEBLOC_ALLOW_UNVERIFIED = '1'`."
+    throw "cosign is required to verify the installer's signed manifest and couldn't be found or bootstrapped. Refusing to fall back to an unauthenticated, same-channel checksum. Fix: install cosign (https://docs.sigstore.dev/cosign/installation/) and re-run, or for local development only set `$env:TRACEBLOC_ALLOW_UNVERIFIED = '1'`."
   }
 
   $sig  = Join-Path $TmpDir "manifest.sha256.sig"
@@ -354,7 +354,7 @@ function Confirm-ManifestSignature {
       Warn "manifest signature/cert not published for this ref -- not verified (TRACEBLOC_ALLOW_UNVERIFIED=1)."
       return
     }
-    throw "manifest.sha256.sig / .cert not published for this release -- can't authenticate the manifest. Pin a release tag that ships them (RFC-0001 R8)."
+    throw "The installer's signature isn't published for this release -- can't confirm the download is authentic. Pin a release tag that ships it."
   }
 
   # The identity is the client release workflow (release-helm-chart.yaml) — the
@@ -408,11 +408,11 @@ function Confirm-ScriptIntegrity {
     $local    = Join-Path $TmpDir ($f -replace '^scripts/', '')
     $expected = Find-ManifestDigest -ManifestPath $Manifest -Key $rel
     if (-not $expected) {
-      throw "$rel has no entry in manifest.sha256 -- refusing to run it (RFC-0001 R8)."
+      throw "$rel isn't in the installer's signed checksum list -- refusing to run it."
     }
     $actual = Get-Sha256 -Path $local
     if ($actual -ne $expected) {
-      throw "Integrity check FAILED for $rel`n          expected: $expected`n          actual:   $actual`n        Someone may have tampered with the installer. Aborting before any privileged step runs (RFC-0001 R8)."
+      throw "Integrity check FAILED for $rel`n          expected: $expected`n          actual:   $actual`n        Someone may have tampered with the installer. Aborting before any privileged step runs."
     }
   }
   Ok "all installer scripts verified against the signed manifest"
@@ -439,7 +439,7 @@ function Invoke-Bootstrap {
   # before the integrity check (parity with install.sh's `mktemp -d`, 0700).
   $tmpDir = Join-Path $env:TEMP ("tracebloc-installer-" + [guid]::NewGuid().ToString('N'))
   if (Test-Path -LiteralPath $tmpDir) {
-    throw "temp dir $tmpDir already exists -- refusing to reuse it (RFC-0001 R8)."
+    throw "temp dir $tmpDir already exists -- refusing to reuse it."
   }
   New-Item -ItemType Directory -Path $tmpDir | Out-Null
   try {
@@ -455,12 +455,12 @@ function Invoke-Bootstrap {
     $manifest = Join-Path $tmpDir "manifest.sha256"
     if (-not (Get-Optional "$repoRel/manifest.sha256" $manifest)) {
       if ($allowUnverified -and (Get-Optional "$repoRaw/scripts/manifest.sha256" $manifest)) {
-        Warn "Using in-repo manifest.sha256 from ref '$ref' (TRACEBLOC_ALLOW_UNVERIFIED=1)."
+        Warn "Using in-repo integrity checksums from ref '$ref' (TRACEBLOC_ALLOW_UNVERIFIED=1)."
       } elseif ($allowUnverified) {
-        Warn "No manifest.sha256 for ref '$ref' -- skipping integrity check (TRACEBLOC_ALLOW_UNVERIFIED=1)."
+        Warn "No integrity checksums for ref '$ref' -- skipping the integrity check (TRACEBLOC_ALLOW_UNVERIFIED=1)."
         $manifest = $null
       } else {
-        throw "Couldn't fetch manifest.sha256 for ref '$ref' -- refusing to run unverified installer scripts (RFC-0001 R8). If this ref pre-dates signed manifests, pin a newer release tag."
+        throw "Couldn't fetch the installer's integrity checksums for ref '$ref' -- refusing to run unverified installer scripts. If this ref pre-dates signed releases, pin a newer release tag."
       }
     }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -339,11 +339,11 @@ function Confirm-ManifestSignature {
   $cosign = Resolve-Cosign -TmpDir $TmpDir
   if (-not $cosign) {
     if ($AllowUnverified) {
-      Warn "cosign unavailable -- manifest signature NOT verified (TRACEBLOC_ALLOW_UNVERIFIED=1)."
+      Warn "cosign unavailable -- the installer's signature NOT verified (TRACEBLOC_ALLOW_UNVERIFIED=1)."
       Warn "Proceeding on checksum-only integrity. Not for production."
       return
     }
-    throw "cosign is required to verify the installer's signed manifest and couldn't be found or bootstrapped. Refusing to fall back to an unauthenticated, same-channel checksum. Fix: install cosign (https://docs.sigstore.dev/cosign/installation/) and re-run, or for local development only set `$env:TRACEBLOC_ALLOW_UNVERIFIED = '1'`."
+    throw "cosign is required to verify the installer's signature and couldn't be found or bootstrapped. Refusing to fall back to an unauthenticated, same-channel checksum. Fix: install cosign (https://docs.sigstore.dev/cosign/installation/) and re-run, or for local development only set `$env:TRACEBLOC_ALLOW_UNVERIFIED = '1'`."
   }
 
   $sig  = Join-Path $TmpDir "manifest.sha256.sig"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -351,7 +351,7 @@ function Confirm-ManifestSignature {
   if (-not (Get-Optional "$RepoRel/manifest.sha256.sig"  $sig) -or
       -not (Get-Optional "$RepoRel/manifest.sha256.cert" $cert)) {
     if ($AllowUnverified) {
-      Warn "manifest signature/cert not published for this ref -- not verified (TRACEBLOC_ALLOW_UNVERIFIED=1)."
+      Warn "The installer's signature isn't published for this ref -- not verified (TRACEBLOC_ALLOW_UNVERIFIED=1)."
       return
     }
     throw "The installer's signature isn't published for this release -- can't confirm the download is authentic. Pin a release tag that ships it."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -438,11 +438,11 @@ verify_manifest_signature() {
 
   if ! ensure_cosign; then
     if [[ "$ALLOW_UNVERIFIED" == "1" ]]; then
-      echo "[WARN]  cosign unavailable — manifest signature NOT verified (TRACEBLOC_ALLOW_UNVERIFIED=1)." >&2
+      echo "[WARN]  cosign unavailable — the installer's signature NOT verified (TRACEBLOC_ALLOW_UNVERIFIED=1)." >&2
       echo "[WARN]  Proceeding on checksum-only integrity. Not for production." >&2
       return 0
     fi
-    echo "[ERROR] cosign is required to verify the installer's signed manifest and" >&2
+    echo "[ERROR] cosign is required to verify the installer's signature and" >&2
     echo "        couldn't be found or bootstrapped. Refusing to fall back to an" >&2
     echo "        unauthenticated, same-channel checksum." >&2
     echo "        Fix: install cosign (https://docs.sigstore.dev/cosign/installation/)" >&2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -375,12 +375,12 @@ verify_against_manifest() {
 
   if ! download_manifest "$manifest"; then
     if [[ "$ALLOW_UNVERIFIED" == "1" ]]; then
-      echo "[WARN]  No manifest.sha256 at ref '$REF' — skipping integrity check (TRACEBLOC_ALLOW_UNVERIFIED=1)." >&2
+      echo "[WARN]  No integrity checksums published at ref '$REF' — skipping the integrity check (TRACEBLOC_ALLOW_UNVERIFIED=1)." >&2
       return 0
     fi
-    echo "[ERROR] Couldn't fetch manifest.sha256 for ref '$REF' — refusing to run" >&2
+    echo "[ERROR] Couldn't fetch the installer's integrity checksums for ref '$REF' — refusing to run" >&2
     echo "        unverified installer scripts. If this ref pre-dates" >&2
-    echo "        signed manifests, pin a newer release tag." >&2
+    echo "        signed releases, pin a newer release tag." >&2
     exit 1
   fi
 
@@ -395,7 +395,7 @@ verify_against_manifest() {
     # many spaces the sha tool emits); take its first field as the digest.
     expected="$(awk -v p="$rel" '$NF == p {print $1; exit}' "$manifest")"
     if [[ -z "$expected" ]]; then
-      echo "[ERROR] $rel has no entry in manifest.sha256 — refusing to run it." >&2
+      echo "[ERROR] $rel isn't in the installer's signed checksum list — refusing to run it." >&2
       exit 1
     fi
     actual="$(_sha256_of "$TMPDIR/${f#scripts/}")"
@@ -453,11 +453,11 @@ verify_manifest_signature() {
   if ! curl -fsSL --tlsv1.2 --connect-timeout 30 --max-time 300 "$REPO_REL/manifest.sha256.sig"  -o "$sig"  2>/dev/null \
      || ! curl -fsSL --tlsv1.2 --connect-timeout 30 --max-time 300 "$REPO_REL/manifest.sha256.cert" -o "$cert" 2>/dev/null; then
     if [[ "$ALLOW_UNVERIFIED" == "1" ]]; then
-      echo "[WARN]  manifest signature/cert not published for ref '$REF' — not verified (TRACEBLOC_ALLOW_UNVERIFIED=1)." >&2
+      echo "[WARN]  The installer's signature isn't published for ref '$REF' — not verified (TRACEBLOC_ALLOW_UNVERIFIED=1)." >&2
       return 0
     fi
-    echo "[ERROR] manifest.sha256.sig / .cert not published for release '$REF' — can't" >&2
-    echo "        authenticate the manifest. Pin a release tag that ships them." >&2
+    echo "[ERROR] The installer's signature isn't published for release '$REF' — can't" >&2
+    echo "        confirm the download is authentic. Pin a release tag that ships it." >&2
     exit 1
   fi
 

--- a/scripts/tests/install-bootstrap.bats
+++ b/scripts/tests/install-bootstrap.bats
@@ -239,7 +239,7 @@ EOF
   mv "$SERVE_REL/m.tmp" "$SERVE_REL/manifest.sha256"
   REF="v9.9.9" COSIGN_RESULT=0 run_boot
   [ "$status" -ne 0 ] || return 1
-  [[ "$output" == *"no entry in manifest"* ]] || return 1
+  [[ "$output" == *"isn't in the installer's signed checksum list"* ]] || return 1
   [ ! -f "$SBX/k8s-ran" ] || return 1
 }
 

--- a/scripts/tests/install-bootstrap.bats
+++ b/scripts/tests/install-bootstrap.bats
@@ -264,7 +264,7 @@ EOF
 @test "unverified opt-in degrades gracefully when cosign is absent" {
   REF="v9.9.9" TRACEBLOC_ALLOW_UNVERIFIED=1 run_boot_no_cosign
   [ "$status" -eq 0 ] || return 1
-  [[ "$output" == *"manifest signature NOT verified"* ]] || return 1
+  [[ "$output" == *"the installer's signature NOT verified"* ]] || return 1
   [ -f "$SBX/k8s-ran" ] || return 1             # checksum integrity still enforced; runs
 }
 

--- a/scripts/tests/install.Tests.ps1
+++ b/scripts/tests/install.Tests.ps1
@@ -146,7 +146,7 @@ Describe "Confirm-ScriptIntegrity — integrity gate before any privileged step"
     $mf = Join-Path $TestDrive 'missing.sha256'
     "zzzz  scripts/other.ps1" | Set-Content -LiteralPath $mf
     { Confirm-ScriptIntegrity -Manifest $mf -TmpDir $script:tmp -Files @('scripts/install-k8s.ps1') } |
-      Should -Throw -ExpectedMessage "*no entry in manifest*"
+      Should -Throw -ExpectedMessage "*isn't in the installer's signed checksum list*"
   }
 }
 


### PR DESCRIPTION
## What & why

Closes #581. Follow-up from the #576/#579 review (saadqbal). #579 sanitized the cosign verification-failure message; this sweeps the **remaining, lower-signal internal identifiers** still present in user-facing bootstrap messages — the `manifest.sha256` release-asset filename and the `RFC-0001 R8` internal spec code — to plain language, for consistency with #576.

**No behaviour change:** fail-closed paths, verification logic, and exit codes are untouched — only the wording of `echo`/`throw`/`Warn` strings changes.

## Changes
- **`install.sh`** — `manifest.sha256` → "the installer's integrity checksums" / "the installer's signed checksum list"; `.sig/.cert not published` / "authenticate the manifest" → "the installer's signature isn't published" / "confirm the download is authentic"; "signed manifests" → "signed releases".
- **`install.ps1`** — same wording, plus `(RFC-0001 R8)` removed from **every throw** (`Resolve-InstallRef`, `Confirm-ManifestSignature`, `Confirm-ScriptIntegrity`, the temp-dir guard).
- **Deliberately left untouched:** `RFC-0001` in code **comments** (not user-facing) and the actual `manifest.sha256` **file paths / URLs** (the real release assets).
- **Tests:** updated the two pinned assertions (`install-bootstrap.bats` + `install.Tests.ps1`) from `"no entry in manifest"` to `"isn't in the installer's signed checksum list"`.

## Verification
- No internal identifiers left in any user-facing message (grep of `echo`/`printf`/`throw`/`Warn`/`Err` — clean).
- Parse clean (bash + PS); `install.Tests.ps1` 28/0; `install-bootstrap.bats` green (the one failure is the pre-existing macOS "early bailout" flake); `bats-hygiene` 18/0; fail-closed + no-entry security tests still pass; check-style clean.
- `install.sh`/`install.ps1` are the bootstrap trust root (not manifested) — no manifest change.

## Note
Completes the #576/#577/#578 installer-robustness log-hygiene tail. Touches the same `install.sh`/`install.ps1` verify messages as #584 (#599); whichever merges second will need a small message-wording merge — I'll resolve it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only changes to installer error/warning strings and matching test assertions; no changes to verification logic or security gates.
> 
> **Overview**
> Continues the #576 installer log-hygiene work by rewriting **user-facing** bootstrap errors and warnings in `install.sh` and `install.ps1` so they no longer mention internal artifacts like `manifest.sha256` or the `RFC-0001 R8` spec code.
> 
> Messages now talk about **the installer's integrity checksums**, **signed checksum list**, and **installer signature** instead of manifest filenames and “authenticate the manifest.” PowerShell **throws** also drop the `(RFC-0001 R8)` suffix on ref, path-traversal, cosign, and integrity failures. **Comments and real release URLs/paths** for `manifest.sha256` are unchanged.
> 
> **Tests** (`install-bootstrap.bats`, `install.Tests.ps1`) only update expected substrings for the new copy. Verification logic, fail-closed behavior, and exit codes are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80333ba01e85e52b75cd9cba7de678a9129f4750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->