### PR TITLE
fix(#555): add activeDeadlineSeconds to the auto-upgrade Job

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.23
-appVersion: "1.9.23"
+version: 1.9.24
+appVersion: "1.9.24"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -430,3 +430,26 @@ unknown
 unknown
 {{- end -}}
 {{- end -}}
+
+{{/*
+tracebloc.durationSeconds — parse a Go/Helm duration string (as accepted by
+`helm --timeout`, e.g. "10m", "30m", "1h", "600s", "1h30m") into a whole
+number of seconds. Sums every `<int><unit>` component so compound durations
+work; recognises s/m/h/d, ignores anything else. Empty/nil input -> 0.
+Used by auto-upgrade-cronjob.yaml (#555) so the Job's activeDeadlineSeconds
+can be kept above the configured helm timeout.
+*/}}
+{{- define "tracebloc.durationSeconds" -}}
+{{- $d := . | toString -}}
+{{- $total := 0 -}}
+{{- range regexFindAll "[0-9]+[smhd]" $d -1 -}}
+{{- $num := regexFind "[0-9]+" . | atoi -}}
+{{- $unit := regexFind "[smhd]" . -}}
+{{- if eq $unit "s" -}}{{- $total = add $total $num -}}
+{{- else if eq $unit "m" -}}{{- $total = add $total (mul $num 60) -}}
+{{- else if eq $unit "h" -}}{{- $total = add $total (mul $num 3600) -}}
+{{- else if eq $unit "d" -}}{{- $total = add $total (mul $num 86400) -}}
+{{- end -}}
+{{- end -}}
+{{- $total -}}
+{{- end -}}

--- a/client/templates/auto-upgrade-cronjob.yaml
+++ b/client/templates/auto-upgrade-cronjob.yaml
@@ -112,7 +112,7 @@ spec:
       # fetches can hang on a TCP black-hole with no timeout, and with
       # concurrencyPolicy: Forbid a single hung Job skips every future tick.
       # This backstop fails the Job so the next tick can run.
-      activeDeadlineSeconds: {{ .Values.autoUpgrade.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.autoUpgrade.activeDeadlineSeconds | default 900 }}
       template:
         metadata:
           labels:

--- a/client/templates/auto-upgrade-cronjob.yaml
+++ b/client/templates/auto-upgrade-cronjob.yaml
@@ -107,6 +107,12 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
+      # #555: hard wall-clock cap on the Job. `timeout` bounds only
+      # `helm upgrade --wait`; the earlier `helm repo add`/`helm repo update`
+      # fetches can hang on a TCP black-hole with no timeout, and with
+      # concurrencyPolicy: Forbid a single hung Job skips every future tick.
+      # This backstop fails the Job so the next tick can run.
+      activeDeadlineSeconds: {{ .Values.autoUpgrade.activeDeadlineSeconds }}
       template:
         metadata:
           labels:

--- a/client/templates/auto-upgrade-cronjob.yaml
+++ b/client/templates/auto-upgrade-cronjob.yaml
@@ -112,7 +112,16 @@ spec:
       # fetches can hang on a TCP black-hole with no timeout, and with
       # concurrencyPolicy: Forbid a single hung Job skips every future tick.
       # This backstop fails the Job so the next tick can run.
-      activeDeadlineSeconds: {{ .Values.autoUpgrade.activeDeadlineSeconds | default 900 }}
+      #
+      # The deadline must never undercut a longer configured autoUpgrade.timeout:
+      # that would kill a healthy `helm upgrade --wait` before its own timeout
+      # fires. So take the MAX of the configured floor (default 900s) and the
+      # parsed timeout plus 300s repo-fetch headroom (the same 900-600 headroom
+      # baked into the defaults). `| default 900` preserves the reuse-values
+      # nil-guard when the key is absent.
+      {{- $deadlineFloor := .Values.autoUpgrade.activeDeadlineSeconds | default 900 | int }}
+      {{- $timeoutSeconds := include "tracebloc.durationSeconds" .Values.autoUpgrade.timeout | int }}
+      activeDeadlineSeconds: {{ max $deadlineFloor (add $timeoutSeconds 300) }}
       template:
         metadata:
           labels:

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -737,6 +737,10 @@
           "type": "integer",
           "minimum": 0
         },
+        "activeDeadlineSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
         "image": {
           "type": "object",
           "required": ["repository", "tag"],

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -687,6 +687,16 @@ autoUpgrade:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 600
+  # Hard wall-clock cap on the whole Job (#555). `timeout` above only bounds
+  # `helm upgrade --wait`; the earlier `helm repo add`/`helm repo update`
+  # HTTPS fetches have no timeout of their own, so on a TCP black-hole (a
+  # corporate proxy that drops packets with no RST) the Job can hang
+  # indefinitely — and with concurrencyPolicy: Forbid that hung Job makes
+  # every future tick "still active" and skipped, wedging auto-upgrade until a
+  # human kills the pod. activeDeadlineSeconds is the backstop that fails the
+  # Job instead. Keep it comfortably above `timeout` (600s) plus repo-update
+  # headroom so a slow-but-healthy upgrade is never killed mid-flight.
+  activeDeadlineSeconds: 900
   # Pod image: helm CLI only. alpine/helm is small and the tag pins the
   # helm version, so behaviour cannot drift if upstream re-tags.
   image:

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -694,8 +694,11 @@ autoUpgrade:
   # indefinitely — and with concurrencyPolicy: Forbid that hung Job makes
   # every future tick "still active" and skipped, wedging auto-upgrade until a
   # human kills the pod. activeDeadlineSeconds is the backstop that fails the
-  # Job instead. Keep it comfortably above `timeout` (600s) plus repo-update
-  # headroom so a slow-but-healthy upgrade is never killed mid-flight.
+  # Job instead. This is a FLOOR, not the final value: the template renders
+  # activeDeadlineSeconds as max(this, parsed `timeout` + 300s repo-fetch
+  # headroom), so raising `timeout` above ~10m automatically lifts the deadline
+  # too and a slow-but-healthy upgrade is never killed mid-flight. Raise this
+  # only to give even more slack than the timeout-derived value.
   activeDeadlineSeconds: 900
   # Pod image: helm CLI only. alpine/helm is small and the tag pins the
   # helm version, so behaviour cannot drift if upstream re-tags.


### PR DESCRIPTION
Closes #555.

## Fix
Add `activeDeadlineSeconds` to the auto-upgrade Job spec (new `autoUpgrade.activeDeadlineSeconds`, default 900) so a hung `helm repo update` can no longer run unbounded.

## Files
- `client/templates/auto-upgrade-cronjob.yaml`, `client/values.yaml`, `client/values.schema.json`

## Validation
`helm template`, schema JSON valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only the auto-upgrade CronJob lifecycle timing on fleet edges; logic is designed not to kill in-flight upgrades before `helm upgrade --wait` times out, but mis-tuned deadlines could still fail long upgrades.
> 
> **Overview**
> Fixes **#555** by giving the auto-upgrade CronJob Job a hard wall-clock limit so a stuck `helm repo add` / `helm repo update` cannot block every future run under `concurrencyPolicy: Forbid`.
> 
> The Job now sets **`activeDeadlineSeconds`** to **`max(autoUpgrade.activeDeadlineSeconds, parsed timeout + 300s)`**, with a new configurable floor (default **900s**) and a **`tracebloc.durationSeconds`** helper that turns `autoUpgrade.timeout` (e.g. `10m`) into seconds. Chart version bumps to **1.9.24**; values and JSON schema document the new knob.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a362b76198a6989b25241b24cc881c7266388d2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->