### PR TITLE
fix(#567): guard that Windows installs k3d from the pinned, verified release

### DIFF
--- a/scripts/tests/install-k8s.Tests.ps1
+++ b/scripts/tests/install-k8s.Tests.ps1
@@ -568,6 +568,20 @@ Describe "Invoke-TrackedInstall (#500 capture installer output)" {
     $script:ISRC | Should -Not -Match '-Tag "k3d-winget"'
     $script:ISRC | Should -Not -Match 'install","-e","--id","Rancher\.k3d"'
   }
+  # #567 (F3 follow-up from #547): k3d's CLI version must be deterministic on
+  # Windows. winget could install whatever version its manifest floated to; the
+  # pinned, checksum-verified direct download is now the SINGLE k3d path (matching
+  # Linux/macOS which honor the pin). These positive source guards lock that in so
+  # a future edit can't silently reintroduce a floating/unpinned k3d source.
+  It "installs k3d from the PINNED release version (#567)" {
+    $script:ISRC | Should -Match 'Resolve-ToolVersion -Name "k3d" -Value \$K3dVersion'
+    $script:ISRC | Should -Match '\$k3dUrl = "https://github\.com/k3d-io/k3d/releases/download/\$k3dVer/k3d-windows-\$arch\.exe"'
+  }
+  It "verifies the k3d download (fail-closed) rather than trusting an unpinned source (#567)" {
+    $script:ISRC | Should -Match 'Get-VerifiedDownload -Url \$k3dUrl'
+    # checksum mismatch / unfetchable checksums both abort (fail-closed).
+    $script:ISRC | Should -Match 'k3d checksums[\s\S]{0,600}Err "System tool checksum verification failed."'
+  }
   It "returns ok with the exit code when the process succeeds" {
     Mock Start-Process { [pscustomobject]@{ ExitCode = 0; HasExited = $true } }
     Mock Wait-ProcessWithDeadline { $true }


### PR DESCRIPTION
Closes #567.

## Context
The **substantive fix already landed in #607** on develop: k3d has no winget manifest, so the winget path was removed and the pinned, checksum-verified direct download is the single k3d path (matching Linux/macOS). This PR only adds the positive Pester **source guards** F3 asked to extend, locking in the determinism.

> If you consider #607 sufficient, this PR can simply be closed.

## Files
- `scripts/tests/install-k8s.Tests.ps1`

## Validation
Regex patterns verified against source. **`pwsh` unavailable in this env — run the Pester suite on a Windows runner before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no installer behavior modified. Low risk unless regex patterns drift from `install-k8s.ps1` and cause false CI failures.
> 
> **Overview**
> Adds **Pester source guards** in `install-k8s.Tests.ps1` so Windows k3d install behavior stays locked after #607 removed winget. The installer logic is unchanged in this PR.
> 
> Two new tests assert `install-k8s.ps1` still resolves k3d via **`Resolve-ToolVersion`** with **`$K3dVersion`**, builds the **GitHub release URL** for `k3d-windows-$arch.exe`, downloads through **`Get-VerifiedDownload`**, and **fail-closed** checksum verification (mismatch or unfetchable checksums → **`Err "System tool checksum verification failed."`**). That blocks a future change from reintroducing an unpinned or unverified k3d path on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0af6d647de255e3ba7a498cdd4414a6e8b722cbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->