### PR TITLE
feat(gpu): custom k3s-CUDA node image + publish workflow (#616)

### DIFF
--- a/.github/workflows/build-k3s-cuda.yaml
+++ b/.github/workflows/build-k3s-cuda.yaml
@@ -1,0 +1,46 @@
+name: build-k3s-cuda
+
+# Build (and optionally publish) the custom k3s node image with NVIDIA GPU
+# support for GPU-enabled edges (#616). Manual only — a ~GB CUDA image build
+# should never run on every push. Set push=true to publish to GHCR.
+on:
+  workflow_dispatch:
+    inputs:
+      k3s_tag:
+        description: "k3s image tag — MUST match K8S_VERSION (scripts/lib/common.sh)"
+        default: "v1.29.4-k3s1"
+      cuda_tag:
+        description: "NVIDIA CUDA base tag"
+        default: "12.4.1-base-ubuntu22.04"
+      push:
+        description: "Publish to ghcr.io (otherwise build-only validation)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # Plain docker CLI (no unpinned marketplace actions -> passes action-pins).
+      - name: Prepare buildx
+        run: docker buildx create --use --name k3scuda || docker buildx use k3scuda
+
+      - name: Log in to GHCR
+        if: ${{ inputs.push }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build${{ inputs.push && ' and push' || ' (validate only)' }}
+        env:
+          K3S_TAG: ${{ inputs.k3s_tag }}
+          CUDA_TAG: ${{ inputs.cuda_tag }}
+          PUSH: ${{ inputs.push }}
+          IMAGE_REGISTRY: ghcr.io
+          IMAGE_REPOSITORY: ${{ github.repository_owner }}/k3s-cuda
+          PLATFORM: linux/amd64
+        run: bash docker/k3s-cuda/build.sh

--- a/.github/workflows/build-k3s-cuda.yaml
+++ b/.github/workflows/build-k3s-cuda.yaml
@@ -24,6 +24,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Bound the ~GB CUDA build so a stalled nvcr.io pull or wedged push fails fast
+    # instead of spinning to the 6h default (parity with helm-ci / installer-tests).
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -31,9 +34,15 @@ jobs:
       - name: Prepare buildx
         run: docker buildx create --use --name k3scuda || docker buildx use k3scuda
 
+      # Pass the token + actor through env (NOT interpolated into the run line): context
+      # values are substituted before the shell parses, so a metacharacter in the expansion
+      # would become shell syntax in a packages:write job. Quoted env vars keep them inert.
       - name: Log in to GHCR
         if: ${{ inputs.push }}
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
       - name: Build${{ inputs.push && ' and push' || ' (validate only)' }}
         env:

--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -16,6 +16,11 @@ on:
     paths:
       - 'scripts/**'
       - '.github/workflows/installer-tests.yaml'
+      # #616: the check-facts drift gate enforces the GPU node image's k3s pin against
+      # facts.env — run it when those files change too, else a K3S_TAG edit could drift
+      # and merge green (Bugbot).
+      - 'docker/k3s-cuda/**'
+      - '.github/workflows/build-k3s-cuda.yaml'
   pull_request:
     # `labeled` is required so adding the `e2e` label to an open PR starts the
     # e2e-journey job immediately — with the default types it would only fire on
@@ -25,6 +30,11 @@ on:
     paths:
       - 'scripts/**'
       - '.github/workflows/installer-tests.yaml'
+      # #616: the check-facts drift gate enforces the GPU node image's k3s pin against
+      # facts.env — run it when those files change too, else a K3S_TAG edit could drift
+      # and merge green (Bugbot).
+      - 'docker/k3s-cuda/**'
+      - '.github/workflows/build-k3s-cuda.yaml'
   schedule:
     - cron: '0 3 * * 1'   # Mondays 03:00 UTC — catch drift as distro base images move
   workflow_dispatch:

--- a/docker/k3s-cuda/Dockerfile
+++ b/docker/k3s-cuda/Dockerfile
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1.7-labs
+# =============================================================================
+#  Custom k3s node image with NVIDIA GPU support  (tracebloc/client #616)
+# =============================================================================
+# WHY this exists: the stock `rancher/k3s` image is Alpine-based and ships NO
+# NVIDIA container runtime, so GPU pods can never schedule on it — the node
+# advertises 0 nvidia.com/gpu. This image rebuilds the SAME pinned k3s on an
+# NVIDIA CUDA Ubuntu base, installs the NVIDIA Container Toolkit, configures
+# containerd for the `nvidia` runtime, and bakes in the device-plugin +
+# `nvidia` RuntimeClass so the node advertises nvidia.com/gpu on first boot.
+# Based on the official k3d CUDA recipe (https://k3d.io/.../usage/advanced/cuda/).
+#
+# IMPORTANT: K3S_TAG MUST match the installer's K8S_VERSION pin
+# (scripts/lib/common.sh: K8S_VERSION) so a GPU node runs the exact same
+# validated k3s as a normal CPU node. The build workflow enforces this.
+ARG K3S_TAG="v1.29.4-k3s1"
+ARG CUDA_TAG="12.4.1-base-ubuntu22.04"
+
+FROM rancher/k3s:${K3S_TAG} AS k3s
+
+FROM nvcr.io/nvidia/cuda:${CUDA_TAG}
+
+# NVIDIA Container Toolkit, then point containerd at the `nvidia` runtime. The
+# gpg key + apt list are pinned via the keyring the same way the in-WSL toolkit
+# install does (scripts/install-k8s.ps1) so a restricted-network mirror can
+# re-home them consistently.
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
+    && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+         | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+    && curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+         | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+         | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nvidia-container-toolkit \
+    && nvidia-ctk runtime configure --runtime=containerd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the pinned k3s rootfs over the CUDA base. Exclude /bin on the first copy
+# so the Ubuntu userland (curl, apt, nvidia-ctk) survives, then bring in k3s's
+# own /bin (the k3s binary + /bin/aux) explicitly — the official recipe's split.
+COPY --from=k3s --exclude=/bin / /
+COPY --from=k3s /bin /bin
+
+# Auto-deploy the NVIDIA device plugin + `nvidia` RuntimeClass on first server
+# boot (k3s auto-applies manifests dropped here). This is what makes the node
+# advertise nvidia.com/gpu without a separate `kubectl apply`.
+COPY nvidia-device-plugin-daemonset.yaml /var/lib/rancher/k3s/server/manifests/nvidia-device-plugin-daemonset.yaml
+
+VOLUME /var/lib/kubelet
+VOLUME /var/lib/rancher/k3s
+VOLUME /var/lib/cni
+VOLUME /var/log
+
+ENV PATH="$PATH:/bin/aux"
+
+ENTRYPOINT ["/bin/k3s"]
+CMD ["agent"]

--- a/docker/k3s-cuda/Dockerfile
+++ b/docker/k3s-cuda/Dockerfile
@@ -11,8 +11,10 @@
 # Based on the official k3d CUDA recipe (https://k3d.io/.../usage/advanced/cuda/).
 #
 # IMPORTANT: K3S_TAG MUST match the installer's K8S_VERSION pin
-# (scripts/lib/common.sh: K8S_VERSION) so a GPU node runs the exact same
-# validated k3s as a normal CPU node. The build workflow enforces this.
+# (scripts/spec/facts.env / scripts/lib/common.sh) so a GPU node runs the exact
+# same validated k3s as a normal CPU node. scripts/check-facts.sh enforces this:
+# this ARG, build.sh, and the workflow input default are all checked against
+# facts.env's K8S_VERSION, so a bump can't leave the GPU image tag stale (#547).
 ARG K3S_TAG="v1.29.4-k3s1"
 ARG CUDA_TAG="12.4.1-base-ubuntu22.04"
 
@@ -23,13 +25,15 @@ FROM nvcr.io/nvidia/cuda:${CUDA_TAG}
 # NVIDIA Container Toolkit, then point containerd at the `nvidia` runtime. The
 # gpg key + apt list are pinned via the keyring the same way the in-WSL toolkit
 # install does (scripts/install-k8s.ps1) so a restricted-network mirror can
-# re-home them consistently.
+# re-home them consistently. curl carries the TLS floor + bounded timeouts inline
+# (a Dockerfile can't source common.sh's curl_secure()) so a stalled or downgraded
+# connection to nvidia.github.io fails fast instead of hanging the build (house rule).
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
-    && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+    && curl -fsSL --tlsv1.2 --connect-timeout 30 --max-time 60 https://nvidia.github.io/libnvidia-container/gpgkey \
          | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
-    && curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+    && curl -fsSL --tlsv1.2 --connect-timeout 30 --max-time 60 https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
          | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
          | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list \
     && apt-get update \

--- a/docker/k3s-cuda/README.md
+++ b/docker/k3s-cuda/README.md
@@ -1,0 +1,43 @@
+# Custom k3s-CUDA node image (GPU-enabled edges — #616)
+
+The stock `rancher/k3s` image is Alpine-based and has **no NVIDIA container
+runtime**, so GPU pods can never schedule on it (the node advertises
+`0 nvidia.com/gpu`). This directory builds a drop-in replacement k3s node image
+that:
+
+1. rebuilds the **same pinned k3s** (`K3S_TAG`, matched to the installer's
+   `K8S_VERSION`) on an NVIDIA CUDA Ubuntu base,
+2. installs the NVIDIA Container Toolkit and configures containerd for the
+   `nvidia` runtime, and
+3. bakes in the NVIDIA device plugin + an `nvidia` `RuntimeClass`, so the node
+   advertises `nvidia.com/gpu` on first boot.
+
+Based on the official [k3d CUDA recipe](https://k3d.io/v5.7.4/usage/advanced/cuda/).
+
+## How it's used
+
+When a GPU is detected **and** verified usable, `scripts/install-k8s.ps1`
+creates the k3d cluster with `--image <this image> --gpus=all` (instead of
+`rancher/k3s:<K8S_VERSION>`) and sets `RUNTIME_CLASS_NAME=nvidia` so every
+spawned training pod runs under the `nvidia` RuntimeClass. If the GPU can't be
+wired up, the installer falls back to the stock image and CPU (see #616 Layer 1).
+
+## Build
+
+```bash
+# local build (no push)
+K3S_TAG=v1.29.4-k3s1 ./build.sh
+
+# build + push to ghcr.io/tracebloc/k3s-cuda:<k3s>-cuda-<cuda>
+PUSH=true ./build.sh
+```
+
+Or run the **build-k3s-cuda** GitHub workflow (manual `workflow_dispatch`; set
+`push: true` to publish).
+
+## Version pinning
+
+`K3S_TAG` **must** equal the installer's `K8S_VERSION`
+(`scripts/lib/common.sh`). The image tag encodes both the k3s pin and the CUDA
+base — e.g. `v1.29.4-k3s1-cuda-12.4.1-base-ubuntu22.04` — so a new k8s pin can
+never silently reuse a stale GPU image. Bump both together.

--- a/docker/k3s-cuda/build.sh
+++ b/docker/k3s-cuda/build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  Build (and optionally push) the custom k3s-CUDA node image  (#616)
+# =============================================================================
+# See ./Dockerfile for WHY this image is needed. Env knobs:
+#   K3S_TAG           k3s tag — MUST match the installer's K8S_VERSION pin
+#   CUDA_TAG          NVIDIA CUDA base tag
+#   IMAGE_REGISTRY    default ghcr.io
+#   IMAGE_REPOSITORY  default tracebloc/k3s-cuda
+#   PLATFORM          default linux/amd64 (NVIDIA GPU nodes)
+#   PUSH              "true" to push, otherwise build+load locally
+set -euo pipefail
+
+K3S_TAG="${K3S_TAG:-v1.29.4-k3s1}"
+CUDA_TAG="${CUDA_TAG:-12.4.1-base-ubuntu22.04}"
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-ghcr.io}"
+IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-tracebloc/k3s-cuda}"
+PLATFORM="${PLATFORM:-linux/amd64}"
+PUSH="${PUSH:-false}"
+
+# The tag encodes BOTH the k3s pin and the CUDA base, so a new k8s pin can never
+# silently reuse a stale GPU image, and the installer can derive it from
+# K8S_VERSION deterministically.
+TAG="${K3S_TAG}-cuda-${CUDA_TAG}"
+IMAGE="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${TAG}"
+
+cd "$(dirname "$0")"
+echo "Building ${IMAGE}  (k3s=${K3S_TAG} cuda=${CUDA_TAG} platform=${PLATFORM} push=${PUSH})"
+
+args=(build
+  --build-arg "K3S_TAG=${K3S_TAG}"
+  --build-arg "CUDA_TAG=${CUDA_TAG}"
+  --platform "${PLATFORM}"
+  -t "${IMAGE}"
+  .)
+if [[ "${PUSH}" == "true" ]]; then
+  docker buildx "${args[@]}" --push
+else
+  docker buildx "${args[@]}" --load
+fi
+echo "Done: ${IMAGE}"

--- a/docker/k3s-cuda/nvidia-device-plugin-daemonset.yaml
+++ b/docker/k3s-cuda/nvidia-device-plugin-daemonset.yaml
@@ -1,0 +1,59 @@
+# =============================================================================
+#  NVIDIA device plugin + `nvidia` RuntimeClass  (tracebloc/client #616)
+# =============================================================================
+# Baked into the custom k3s-CUDA image at
+# /var/lib/rancher/k3s/server/manifests/ so k3s auto-applies it on first server
+# boot — the node then advertises nvidia.com/gpu with no separate kubectl apply.
+#
+# The `nvidia` RuntimeClass is what training pods reference via
+# runtimeClassName: nvidia (the installer sets RUNTIME_CLASS_NAME=nvidia when
+# the GPU is enabled, which jobs-manager threads into every spawned pod).
+#
+# Pinned to NVIDIA k8s-device-plugin v0.14.5 (same version the installer's
+# post-create fallback applies), so the two paths never disagree.
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: nvidia
+handler: nvidia
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-ds
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: nvidia-device-plugin-ds
+    spec:
+      runtimeClassName: nvidia
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      priorityClassName: system-node-critical
+      containers:
+        - name: nvidia-device-plugin-ctr
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.14.5
+          env:
+            - name: FAIL_ON_INIT_ERROR
+              value: "false"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/scripts/check-facts.sh
+++ b/scripts/check-facts.sh
@@ -27,6 +27,13 @@ COMMON="scripts/lib/common.sh"
 SUMMARY="scripts/lib/summary.sh"
 PS1="scripts/install-k8s.ps1"
 CLUSTER="scripts/lib/cluster.sh"
+# #616: the GPU node image (docker/k3s-cuda) rebuilds the SAME pinned k3s, so its
+# K3S_TAG in the Dockerfile ARG, build.sh, and the workflow input default must all
+# equal facts.env's K8S_VERSION — else a K8S_VERSION bump derives a GPU image tag
+# that was never published and the installer pulls a missing image.
+CUDA_DOCKERFILE="docker/k3s-cuda/Dockerfile"
+CUDA_BUILD="docker/k3s-cuda/build.sh"
+CUDA_WORKFLOW=".github/workflows/build-k3s-cuda.yaml"
 
 MODE="write"
 case "${1:-}" in
@@ -63,9 +70,12 @@ FACT_NAMES=(
   "install-k8s.ps1:K8S_VERSION"
   "summary.sh:READY_TIMEOUT"
   "install-k8s.ps1:ReadyTimeout"
+  "k3s-cuda/Dockerfile:K3S_TAG"
+  "k3s-cuda/build.sh:K3S_TAG"
+  "build-k3s-cuda.yaml:k3s_tag"
 )
-FACT_FILES=( "$COMMON" "$COMMON" "$COMMON" "$PS1" "$PS1" "$PS1" "$SUMMARY" "$PS1" )
-FACT_KEYS=( K3D_VERSION HELM_VERSION K8S_VERSION K3D_VERSION HELM_VERSION K8S_VERSION READY_TIMEOUT READY_TIMEOUT )
+FACT_FILES=( "$COMMON" "$COMMON" "$COMMON" "$PS1" "$PS1" "$PS1" "$SUMMARY" "$PS1" "$CUDA_DOCKERFILE" "$CUDA_BUILD" "$CUDA_WORKFLOW" )
+FACT_KEYS=( K3D_VERSION HELM_VERSION K8S_VERSION K3D_VERSION HELM_VERSION K8S_VERSION READY_TIMEOUT READY_TIMEOUT K8S_VERSION K8S_VERSION K8S_VERSION )
 FACT_EXTRACT=(
   's/^K3D_VERSION="\${K3D_VERSION:-\(.*\)}".*/\1/p'
   's/^HELM_VERSION="\${HELM_VERSION:-\(.*\)}".*/\1/p'
@@ -75,6 +85,9 @@ FACT_EXTRACT=(
   's/.*\$K8S_VERSION .*else { "\([^"]*\)" }.*/\1/p'
   's/^READY_TIMEOUT="\${READY_TIMEOUT:-\(.*\)}".*/\1/p'
   's/.*\$ReadyTimeout .*else { "\([^"]*\)" }.*/\1/p'
+  's/^ARG K3S_TAG="\(.*\)".*/\1/p'
+  's/^K3S_TAG="\${K3S_TAG:-\(.*\)}".*/\1/p'
+  's/^ *default: "\(v[0-9][^"]*\)".*/\1/p'
 )
 # For --write: an sed program that substitutes the OLD value with @@VAL@@ (replaced with
 # the spec value below). Anchored the same way as the extractor so only the pinned token
@@ -88,6 +101,9 @@ FACT_REWRITE=(
   's|\(\$K8S_VERSION .*else { "\)[^"]*\(" }\)|\1@@VAL@@\2|'
   's|^\(READY_TIMEOUT="${READY_TIMEOUT:-\)[^}]*\(}"\)|\1@@VAL@@\2|'
   's|\(\$ReadyTimeout .*else { "\)[^"]*\(" }\)|\1@@VAL@@\2|'
+  's|^\(ARG K3S_TAG="\)[^"]*\("\)|\1@@VAL@@\2|'
+  's|^\(K3S_TAG="${K3S_TAG:-\)[^}]*\(}"\)|\1@@VAL@@\2|'
+  's|\(default: "\)v[0-9][^"]*\("\)|\1@@VAL@@\2|'
 )
 
 # Capture whole, then take the first line with `%%$'\n'*` — NOT `… | head -1`, which

--- a/scripts/tests/check-facts.bats
+++ b/scripts/tests/check-facts.bats
@@ -34,6 +34,25 @@ SH
   cat > "$REPO/scripts/lib/cluster.sh" <<'SH'
 K3D_ARGS+=(--image "rancher/k3s:${K8S_VERSION}")
 SH
+  # #616: the GPU node image's k3s pin lives in the Dockerfile ARG, build.sh, and the
+  # workflow input default — all check-facts consumers of K8S_VERSION. Seed them to
+  # match the spec so a bump can't leave a GPU image tag that was never published.
+  mkdir -p "$REPO/docker/k3s-cuda" "$REPO/.github/workflows"
+  cat > "$REPO/docker/k3s-cuda/Dockerfile" <<'DF'
+ARG K3S_TAG="v1.29.4-k3s1"
+ARG CUDA_TAG="12.4.1-base-ubuntu22.04"
+DF
+  cat > "$REPO/docker/k3s-cuda/build.sh" <<'SH'
+K3S_TAG="${K3S_TAG:-v1.29.4-k3s1}"
+SH
+  # Two defaults on purpose: the extractor must pick the k3s_tag one (v… tag) and
+  # leave the cuda_tag default (12.4.1…) alone.
+  cat > "$REPO/.github/workflows/build-k3s-cuda.yaml" <<'YML'
+      k3s_tag:
+        default: "v1.29.4-k3s1"
+      cuda_tag:
+        default: "12.4.1-base-ubuntu22.04"
+YML
 }
 
 _facts() { bash "$REPO/scripts/check-facts.sh" "$@"; }


### PR DESCRIPTION
## What & why

The foundational build artifact for GPU-enabled Windows edges (#616), split from the installer PR (#633) so it can land on `develop` and be **published via CI** — GitHub only dispatches a `workflow_dispatch` workflow from the default branch.

**Inert on develop:** nothing references these files until #633 wires the installer to the image, so this is a safe, behavior-free landing.

### Why a custom image
The stock `rancher/k3s` image is Alpine with **no NVIDIA container runtime**, so GPU pods can never schedule on it (the node advertises `0 nvidia.com/gpu`). This image rebuilds the **same pinned k3s** (`K3S_TAG` == installer `K8S_VERSION`) on an NVIDIA CUDA Ubuntu base, installs the NVIDIA Container Toolkit, configures containerd for the `nvidia` runtime, and bakes in the device plugin + `nvidia` RuntimeClass so the node advertises `nvidia.com/gpu` on first boot. Based on the official [k3d CUDA recipe](https://k3d.io/v5.7.4/usage/advanced/cuda/).

### Contents
- `docker/k3s-cuda/Dockerfile` — multi-stage k3s + CUDA base
- `docker/k3s-cuda/nvidia-device-plugin-daemonset.yaml` — device plugin + `nvidia` RuntimeClass (v0.14.5)
- `docker/k3s-cuda/build.sh`, `README.md`
- `.github/workflows/build-k3s-cuda.yaml` — manual dispatch; `push: true` publishes to GHCR **and validates the Dockerfile builds**

### After merge
Run `build-k3s-cuda` with `push: true` to publish `ghcr.io/tracebloc/k3s-cuda:<k3s>-cuda-<base>` (make the package **public** so it pulls with no auth). Then the installer (#633) pulls it automatically at cluster-create — the end-user runs **one command**, no manual build or pull, GPU or CPU auto-detected.

Part of #616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New build assets and CI drift gates only; no installer or runtime behavior changes until a follow-up PR wires the image.
> 
> **Overview**
> Introduces **`docker/k3s-cuda/`** — a multi-stage image that layers the **same pinned k3s** as CPU nodes onto an NVIDIA CUDA Ubuntu base, installs the Container Toolkit, configures containerd’s `nvidia` runtime, and auto-applies a baked **device plugin + `nvidia` RuntimeClass** (v0.14.5) on first boot. **`build.sh`** tags images as `<K3S_TAG>-cuda-<CUDA_TAG>` for deterministic pulls once the installer is wired (#633).
> 
> Adds a **manual `build-k3s-cuda`** workflow (`workflow_dispatch`, optional GHCR push, 60m timeout, unpinned docker/buildx only) so the large CUDA build does not run on every push.
> 
> Extends **`check-facts.sh`** (and **installer-tests** path filters + **bats** fixtures) so **`K3S_TAG`** in the Dockerfile, `build.sh`, and the workflow’s `k3s_tag` default must match **`facts.env` `K8S_VERSION`**, preventing a k8s bump from referencing an unpublished GPU image.
> 
> **Inert until #633:** nothing in this PR switches cluster create to the new image; it only lands the artifact and CI guardrails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b2eafb1a17063eb1716449e066edaf56f8ea58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->