### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/workflows/version-bump-gate-caller.yml
+++ b/.github/workflows/version-bump-gate-caller.yml
@@ -1,0 +1,23 @@
+name: Version bump gate
+
+# Caller for tracebloc/.github version-bump-gate.yml. Fails a develop PR that
+# touches this repo's published files while the version those files would ship
+# under is ALREADY released -- caught on the author's diff, not days later at the
+# prod hop (backend#1563; the cli + py-package surprise on 2026-08-10).
+# Override a false positive with the 'skip-version-gate' label (visible in audit).
+on:
+  pull_request:
+    branches: [develop]
+    # labeled/unlabeled so the skip-version-gate override actually re-runs the gate (Bugbot)
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  version-bump-gate:
+    uses: tracebloc/.github/.github/workflows/version-bump-gate.yml@main
+    with:
+      version-file: "client/Chart.yaml"
+      publish-paths: "client/*"
+      soft-fail: false


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with read-only repo permissions; it may block develop PRs until versions are bumped or the skip label is applied.
> 
> **Overview**
> Adds a **develop** pull request check that blocks changes under `client/*` when `client/Chart.yaml` still names a version that is already released, so mismatches surface on the author’s PR instead of at a later release hop.
> 
> The new workflow delegates to `tracebloc/.github`’s reusable `version-bump-gate.yml`, runs on open/sync/reopen/ready and on **label** changes (so a `skip-version-gate` override re-runs the job), and uses **hard fail** (`soft-fail: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3fcb21351c784b6094672a29855aeb0dad494a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->