### PR TITLE
sec(#1528): provision tb_meta + tb_ingest service-account Secrets (S1)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -3,7 +3,7 @@ name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
 version: 1.9.28
-appVersion: "1.9.27"
+appVersion: "1.9.28"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.27
+version: 1.9.28
 appVersion: "1.9.27"
 keywords:
   - tracebloc

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -203,6 +203,30 @@ spec:
               name: {{ include "tracebloc.secretName" . }}
               key: TB_CREDMGR_PASSWORD
         {{- end }}
+        {{- if .Values.serviceDbAccounts }}
+        # backend#1528 S1 (RFC-0003 D10 close-out): dedicated MySQL service
+        # identities that replace the root-equivalent edgeuser. jobs-manager
+        # mints tb_meta (owns the metadata DB) and tb_ingest (writes the dataset
+        # DB) at startup from these generated Secrets. Additive — nothing
+        # consumes the accounts until S2 — so this is rendered only when enabled
+        # and a default install stays byte-identical.
+        - name: SERVICE_DB_ACCOUNTS
+          value: "1"
+        - name: TB_META_USER
+          value: "tb_meta"
+        - name: TB_META_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "tracebloc.secretName" . }}
+              key: TB_META_PASSWORD
+        - name: TB_INGEST_USER
+          value: "tb_ingest"
+        - name: TB_INGEST_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "tracebloc.secretName" . }}
+              key: TB_INGEST_PASSWORD
+        {{- end }}
         # Ingestor image wiring for the POST /internal/submit-ingestion-run
         # endpoint. jobs-manager spawns each ingestion Job from these values
         # (see client-runtime submit_ingestion_run._build_image_reference):

--- a/client/templates/secrets.yaml
+++ b/client/templates/secrets.yaml
@@ -52,6 +52,44 @@
 {{-     $credmgrPassword = randAlphaNum 48 -}}
 {{-   end -}}
 {{- end -}}
+{{- /*
+  Dedicated service-account passwords (backend#1528 S1). tb_meta owns the
+  metadata DB, tb_ingest writes the dataset DB; together they replace the
+  root-equivalent edgeuser. Same generate-once stability + 3-tier resolution as
+  the credmgr password above, one per account:
+    1. explicit .Values.tbMetaPassword / .Values.tbIngestPassword (operator pin
+       — DR, a pre-created MySQL account, or a forced rotation), else
+    2. the value already stored in the live Secret (preserve across upgrades), else
+    3. a freshly generated random secret (first install).
+  jobs-manager re-syncs each account to its value on every startup, so both must
+  be stable across upgrades (regenerating would churn the account). Emitted only
+  when serviceDbAccounts is on; the same off->on->off->on toggle caveat as
+  credmgr applies — pin the values to keep them stable across toggles.
+*/ -}}
+{{- $tbMetaPassword := "" -}}
+{{- $tbIngestPassword := "" -}}
+{{- if .Values.serviceDbAccounts -}}
+{{-   if .Values.tbMetaPassword -}}
+{{-     if not (regexMatch "^[A-Za-z0-9]+$" .Values.tbMetaPassword) -}}
+{{-       fail "tbMetaPassword must be alphanumeric ([A-Za-z0-9]+) — jobs-manager rejects other characters in the tb_meta password" -}}
+{{-     end -}}
+{{-     $tbMetaPassword = .Values.tbMetaPassword -}}
+{{-   else if and $existingSecret $existingSecret.data (hasKey $existingSecret.data "TB_META_PASSWORD") -}}
+{{-     $tbMetaPassword = (index $existingSecret.data "TB_META_PASSWORD" | b64dec) -}}
+{{-   else -}}
+{{-     $tbMetaPassword = randAlphaNum 48 -}}
+{{-   end -}}
+{{-   if .Values.tbIngestPassword -}}
+{{-     if not (regexMatch "^[A-Za-z0-9]+$" .Values.tbIngestPassword) -}}
+{{-       fail "tbIngestPassword must be alphanumeric ([A-Za-z0-9]+) — jobs-manager rejects other characters in the tb_ingest password" -}}
+{{-     end -}}
+{{-     $tbIngestPassword = .Values.tbIngestPassword -}}
+{{-   else if and $existingSecret $existingSecret.data (hasKey $existingSecret.data "TB_INGEST_PASSWORD") -}}
+{{-     $tbIngestPassword = (index $existingSecret.data "TB_INGEST_PASSWORD" | b64dec) -}}
+{{-   else -}}
+{{-     $tbIngestPassword = randAlphaNum 48 -}}
+{{-   end -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -66,6 +104,10 @@ data:
   POD_TOKEN_SIGNING_SECRET: {{ $podTokenSecret | b64enc | quote }}
 {{- if .Values.perExperimentDbCreds }}
   TB_CREDMGR_PASSWORD: {{ $credmgrPassword | b64enc | quote }}
+{{- end }}
+{{- if .Values.serviceDbAccounts }}
+  TB_META_PASSWORD: {{ $tbMetaPassword | b64enc | quote }}
+  TB_INGEST_PASSWORD: {{ $tbIngestPassword | b64enc | quote }}
 {{- end }}
 {{- if and (ne .Values.resourceMonitor false) (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
 ---

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -476,3 +476,54 @@ tests:
           path: spec.template.spec.securityContext.fsGroup
       - notExists:
           path: spec.template.spec.initContainers
+
+  # backend#1528 S1: the tb_meta / tb_ingest env is flag-gated on
+  # serviceDbAccounts so a default install is byte-identical.
+  - it: service DB account env absent by default (byte-for-byte off)
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SERVICE_DB_ACCOUNTS
+            value: "1"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_META_USER
+            value: "tb_meta"
+
+  - it: service DB account env wired when serviceDbAccounts is on
+    set:
+      serviceDbAccounts: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SERVICE_DB_ACCOUNTS
+            value: "1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_META_USER
+            value: "tb_meta"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_INGEST_USER
+            value: "tb_ingest"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_META_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-secrets
+                key: TB_META_PASSWORD
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_INGEST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-secrets
+                key: TB_INGEST_PASSWORD

--- a/client/tests/secrets_test.yaml
+++ b/client/tests/secrets_test.yaml
@@ -140,3 +140,70 @@ tests:
       credmgrPassword: "bad-pass!"
     asserts:
       - failedTemplate: {}
+
+  # backend#1528 S1: tb_meta / tb_ingest passwords are flag-gated on
+  # serviceDbAccounts, mirroring TB_CREDMGR_PASSWORD.
+  - it: TB_META/INGEST_PASSWORD absent by default (byte-for-byte off)
+    template: templates/secrets.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
+    asserts:
+      - notExists:
+          path: data.TB_META_PASSWORD
+        documentIndex: 0
+      - notExists:
+          path: data.TB_INGEST_PASSWORD
+        documentIndex: 0
+
+  - it: TB_META/INGEST_PASSWORD rendered when serviceDbAccounts is on
+    template: templates/secrets.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
+      serviceDbAccounts: true
+    asserts:
+      - isNotEmpty:
+          path: data.TB_META_PASSWORD
+        documentIndex: 0
+      - isNotEmpty:
+          path: data.TB_INGEST_PASSWORD
+        documentIndex: 0
+
+  - it: tbMetaPassword / tbIngestPassword operator pins flow into the Secret
+    template: templates/secrets.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
+      serviceDbAccounts: true
+      tbMetaPassword: "MetaPin123"
+      tbIngestPassword: "IngestPin123"
+    asserts:
+      - equal:
+          path: data.TB_META_PASSWORD
+          value: "TWV0YVBpbjEyMw=="
+        documentIndex: 0
+      - equal:
+          path: data.TB_INGEST_PASSWORD
+          value: "SW5nZXN0UGluMTIz"
+        documentIndex: 0
+
+  - it: rejects a non-alphanumeric tbMetaPassword pin
+    template: templates/secrets.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
+      serviceDbAccounts: true
+      tbMetaPassword: "bad-pass!"
+    asserts:
+      - failedTemplate: {}
+
+  - it: rejects a non-alphanumeric tbIngestPassword pin
+    template: templates/secrets.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
+      serviceDbAccounts: true
+      tbIngestPassword: "bad-pass!"
+    asserts:
+      - failedTemplate: {}

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "description": "RFC-0003 D10 (backend#1181): optional operator pin for the tb_credmgr account password (3-tier resolution, mirrors podTokenSigningSecret). Empty = generate-and-persist. Set for DR / a pre-created MySQL account / forced rotation, or to keep it stable across a perExperimentDbCreds toggle. Must be alphanumeric."
     },
+    "serviceDbAccounts": {
+      "type": "boolean",
+      "description": "backend#1528 S1 (RFC-0003 D10 close-out): provision the dedicated MySQL service identities tb_meta (metadata DB) and tb_ingest (dataset DB) that replace the root-equivalent edgeuser. Additive — jobs-manager mints them at startup but nothing consumes them until S2, so a default install is byte-identical. Flip per environment, dev first."
+    },
+    "tbMetaPassword": {
+      "type": "string",
+      "description": "backend#1528 S1: optional operator pin for the tb_meta account password (3-tier resolution, mirrors credmgrPassword). Empty = generate-and-persist. Set for DR / a pre-created MySQL account / forced rotation. Must be alphanumeric."
+    },
+    "tbIngestPassword": {
+      "type": "string",
+      "description": "backend#1528 S1: optional operator pin for the tb_ingest account password (3-tier resolution, mirrors credmgrPassword). Empty = generate-and-persist. Set for DR / a pre-created MySQL account / forced rotation. Must be alphanumeric."
+    },
     "perIngestionTables": {
       "type": "boolean",
       "description": "RFC-0003 D16 (backend#1204/#1205): stamp PER_INGESTION_TABLES=1 into every ingestion Job. Flip per environment, dev first; file-bearing categories are refused under the flag until client-runtime#203 phase 2."

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -890,6 +890,26 @@ perExperimentDbCreds: false
 # jobs-manager rejects other characters.
 credmgrPassword: ""
 
+# backend#1528 S1 (RFC-0003 D10 close-out): provision the dedicated MySQL
+# service identities tb_meta (owns the metadata DB) and tb_ingest (writes the
+# dataset DB) that replace the root-equivalent edgeuser for jobs-manager,
+# requests-proxy and the ingestor. jobs-manager mints both at startup from the
+# generated Secret below (SERVICE_DB_ACCOUNTS). Additive: nothing consumes them
+# until the S2 consumer switch, so a default install is byte-identical.
+#
+# Flip per environment, dev first. Default false: today's shared-edgeuser
+# behavior, byte-for-byte. Needs no per-edge action — the passwords are
+# generated, upgrade-stable Secret values.
+serviceDbAccounts: false
+
+# Optional operator pins for the tb_meta / tb_ingest account passwords (each
+# mirrors credmgrPassword's 3-tier resolution). Leave "" to generate-and-persist
+# on first install. Set for DR, to match a pre-created MySQL account, or to
+# force a rotation. Must be alphanumeric ([A-Za-z0-9]+); jobs-manager rejects
+# other characters.
+tbMetaPassword: ""
+tbIngestPassword: ""
+
 # ============================================================
 # Ingestion endpoint authorization (client-runtime#21)
 # ============================================================


### PR DESCRIPTION
## What & why

Chart side of **backend#1528** S1 (RFC-0003 D10 close-out), paired with **tracebloc/client-runtime#290**. jobs-manager mints two dedicated, single-database MySQL identities (`tb_meta`, `tb_ingest`) to replace the root-equivalent `edgeuser`; this PR wires the Secrets + env they read.

- **values**: `serviceDbAccounts` (default false) + optional `tbMetaPassword` / `tbIngestPassword` operator pins, mirroring `perExperimentDbCreds` / `credmgrPassword`. Added to `values.schema.json`.
- **secrets.yaml**: `TB_META_PASSWORD` / `TB_INGEST_PASSWORD` via the same generate-once, upgrade-stable **3-tier resolution** as `TB_CREDMGR_PASSWORD` (operator pin → existing Secret value → `randAlphaNum`), with alphanumeric-pin validation. Emitted only when `serviceDbAccounts` is on.
- **jobs-manager-deployment**: `SERVICE_DB_ACCOUNTS=1` + `TB_META_USER`/`TB_INGEST_USER` + the two `secretKeyRef` passwords, rendered only when the flag is on.

## Safety
Gated so a **default install is byte-identical** — verified with `helm template`: flag off renders **none** of the new keys; flag on renders the Secret keys (pins decode correctly) and the deployment env. The mirrored node-agents Secret intentionally does **not** carry the service creds.

## Tests
`helm unittest ./client` — `secrets_test.yaml` + `jobs_manager_test.yaml` extended (49 assertions across the two suites, green). (5 pre-existing failures in other suites are a local helm-unittest 1.1.2 / helm v4 vs CI-pinned 0.5.2 artifact, present on clean `develop` too — not touched here.)

## Merge coordination
Safe in any order with #290: the env only exists when `serviceDbAccounts=true`, and the runtime mint is inert until the env is present. Neither is enabled by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are flag-gated and additive; default installs render no new secrets or env. Password handling mirrors the existing credmgr pattern with no runtime consumer switch in this PR alone.
> 
> **Overview**
> **backend#1528 S1 (RFC-0003 D10 close-out)** wires chart support for dedicated MySQL service identities `tb_meta` and `tb_ingest`, paired with client-runtime minting. Everything is behind **`serviceDbAccounts`** (default **`false`**) so a normal install stays byte-identical.
> 
> When the flag is on, **`secrets.yaml`** adds **`TB_META_PASSWORD`** and **`TB_INGEST_PASSWORD`** using the same **3-tier resolution** as `TB_CREDMGR_PASSWORD` (operator pin → existing Secret → `randAlphaNum`), with alphanumeric validation on **`tbMetaPassword`** / **`tbIngestPassword`**. **`jobs-manager-deployment`** gets **`SERVICE_DB_ACCOUNTS=1`**, fixed usernames, and **`secretKeyRef`** for both passwords.
> 
> **`values.yaml`**, **`values.schema.json`**, and chart version **1.9.28** document the knobs. **helm unittest** covers default-off rendering and flag-on Secret/env wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bdf91f0746b5f1f09224da0ba6cf4ba5d8750c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->