### PR TITLE
ci: arm the action-pin gate — findings fail, not just report (backend#1492)

### DIFF
--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -7,12 +7,6 @@ on:
   # job in all-files mode instead of a PR diff.
   workflow_dispatch:
     inputs:
-      # Armed 2026-08-06 (backend#1492). Measured zero pin violations on every
-      # develop branch first, so this makes a green check stay green rather than
-      # importing a backlog. Soft-fail let #1449 add a second unpinned call site
-      # of an action while #1446 was open to pin it.
-      action-pins: true
-      action-pins-soft-fail: false
       all-files:
         description: "Scan the whole repo, not a diff"
         type: boolean
@@ -31,6 +25,12 @@ jobs:
   quality:
     uses: tracebloc/.github/.github/workflows/code-quality.yml@main
     with:
+      # Armed 2026-08-06 (backend#1492). Measured zero pin violations on every
+      # develop branch first, so this makes a green check stay green rather than
+      # importing a backlog. Soft-fail let #1449 add a second unpinned call site
+      # of an action while #1446 was open to pin it.
+      action-pins: true
+      action-pins-soft-fail: false
       shell: true           # repos with shell scripts
       # The gate is armed: findings fail the job. Backlog cleared to zero
       # fleet-wide + advisory soak done (backend#1303).

--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -7,6 +7,12 @@ on:
   # job in all-files mode instead of a PR diff.
   workflow_dispatch:
     inputs:
+      # Armed 2026-08-06 (backend#1492). Measured zero pin violations on every
+      # develop branch first, so this makes a green check stay green rather than
+      # importing a backlog. Soft-fail let #1449 add a second unpinned call site
+      # of an action while #1446 was open to pin it.
+      action-pins: true
+      action-pins-soft-fail: false
       all-files:
         description: "Scan the whole repo, not a diff"
         type: boolean


### PR DESCRIPTION
Arms `action-pins` so a mutable action ref **fails** the PR instead of merely reporting. This is backend#1492.

## Why now

The pinning work is complete — **415 mutable refs fleet-wide on 2026-08-04, zero on every develop branch today** (#1490 and #1491 closed today with that scan). This is the part that makes it *stay* done.

`action-pins` has been running here in **soft-fail** since it reached `main`: it reports a violation and lets the PR merge anyway. That is exactly the state hand-pinning already proved insufficient — while #1446 was open to pin one action, **#1449 added a second unpinned call site of the same action** in a non-overlapping hunk of the same file. Both merged cleanly, git reported no conflict because there was none, and a human reading the diff caught it. No gate did.

## Arming imports no backlog

Measured immediately before opening this, across all 15 develop branches carrying this caller:

```
TOTAL develop-branch pin violations: 0
```

So this flips a check that is already green into one that stays green. Expect `quality / action-pins` green on this PR.

## What it enforces (D10)

Third-party and `actions/*` refs pinned to a full 40-character commit SHA with a trailing exact-version comment; `tracebloc/*` refs pinned to `@main` (Q3). A floating tag can be repointed by its owner at any commit — that is the supply-chain risk this removes.

`.github` armed this first, because it publishes these workflows to every other repo and its refs are inherited fleet-wide (.github#178, backend#1603).

Parent backend#1405.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow inputs only; no application runtime, auth, or data-path changes.
> 
> **Overview**
> **Arms the shared code-quality workflow** so unpinned GitHub Action refs **fail** PR checks instead of only reporting while still allowing merge.
> 
> The caller now passes `action-pins: true` and `action-pins-soft-fail: false` into `tracebloc/.github/.github/workflows/code-quality.yml@main`, with inline notes that fleet-wide develop branches were at zero violations before flipping the gate. A trailing newline is added on the `gitleaks-baseline` input line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a48de87785d7288857b6a99c0164fb8f1bbcb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->