### PR TITLE
fix(chart): image-refresh builds explicit in-cluster kubeconfig (#634)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.22
-appVersion: "1.9.22"
+version: 1.9.23
+appVersion: "1.9.23"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -50,6 +50,27 @@ data:
     log "release=$RELEASE_NAME namespace=$RELEASE_NAMESPACE deployment=$DEPLOYMENT_NAME"
     log "  client images: tracebloc/{jobs-manager,pods-monitor} on docker.io under tag=$IMAGE_TAG"
 
+    # kubectl in the alpine/k8s image does NOT reliably auto-detect in-cluster
+    # config in this Job's pod: with no kubeconfig on disk it falls back to
+    # http://localhost:8080 and every API call fails ("connection refused"),
+    # even though the SA token and KUBERNETES_SERVICE_* env are both present
+    # (#634 — observed failing fleet-wide, where it masqueraded as the generic
+    # "cannot read deployment" below and cost a full live investigation). Build
+    # an explicit in-cluster kubeconfig from the mounted ServiceAccount so every
+    # `kubectl` below targets the real API server regardless of that quirk.
+    # These `kubectl config` calls only write the local kubeconfig file
+    # ($KUBECONFIG, on the writable /tmp emptyDir) — they make no API call.
+    SA_DIR=/var/run/secrets/kubernetes.io/serviceaccount
+    export KUBECONFIG=/tmp/kubeconfig
+    kubectl config set-cluster in-cluster \
+      --server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" \
+      --certificate-authority="${SA_DIR}/ca.crt" >/dev/null
+    kubectl config set-credentials in-cluster \
+      --token="$(cat "${SA_DIR}/token")" >/dev/null
+    kubectl config set-context in-cluster \
+      --cluster=in-cluster --user=in-cluster --namespace="$RELEASE_NAMESPACE" >/dev/null
+    kubectl config use-context in-cluster >/dev/null
+
     # Get an anonymous pull-scope token for one repository on a
     # registry. Both docker.io and ghcr.io support anonymous tokens for
     # public images; only the issuer URL differs. tr cleanup handles
@@ -139,7 +160,12 @@ data:
         log "deployment/${DEPLOYMENT_NAME} not settled (rollout in progress or pod not Ready) -- skipping this refresh tick; will retry when settled"
         exit 0
       fi
-      log "ERROR: cannot read deployment/${DEPLOYMENT_NAME} (NotFound, RBAC denial, or API error) -- not a benign skip; failing the tick so it is visible"
+      # Surface the REAL API error instead of swallowing it: the generic
+      # message alone was indistinguishable between NotFound, a 403, and the
+      # `localhost:8080` connection-refused of #634. Re-run the read capturing
+      # only stderr so the failing tick names the actual cause in one log line.
+      err="$(kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" --request-timeout=15s 2>&1 >/dev/null || true)"
+      log "ERROR: cannot read deployment/${DEPLOYMENT_NAME} (NotFound, RBAC denial, or API error): ${err:-unknown error} -- not a benign skip; failing the tick so it is visible"
       exit 1
     fi
 

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -62,11 +62,20 @@ data:
     # ($KUBECONFIG, on the writable /tmp emptyDir) — they make no API call.
     SA_DIR=/var/run/secrets/kubernetes.io/serviceaccount
     export KUBECONFIG=/tmp/kubeconfig
+    # Bracket an IPv6 API host for the URL authority: client-go's in-cluster
+    # config uses net.JoinHostPort, and a bare IPv6 literal without brackets is
+    # an invalid server URL — dual-stack / IPv6 clusters would otherwise hit the
+    # very refresh outage this change fixes.
+    api_host="$KUBERNETES_SERVICE_HOST"
+    case "$api_host" in *:*) api_host="[$api_host]" ;; esac
     kubectl config set-cluster in-cluster \
-      --server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" \
+      --server="https://${api_host}:${KUBERNETES_SERVICE_PORT}" \
       --certificate-authority="${SA_DIR}/ca.crt" >/dev/null
-    kubectl config set-credentials in-cluster \
-      --token="$(cat "${SA_DIR}/token")" >/dev/null
+    # tokenFile (a PATH), not --token=<value>: the bearer token must never land
+    # on the kubectl process argv (readable via procfs), and a path lets kubectl
+    # re-read the rotating projected ServiceAccount token on every call. No
+    # token value is written to $KUBECONFIG either.
+    kubectl config set "users.in-cluster.tokenFile" "${SA_DIR}/token" >/dev/null
     kubectl config set-context in-cluster \
       --cluster=in-cluster --user=in-cluster --namespace="$RELEASE_NAMESPACE" >/dev/null
     kubectl config use-context in-cluster >/dev/null

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -132,6 +132,21 @@ tests:
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: "registry-1.docker.io"
+      # Regression guard (#634): kubectl in the alpine/k8s image does not
+      # reliably auto-detect in-cluster config in this pod, so the script MUST
+      # build an explicit in-cluster kubeconfig from the mounted ServiceAccount
+      # (API server from KUBERNETES_SERVICE_*, ca + token from the projected SA
+      # volume) before any API call. Without this every tick failed against
+      # http://localhost:8080 fleet-wide. Lock the preamble in place.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "export KUBECONFIG="
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'kubectl config set-cluster in-cluster'
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'server="https://\$\{KUBERNETES_SERVICE_HOST\}:\$\{KUBERNETES_SERVICE_PORT\}"'
       # Regression guard (#546): the tick MUST skip when the deployment isn't settled,
       # so a stuck/unschedulable jobs-manager (e.g. the RWO-PVC deadlock #545) can't be
       # re-restarted every tick into a ReplicaSet storm. The guard runs `rollout status`

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -144,9 +144,22 @@ tests:
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: 'kubectl config set-cluster in-cluster'
+      # The server authority is built from the *bracketed* API host so an IPv6
+      # KUBERNETES_SERVICE_HOST yields a valid URL (client-go net.JoinHostPort).
       - matchRegex:
           path: data["image-refresh.sh"]
-          pattern: 'server="https://\$\{KUBERNETES_SERVICE_HOST\}:\$\{KUBERNETES_SERVICE_PORT\}"'
+          pattern: 'api_host="\[\$api_host\]"'
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'server="https://\$\{api_host\}:\$\{KUBERNETES_SERVICE_PORT\}"'
+      # The bearer token goes in via tokenFile (a path) and MUST NOT be passed
+      # as --token=<value> on the kubectl argv (credential exposure via procfs).
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'users\.in-cluster\.tokenFile'
+      - notMatchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'set-credentials in-cluster --token'
       # Regression guard (#546): the tick MUST skip when the deployment isn't settled,
       # so a stuck/unschedulable jobs-manager (e.g. the RWO-PVC deadlock #545) can't be
       # re-restarted every tick into a ReplicaSet storm. The guard runs `rollout status`


### PR DESCRIPTION
Fixes #634.

## Problem

The `image-refresh` CronJob was failing on **every tick across the whole fleet** (dev/stg/prod). The logged error — `cannot read deployment/<release>-jobs-manager (NotFound, RBAC denial, or API error)` — was misleading: it is **none of those three**. `kubectl` in the `alpine/k8s` Job pod does **not** reliably auto-detect in-cluster config; with no kubeconfig on disk it falls back to `http://localhost:8080` and every API call fails, even though the SA token and `KUBERNETES_SERVICE_*` env are present. The read gate ran both `kubectl` calls with `>/dev/null 2>&1`, so the real cause was hidden until reproduced by hand (see #634 for the full live investigation).

Consequence: image-refresh stopped reconciling new `tracebloc/{jobs-manager,pods-monitor}` digests, so **clients silently stopped picking up new control-plane images**.

## Fix

- **Build an explicit in-cluster kubeconfig** from the mounted ServiceAccount at script start (API server from `KUBERNETES_SERVICE_*`, ca + token from the projected SA volume) and point `KUBECONFIG` at it, so every `kubectl` below targets the real API server regardless of the auto-detect quirk. All existing `kubectl` calls stay literal.
- **Surface the real API error** on the fail path instead of `>/dev/null 2>&1`, so the next incident is one log line naming the actual cause (NotFound vs 403 vs connection-refused vs timeout), not a repro session.
- **Regression guards** lock the kubeconfig preamble in place.
- **Chart bump 1.9.22 → 1.9.23** (script is chart content; `chart-version-guard`).

## Validation

- `helm unittest client` — **346/346 pass**, including the 3 new guards (they assert the preamble renders into the ConfigMap script).
- **Live dev pod** running the exact preamble under the real pod constraints (`readOnlyRootFilesystem`, `HOME=/home/kubectl`, emptyDir `/tmp` + `/home/kubectl`): bare `kubectl rollout status` and `kubectl get deployment -o json | jq` both return rc=0. Before the fix the same calls hit `localhost:8080` and failed.

## Not in scope / follow-up

The environmental trigger (why it broke ~2 days ago despite unchanged chart/image/script) is still **unconfirmed** — prime suspect is the `alpine/k8s:1.30.5` tag being re-pushed with a different kubectl build combined with a node recycle (`IfNotPresent` → new nodes pull fresh). This fix makes the script robust regardless of the trigger; the root-trigger investigation can continue separately under #634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the image-refresh job talks to the Kubernetes API fleet-wide; misconfiguration could block control-plane image rollouts, but behavior is locked by unittest guards and matches standard in-cluster client patterns.
> 
> **Overview**
> Fixes fleet-wide **image-refresh** CronJob failures where `kubectl` in the `alpine/k8s` job pod did not auto-detect in-cluster config and hit `http://localhost:8080`, blocking digest reconciliation for `tracebloc/{jobs-manager,pods-monitor}`.
> 
> The refresh script now **builds an explicit kubeconfig** at startup from the mounted ServiceAccount (`KUBECONFIG` on `/tmp`, API server from `KUBERNETES_SERVICE_*`, CA + **`tokenFile`** for the bearer token), including **IPv6 bracketing** for the API host. On deployment read failure it **logs the real `kubectl` stderr** instead of a generic message.
> 
> **Helm unittest** adds regression guards for that preamble; chart version **1.9.22 → 1.9.23**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ed9f9730e04484d7fac454892e8c074658a901c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->