### PR TITLE
chore(devex): Makefile with a uniform 'make check' (backend#1606)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,149 @@
+# Makefile for tracebloc/client — uniform entry points (backend#1606).
+#
+# Every active tracebloc repo exposes the SAME three targets, so "run
+# your tests before you push" stops being a rule you can only obey with
+# per-repo tribal knowledge:
+#
+#   make check      lint + fast tests.   Budget: under 60 s.
+#   make check-all  everything CI runs (bar the CI-only heavy suites).
+#   make setup      install what those targets need.
+#
+# This file is a THIN WRAPPER. Every command below is copied from the
+# workflow that already runs it — standard-checks.yml, installer-tests.yaml
+# and helm-ci.yaml. It introduces no new tool, no new config, and no new
+# rule. When a workflow changes, change the matching line here.
+
+.DEFAULT_GOAL := help
+
+# The shellcheck file set from installer-tests.yaml's `static` job (a
+# superset of standard-checks.yml's list), at the same `error` severity.
+SHELLCHECK_FILES := \
+	scripts/install.sh \
+	scripts/install-k8s.sh \
+	scripts/gen-manifest.sh \
+	scripts/check-facts.sh \
+	scripts/check-style.sh \
+	scripts/resolve-ingestor-digest.sh \
+	scripts/lib/*.sh \
+	scripts/tests/check-drift.sh \
+	scripts/tests/distro-prereqs.sh \
+	scripts/tests/e2e-auto-upgrade.sh \
+	scripts/tests/e2e-seal-check.sh \
+	scripts/tests/e2e-full-seal.sh \
+	scripts/tests/e2e-cluster.sh \
+	scripts/tests/e2e-journey.sh \
+	scripts/tests/e2e-proxy.sh \
+	scripts/tests/lib/e2e-common.sh \
+	scripts/tests/path-persist.sh
+
+.PHONY: help
+help:
+	@echo "tracebloc/client — make targets"
+	@echo
+	@echo "  check       lint + fast checks (~4 s) — run this before every push"
+	@echo "  check-all   everything CI runs locally, including the 868-test bats suite"
+	@echo "  setup       check for / point at the tools these targets need"
+	@echo
+	@echo "  individual: lint bats helm-lint helm-template helm-unittest drift"
+	@echo
+	@echo "  NOT here (CI-only, by name): the 9-distro prereq matrix, e2e-cluster"
+	@echo "  (k3d), e2e-proxy (squid), path-persist, Pester, windows-e2e,"
+	@echo "  e2e-journey, upgrade-e2e / seal-check-e2e / full-seal-e2e."
+
+# ---- check: the pre-push tier ------------------------------------
+#
+# Measured at ~4 s (macOS): bash -n 0.1 s, shellcheck 3.2 s, the three
+# drift guards 0.2 s, helm lint 0.7 s.
+#
+# The bats suite is deliberately NOT here. It is the repo's real unit
+# suite (868 tests) and it takes ~2 min serially on macOS — three times
+# over the budget — and it does not parallelise without GNU parallel,
+# which is not a thing every dev machine has. Splitting it into a fast
+# tier is real work, not a Makefile line, so it lives in `check-all`
+# until someone does it. A `check` that quietly took two minutes would
+# be a `check` nobody runs.
+.PHONY: check
+check: lint drift helm-lint
+	@echo "==> check: green (bats + helm unit tests are in 'make check-all')"
+
+.PHONY: check-all
+check-all: lint drift helm-lint bats helm-template helm-unittest
+	@echo "==> check-all: green"
+
+# setup: no dependency is installed and no hook is added (hooks are a
+# later step of backend#1606). This only tells you what is missing.
+.PHONY: setup
+setup:
+	@missing=""; \
+	for t in bash shellcheck bats helm; do \
+	  command -v $$t >/dev/null 2>&1 || missing="$$missing $$t"; \
+	done; \
+	if [ -n "$$missing" ]; then \
+	  echo "missing:$$missing"; \
+	  echo "  macOS: brew install shellcheck bats-core helm"; \
+	  echo "  Debian/Ubuntu: apt-get install shellcheck bats  (helm: https://helm.sh/docs/intro/install/)"; \
+	  exit 1; \
+	fi; \
+	echo "==> setup: shellcheck, bats and helm are all present; run 'make check'"
+
+# ---- individual targets ------------------------------------------
+
+# lint: standard-checks.yml `Lint` + installer-tests.yaml `static`.
+# .bats files are bats DSL, not valid bash — they are exercised by
+# actually running them in the `bats` target.
+.PHONY: lint
+lint:
+	@find scripts -type f -name '*.sh' -print0 \
+	  | while IFS= read -r -d '' f; do bash -n "$$f" || exit 1; done
+	@echo "all shell scripts parse"
+	shellcheck --severity=error --shell=bash $(SHELLCHECK_FILES)
+
+# drift: the three single-source guards from installer-tests.yaml's
+# `static` job. All three are pure local file comparisons (~0.2 s) and
+# all three have a --write / regenerate mode named in their own output.
+.PHONY: drift
+drift:
+	scripts/gen-manifest.sh --check
+	scripts/check-facts.sh --check
+	bash scripts/check-style.sh
+
+# bats: standard-checks.yml `Unit tests` / installer-tests.yaml
+# `unit-bash`. ~2 min serially.
+.PHONY: bats
+bats:
+	bats scripts/tests/*.bats
+
+# helm-lint: helm-ci.yaml `lint`.
+.PHONY: helm-lint
+helm-lint:
+	@for f in client/ci/*-values.yaml; do \
+	  echo "=== Linting client with $$f ==="; \
+	  helm lint --strict ./client -f "$$f" || exit 1; \
+	done
+	helm lint --strict ./ingestor
+
+# helm-template: helm-ci.yaml `template`. kubeconform is pinned by
+# version AND digest in CI; rather than re-implement that download here,
+# this renders every platform (which is the part that catches template
+# breaks) and runs kubeconform only if you already have it.
+.PHONY: helm-template
+helm-template:
+	@for p in aks bm eks oc; do \
+	  echo "=== Rendering $$p ==="; \
+	  helm template test-$$p ./client -f client/ci/$$p-values.yaml > /tmp/rendered-$$p.yaml || exit 1; \
+	  if command -v kubeconform >/dev/null 2>&1; then \
+	    kubeconform -strict -ignore-missing-schemas -summary /tmp/rendered-$$p.yaml || exit 1; \
+	  fi; \
+	done
+	@command -v kubeconform >/dev/null 2>&1 \
+	  || echo "note: kubeconform not on PATH — rendered only. CI also validates the manifests."
+
+# helm-unittest: helm-ci.yaml `unittest`. Needs the plugin; the install
+# command is the one CI uses, pinned to the same version.
+.PHONY: helm-unittest
+helm-unittest:
+	@helm plugin list 2>/dev/null | grep -q unittest \
+	  || { echo "helm-unittest plugin missing — install it with:"; \
+	       echo "  helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.5.2"; \
+	       exit 1; }
+	helm unittest ./client

--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,17 @@ setup:
 # lint: standard-checks.yml `Lint` + installer-tests.yaml `static`.
 # .bats files are bats DSL, not valid bash — they are exercised by
 # actually running them in the `bats` target.
+#
+# The parse loop is `xargs -0 -n1`, NOT `while read -r -d ''`. Make runs
+# recipes under /bin/sh, which on Debian and Ubuntu is dash, and dash
+# rejects `read -d` outright — the loop body would never execute and the
+# pipeline would still exit 0, so `make check` would cheerfully print
+# "all shell scripts parse" having parsed nothing. GitHub Actions uses
+# bash, so CI never showed it. xargs is POSIX, NUL-safe, and propagates
+# a child failure as a non-zero exit. (Bugbot, #630.)
 .PHONY: lint
 lint:
-	@find scripts -type f -name '*.sh' -print0 \
-	  | while IFS= read -r -d '' f; do bash -n "$$f" || exit 1; done
+	@find scripts -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n
 	@echo "all shell scripts parse"
 	shellcheck --severity=error --shell=bash $(SHELLCHECK_FILES)
 


### PR DESCRIPTION
## Summary

Today every repo in the org has a different incantation for "run your
tests": `python manage.py test` here, `yarn test:coverage` there,
`make ci` in cli, `pytest tests/ -m "not slow"` somewhere else. That
makes "run your tests before you push" a rule you can only obey if you
already know the repo — which means it is not really a rule, it is
tribal knowledge with a rule's wording. The people most likely to break
it are exactly the people least likely to know the incantation.

backend#1606 fixes that by giving every active repo the same three
targets:

  make check      lint + fast tests. Budget: UNDER 60 SECONDS.
  make check-all  everything CI runs, minus the CI-only heavy suites.
  make setup      install what those targets need.

The 60-second budget is not decoration. It is the property that decides
whether anyone runs the thing: a `make check` that takes ten minutes is
a rule people learn to skip, and skipping one rule teaches skipping
others. So the split between `check` and `check-all` is drawn on
measured wall-clock time, not on taste.

The Makefile is a THIN WRAPPER. Every command in it was lifted from the
workflow that already runs it. It adds no tool, no config, and no rule,
and it changes no CI workflow — making CI call `make check` is a
separate, later wave (decision 2 on backend#1606), deliberately kept out
of this PR so that a Makefile bug cannot redden the pipeline. No
pre-commit or pre-push hook is installed here either; that is step 4.

In this repo
------------

`make check` — MEASURED 5.3 s:

  bash -n on every shell script, shellcheck at error severity over the
  file set installer-tests.yaml lints, the three single-source drift
  guards (gen-manifest --check, check-facts --check, check-style), and
  helm lint --strict for all four platform values files plus the
  ingestor subchart.

HONEST GAP — this is the one repo in the wave where I could not split
fast from slow without lying. The bats suite IS this repo's unit suite
(868 tests) and it takes ~2 minutes serially on macOS. It does not
parallelise without GNU parallel, which is not on every dev machine, and
the per-file timings show no natural fast tier: the slowest file
(common.bats, 37 s) is also the most load-bearing, so any subset would
be arbitrary and would rot. So bats sits in `check-all`, and `make
check` here is lint-only. A `check` that quietly took two minutes would
be a `check` nobody runs, which is worse. Splitting the bats suite is
real work and belongs in its own ticket.

`make check-all` adds bats, the 4-platform helm template render (with
kubeconform if you have it), and helm unittest (with the plugin install
line if you do not).

CI-only by name: the 9-distro prereq matrix, e2e-cluster (k3d),
e2e-proxy (squid), path-persist, Pester, windows-e2e, e2e-journey, and
the three k3d seal/upgrade e2e jobs.

## Related

Step 1 of tracebloc/backend#1606 — a `Makefile` with a uniform `check` target in every active repo. One PR per repo; this is this repo's.

## Type of change

- [x] Tech-debt / refactor (developer experience)

## Test plan

`make check` run for real: **green in 5.3 s**.

Every bats file was timed individually looking for a natural fast tier. There
isn't one: the full suite is ~2 min serially, and the slowest file
(common.bats, 37 s, 68 tests) is also the most load-bearing — any subset would
be arbitrary and would rot. That is why bats sits in `check-all` and why the
gap is stated above rather than papered over.

`make help` and the dry runs of every target parse clean.

**No CI workflow is touched in this PR.** CI parity — making the workflows call `make check` — is decision 2 on backend#1606 and lands as its own wave, deliberately after the Makefiles exist and are proven locally. No pre-commit or pre-push hook is installed here either; that is step 4.

## Checklist

- [x] Works from a clean checkout — `.PHONY` on every target, `help` is the default goal
- [x] No CI workflow modified
- [x] No pre-commit / pre-push hook installed
- [x] No secrets / credentials in the diff
- [x] Every command is copied from the workflow that already runs it — no new tool, no new config, no new rule
- [x] Portable to GNU Make 3.81 (the macOS system make)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-experience only: new Makefile targets mirror existing CI commands and do not touch runtime, auth, or deployment code.
> 
> **Overview**
> Adds a root **Makefile** so developers can run the same three entry points as other tracebloc repos: `make check` (fast pre-push), `make check-all` (full local CI parity), and `make setup` (tool presence check only—no installs or hooks).
> 
> **`make check`** wraps existing CI steps in ~4–5s: `bash -n` on all `scripts/**/*.sh`, shellcheck at error severity on the installer-tests file set, the three drift guards (`gen-manifest --check`, `check-facts --check`, `check-style`), and strict helm lint for client platform values plus ingestor. The **868-test bats suite** stays in **`make check-all`** with helm template render (optional kubeconform) and helm unittest, because it does not fit the under-60s budget.
> 
> Commands are copied from `standard-checks.yml`, `installer-tests.yaml`, and `helm-ci.yaml`; **no workflow files change**. The lint recipe uses **`find … | xargs -0 -n1 bash -n`** instead of a `read -d ''` loop so parsing still runs under dash when Make uses `/bin/sh`—avoiding a silent no-op that CI on bash would not catch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9bc22ac73f98b81d40bc713fee5ac0f0e6c9ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->