### PR TITLE
fix(#1144): pin jobs-manager memory requests==limits so a mass restart can't OOM-kill it

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.26
-appVersion: "1.9.26"
+version: 1.9.27
+appVersion: "1.9.27"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -104,9 +104,11 @@ spec:
         # for node memory + CPU; with requests (512Mi) below the limit (1Gi)
         # jobs-manager ran Burstable and was the kernel OOM-killer's preferred
         # victim once its working set exceeded the request — the observed
-        # exit-137 kill of both containers. Pinning requests==limits gives it a
-        # Guaranteed memory reservation so it is no longer the node's largest
-        # victim, exactly as mysql-deployment.yaml already does. requests.cpu is
+        # exit-137 kill of both containers. Pinning requests.memory==limits.memory
+        # lowers the container's oom_score_adj so it is a less-preferred victim
+        # when the node runs out of memory — the pod stays Burstable (cpu request
+        # != limit), exactly as mysql-deployment.yaml already does (mysql has no
+        # cpu limit either). requests.cpu is
         # also raised (100m -> 250m) so a mass restart doesn't throttle its
         # startup to a crawl (the ~9m recovery seen on lukas-test).
         resources:
@@ -307,9 +309,10 @@ spec:
             drop: ["ALL"]
         # #1144: same cluster-recovery treatment as the api container above —
         # pods-monitor was also exit-137 killed in the mass restart. Pin
-        # requests.memory == limits.memory (512Mi) for a Guaranteed memory
-        # reservation, and raise requests.cpu (50m -> 100m) so its startup is
-        # not starved under contention.
+        # requests.memory == limits.memory (512Mi) to lower its oom_score_adj
+        # (a less-preferred node OOM victim; the pod stays Burstable), and raise
+        # requests.cpu (50m -> 100m) so its startup is not starved under
+        # contention.
         resources:
           requests:
             cpu: {{ .Values.resources.podsMonitor.requests.cpu | default "100m" | quote }}

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -98,10 +98,21 @@ spec:
         # pod becomes the OOM-killer's preferred target on the node, and
         # mysqld dies as collateral. 512Mi/1Gi covers steady state with
         # headroom; revisit if heap profiling shows the working set growing.
+        #
+        # #1144: requests.memory now == limits.memory (1Gi). On a single-node
+        # cluster-recovery mass restart every pod restarts at once and contends
+        # for node memory + CPU; with requests (512Mi) below the limit (1Gi)
+        # jobs-manager ran Burstable and was the kernel OOM-killer's preferred
+        # victim once its working set exceeded the request — the observed
+        # exit-137 kill of both containers. Pinning requests==limits gives it a
+        # Guaranteed memory reservation so it is no longer the node's largest
+        # victim, exactly as mysql-deployment.yaml already does. requests.cpu is
+        # also raised (100m -> 250m) so a mass restart doesn't throttle its
+        # startup to a crawl (the ~9m recovery seen on lukas-test).
         resources:
           requests:
-            cpu: {{ .Values.resources.jobsManager.requests.cpu | default "100m" | quote }}
-            memory: {{ .Values.resources.jobsManager.requests.memory | default "512Mi" | quote }}
+            cpu: {{ .Values.resources.jobsManager.requests.cpu | default "250m" | quote }}
+            memory: {{ .Values.resources.jobsManager.requests.memory | default "1Gi" | quote }}
           limits:
             cpu: {{ .Values.resources.jobsManager.limits.cpu | default "1000m" | quote }}
             memory: {{ .Values.resources.jobsManager.limits.memory | default "1Gi" | quote }}
@@ -294,10 +305,15 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+        # #1144: same cluster-recovery treatment as the api container above —
+        # pods-monitor was also exit-137 killed in the mass restart. Pin
+        # requests.memory == limits.memory (512Mi) for a Guaranteed memory
+        # reservation, and raise requests.cpu (50m -> 100m) so its startup is
+        # not starved under contention.
         resources:
           requests:
-            cpu: {{ .Values.resources.podsMonitor.requests.cpu | default "50m" | quote }}
-            memory: {{ .Values.resources.podsMonitor.requests.memory | default "256Mi" | quote }}
+            cpu: {{ .Values.resources.podsMonitor.requests.cpu | default "100m" | quote }}
+            memory: {{ .Values.resources.podsMonitor.requests.memory | default "512Mi" | quote }}
           limits:
             cpu: {{ .Values.resources.podsMonitor.limits.cpu | default "500m" | quote }}
             memory: {{ .Values.resources.podsMonitor.limits.memory | default "512Mi" | quote }}

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -70,16 +70,17 @@ tests:
           path: spec.template.spec.containers[0].resources.requests
       - isNotEmpty:
           path: spec.template.spec.containers[0].resources.limits
-      # v1.1.0 floor: 512Mi/1Gi for api, after the prod OOM investigation.
+      # #1144: requests.memory pinned == limits.memory (1Gi api / 512Mi
+      # pods-monitor) to lower oom_score_adj during a mass restart.
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
-          value: 512Mi
+          value: 1Gi
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: 1Gi
       - equal:
           path: spec.template.spec.containers[1].resources.requests.memory
-          value: 256Mi
+          value: 512Mi
       - equal:
           path: spec.template.spec.containers[1].resources.limits.memory
           value: 512Mi
@@ -297,7 +298,7 @@ tests:
   # own default when they are absent. Pin the rendered value here so the two
   # cannot silently diverge again, on BOTH containers that receive it
   # (api + pods-monitor).
-  - it: defaults spawned-job RESOURCE_REQUESTS/LIMITS to cpu=2,memory=8Gi (req==limit => Guaranteed QoS)
+  - it: defaults spawned-job RESOURCE_REQUESTS/LIMITS to cpu=2,memory=8Gi (req==limit)
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -539,12 +539,13 @@ images:
 # jobs-manager: 256Mi was too tight under load; bumped to 512Mi/1Gi so
 # the Service Bus client + pod watcher have headroom before OOM. In v1.x
 # (#1144) requests.memory was raised to EQUAL limits.memory (1Gi api /
-# 512Mi pods-monitor) so both containers hold a Guaranteed memory
-# reservation — on a single-node cluster-recovery mass restart they were
-# otherwise the kernel OOM-killer's preferred (Burstable) victims and were
-# exit-137 killed, taking ~9m to recover. requests.cpu was also raised so a
-# mass restart does not throttle their startup. Same requests==limits
-# philosophy mysql already uses.
+# 512Mi pods-monitor) to lower each container's oom_score_adj — on a
+# single-node cluster-recovery mass restart they were otherwise the kernel
+# OOM-killer's preferred victims and were exit-137 killed, taking ~9m to
+# recover. The pods stay Burstable (cpu request != limit); pinning memory
+# just makes them less-preferred OOM victims. requests.cpu was also raised so
+# a mass restart does not throttle their startup. Same requests.memory==limits
+# philosophy mysql already uses (mysql likewise omits its cpu limit).
 resources:
   mysql:
     requests:

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -537,7 +537,14 @@ images:
 # eviction.
 #
 # jobs-manager: 256Mi was too tight under load; bumped to 512Mi/1Gi so
-# the Service Bus client + pod watcher have headroom before OOM.
+# the Service Bus client + pod watcher have headroom before OOM. In v1.x
+# (#1144) requests.memory was raised to EQUAL limits.memory (1Gi api /
+# 512Mi pods-monitor) so both containers hold a Guaranteed memory
+# reservation — on a single-node cluster-recovery mass restart they were
+# otherwise the kernel OOM-killer's preferred (Burstable) victims and were
+# exit-137 killed, taking ~9m to recover. requests.cpu was also raised so a
+# mass restart does not throttle their startup. Same requests==limits
+# philosophy mysql already uses.
 resources:
   mysql:
     requests:
@@ -548,15 +555,15 @@ resources:
       # No cpu limit — see comment above.
   jobsManager:
     requests:
-      cpu: "100m"
-      memory: "512Mi"
+      cpu: "250m"
+      memory: "1Gi"
     limits:
       cpu: "1000m"
       memory: "1Gi"
   podsMonitor:
     requests:
-      cpu: "50m"
-      memory: "256Mi"
+      cpu: "100m"
+      memory: "512Mi"
     limits:
       cpu: "500m"
       memory: "512Mi"


### PR DESCRIPTION
Closes tracebloc/backend#1144.

## Problem
On a cluster-recovery mass restart, jobs-manager gets OOM-killed (exit 137). Despite the ticket's "CPUKilled" label, exit 137 is a **memory** SIGKILL — CPU limits only throttle, they never kill. The pod was Burstable (memory requests < limits), so once its working set exceeded the request it was a prime node-OOM victim.

## Fix
Pin `requests.memory == limits.memory` for both jobs-manager containers (api 1Gi, pods-monitor 512Mi). This does **not** make the pod Guaranteed QoS — it stays **Burstable** because `requests.cpu != limits.cpu`. What it does is lower each container's `oom_score_adj`, so when the node runs out of memory the kernel OOM-killer treats jobs-manager as a **less-preferred victim**. Same mechanism the chart's mysql already relies on (mysql likewise pins memory and omits its cpu limit). Also raised CPU **requests** (api 100m→250m, pods-monitor 50m→100m) to avoid startup throttling. Memory *limits* are unchanged (1Gi / 512Mi) — this only raises the floor, not the ceiling.

## Files
- `client/templates/jobs-manager-deployment.yaml`, `client/values.yaml`
- `client/tests/jobs_manager_test.yaml` — resource assertions updated to the pinned values
- `client/Chart.yaml` — version + appVersion → 1.9.27

## Validation
`helm lint` clean; `helm unittest` passes (jobs_manager suite + full suite, 354 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default resource reservations for a core control-plane deployment, increasing per-node memory scheduling footprint (~768Mi more requested across both containers) but only adjusts Kubernetes QoS/OOM preference, not application logic.
> 
> **Overview**
> Addresses **cluster-recovery mass restarts** where the jobs-manager **api** and **pods-monitor** containers were **OOM-killed (exit 137)** because memory **requests** sat below **limits**, making them favored node-OOM victims.
> 
> The chart now **raises memory requests to match existing limits** (api **1Gi**, pods-monitor **512Mi**) and **increases CPU requests** (api **100m→250m**, pods-monitor **50m→100m**) so startup is less throttled under contention. **Memory limits are unchanged**; pods remain **Burstable** (CPU request ≠ limit), matching the mysql pinning pattern. Defaults and template comments live in `values.yaml` and `jobs-manager-deployment.yaml`; **helm unittest** expectations were updated. Chart version bumps to **1.9.27**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d26d2a9eebc10b32cbaeb3cd7253b080a2ddb7ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->