### PR TITLE
fix(chart): hide internal CLIENT_ENV from user-facing values.yaml (#605)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.14
-appVersion: "1.9.14"
+version: 1.9.15
+appVersion: "1.9.15"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -20,7 +20,6 @@ global:
 
 # -- Environment variables passed to containers
 env: {
-  # CLIENT_ENV: prod
   # Optional proxy settings
   # HTTP_PROXY_HOST: ""
   # HTTP_PROXY_PORT: ""


### PR DESCRIPTION
Closes tracebloc/client#605.

## What
Remove the commented `# CLIENT_ENV: prod` from the user-facing `client/values.yaml` env block, so environment selection is no longer advertised as a user knob. Bump chart `1.9.14 → 1.9.15` (values.yaml is packaged chart content — the chart-version-guard requires a bump for the edit to reach installs).

## Why
Environments (dev/stg/prod) are internal to tracebloc — a real install always resolves to `prod` and a user never picks one. Exposing `CLIENT_ENV` in the customer template is confusing and invites misconfiguration (found during the staging E2E 'act like a user' pass, epic backend#1540).

## Scope / what stays
Environment selection remains fully functional and internal-only:
- `client/values.schema.json` keeps `CLIENT_ENV` (load-bearing — it selects `images.ingestor.channelTags` and the prod digest pin).
- `ci/*-values.yaml` keep their `dev`/`stg` overrides.

Only the user-facing template stops exposing the knob. YAML validated; chart-version-guard passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the default values template with a routine chart version bump; no runtime or auth logic changes.
> 
> **Overview**
> Stops advertising **`CLIENT_ENV`** in the customer **`values.yaml`** `env` block by removing the commented `# CLIENT_ENV: prod` example, so installs are not steered toward picking dev/stg/prod manually.
> 
> Chart version is bumped **`1.9.14` → `1.9.15`** so the packaged default values change ships with the release (chart-version guard).
> 
> **`CLIENT_ENV` behavior is unchanged internally** — it still drives ingestor channel tags and prod digest pinning via **`values.schema.json`** and CI value files; only the user-facing template no longer exposes the knob.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77b05f8ec7d2c6509e3407c5d11b8d778a4b25d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->