### PR TITLE
fix(#343): stop stamping GPU_LIMITS on CPU-only installs

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.21
-appVersion: "1.9.21"
+version: 1.9.22
+appVersion: "1.9.22"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -253,14 +253,17 @@ spec:
           value: {{ if hasKey .Values.env "RESOURCE_REQUESTS" }}{{ .Values.env.RESOURCE_REQUESTS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         - name: RESOURCE_LIMITS
           value: {{ if hasKey .Values.env "RESOURCE_LIMITS" }}{{ .Values.env.RESOURCE_LIMITS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
-        - name: GPU_REQUESTS
-          value: {{ if hasKey .Values.env "GPU_REQUESTS" }}{{ .Values.env.GPU_REQUESTS | quote }}{{ else }}"nvidia.com/gpu=1"{{ end }}
-        # #343: only stamp GPU_LIMITS when a GPU is actually configured. A
+        # #343: only stamp the GPU vars when a GPU is actually configured. A
         # CPU-only install writes GPU_LIMITS: "" (empty), and a chart-direct
         # install may omit the key entirely — in both cases emitting the var
         # (or its "nvidia.com/gpu=1" default) surfaces a phantom GPU in the
-        # CLI resources view. Render it only for a non-empty value.
+        # CLI resources view. GPU_REQUESTS is gated on the SAME condition so a
+        # CPU-only install emits NEITHER var, and a GPU install emits BOTH
+        # (a lone GPU request with no matching limit is rejected by the API
+        # server). Render only for a non-empty GPU_LIMITS value.
         {{- if (default "" .Values.env.GPU_LIMITS) }}
+        - name: GPU_REQUESTS
+          value: {{ if hasKey .Values.env "GPU_REQUESTS" }}{{ .Values.env.GPU_REQUESTS | quote }}{{ else }}"nvidia.com/gpu=1"{{ end }}
         - name: GPU_LIMITS
           value: {{ .Values.env.GPU_LIMITS | quote }}
         {{- end }}
@@ -325,11 +328,13 @@ spec:
           value: {{ if hasKey .Values.env "RESOURCE_REQUESTS" }}{{ .Values.env.RESOURCE_REQUESTS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         - name: RESOURCE_LIMITS
           value: {{ if hasKey .Values.env "RESOURCE_LIMITS" }}{{ .Values.env.RESOURCE_LIMITS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
+        # #343: only stamp the GPU vars when a GPU is actually configured (see
+        # the api container above) — GPU_REQUESTS and GPU_LIMITS share one gate
+        # so a CPU-only install emits neither (no phantom GPU in the CLI view)
+        # and a GPU install emits both (request == limit).
+        {{- if (default "" .Values.env.GPU_LIMITS) }}
         - name: GPU_REQUESTS
           value: {{ if hasKey .Values.env "GPU_REQUESTS" }}{{ .Values.env.GPU_REQUESTS | quote }}{{ else }}"nvidia.com/gpu=1"{{ end }}
-        # #343: only stamp GPU_LIMITS when a GPU is actually configured (see the
-        # api container above) — a phantom GPU otherwise leaks to the CLI view.
-        {{- if (default "" .Values.env.GPU_LIMITS) }}
         - name: GPU_LIMITS
           value: {{ .Values.env.GPU_LIMITS | quote }}
         {{- end }}

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -255,8 +255,15 @@ spec:
           value: {{ if hasKey .Values.env "RESOURCE_LIMITS" }}{{ .Values.env.RESOURCE_LIMITS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         - name: GPU_REQUESTS
           value: {{ if hasKey .Values.env "GPU_REQUESTS" }}{{ .Values.env.GPU_REQUESTS | quote }}{{ else }}"nvidia.com/gpu=1"{{ end }}
+        # #343: only stamp GPU_LIMITS when a GPU is actually configured. A
+        # CPU-only install writes GPU_LIMITS: "" (empty), and a chart-direct
+        # install may omit the key entirely — in both cases emitting the var
+        # (or its "nvidia.com/gpu=1" default) surfaces a phantom GPU in the
+        # CLI resources view. Render it only for a non-empty value.
+        {{- if (default "" .Values.env.GPU_LIMITS) }}
         - name: GPU_LIMITS
-          value: {{ if hasKey .Values.env "GPU_LIMITS" }}{{ .Values.env.GPU_LIMITS | quote }}{{ else }}"nvidia.com/gpu=1"{{ end }}
+          value: {{ .Values.env.GPU_LIMITS | quote }}
+        {{- end }}
         - name: RUNTIME_CLASS_NAME
           value: {{ if hasKey .Values.env "RUNTIME_CLASS_NAME" }}{{ .Values.env.RUNTIME_CLASS_NAME | quote }}{{ else }}""{{ end }}
         # client-runtime#92: gates jobs-manager's GPU->CPU pending-job fallback.
@@ -320,8 +327,12 @@ spec:
           value: {{ if hasKey .Values.env "RESOURCE_LIMITS" }}{{ .Values.env.RESOURCE_LIMITS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         - name: GPU_REQUESTS
           value: {{ if hasKey .Values.env "GPU_REQUESTS" }}{{ .Values.env.GPU_REQUESTS | quote }}{{ else }}"nvidia.com/gpu=1"{{ end }}
+        # #343: only stamp GPU_LIMITS when a GPU is actually configured (see the
+        # api container above) — a phantom GPU otherwise leaks to the CLI view.
+        {{- if (default "" .Values.env.GPU_LIMITS) }}
         - name: GPU_LIMITS
-          value: {{ if hasKey .Values.env "GPU_LIMITS" }}{{ .Values.env.GPU_LIMITS | quote }}{{ else }}"nvidia.com/gpu=1"{{ end }}
+          value: {{ .Values.env.GPU_LIMITS | quote }}
+        {{- end }}
         - name: RUNTIME_CLASS_NAME
           value: {{ if hasKey .Values.env "RUNTIME_CLASS_NAME" }}{{ .Values.env.RUNTIME_CLASS_NAME | quote }}{{ else }}""{{ end }}
         # Kept in sync with the api container (client-runtime#92). pods-monitor


### PR DESCRIPTION
Closes #343.

## Fix
Only stamp the `GPU_LIMITS` env var (both jobs-manager containers) when a GPU value is actually configured (non-empty), removing the phantom-GPU source on CPU-only installs.

## Files
- `client/templates/jobs-manager-deployment.yaml`

## Validation
`helm template` — 2 `GPU_LIMITS` entries when set, 0 when empty/absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Helm templating change for optional GPU env vars; GPU-enabled installs keep paired request/limit behavior.
> 
> **Overview**
> Fixes **#343** by changing how the jobs-manager Helm template sets GPU-related env on the **api** and **pods-monitor** containers.
> 
> **`GPU_REQUESTS` and `GPU_LIMITS` are only rendered when `env.GPU_LIMITS` is non-empty.** CPU-only installs (empty `GPU_LIMITS` or the key omitted) no longer get those vars or the previous `nvidia.com/gpu=1` default, which was showing a phantom GPU in the CLI resources view. GPU installs still emit **both** request and limit together; `GPU_LIMITS` is taken from values without a chart default inside the gated block.
> 
> Chart version bumps to **1.9.22**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5d5ee38dd17f32adc112b579ba74bbc25ab9d4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->