### PR TITLE
fix(chart): derive pvcAccessMode from hostPath mode so the single-node PVC binds (#559)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.28
+version: 1.9.29
 appVersion: "1.9.28"
 keywords:
   - tracebloc

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -3,7 +3,7 @@ name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
 version: 1.9.29
-appVersion: "1.9.28"
+appVersion: "1.9.29"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/logs-pvc.yaml
+++ b/client/templates/logs-pvc.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   storageClassName: {{ include "tracebloc.storageClassName" . }}
   accessModes:
-    - {{ .Values.pvcAccessMode | default "ReadWriteMany" }}
+    - {{ .Values.pvcAccessMode | default (ternary "ReadWriteOnce" "ReadWriteMany" .Values.hostPath.enabled) }}
   resources:
     requests:
       storage: {{ $storage }}

--- a/client/templates/mysql-storage-pvc.yaml
+++ b/client/templates/mysql-storage-pvc.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   storageClassName: {{ include "tracebloc.storageClassName" . }}
   accessModes:
-    - {{ .Values.pvcAccessMode | default "ReadWriteMany" }}
+    - {{ .Values.pvcAccessMode | default (ternary "ReadWriteOnce" "ReadWriteMany" .Values.hostPath.enabled) }}
   resources:
     requests:
       storage: {{ $storage }}

--- a/client/templates/shared-images-pvc.yaml
+++ b/client/templates/shared-images-pvc.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   storageClassName: {{ include "tracebloc.storageClassName" . }}
   accessModes:
-    - {{ .Values.pvcAccessMode | default "ReadWriteMany" }}
+    - {{ .Values.pvcAccessMode | default (ternary "ReadWriteOnce" "ReadWriteMany" .Values.hostPath.enabled) }}
   resources:
     requests:
       storage: {{ $storage }}

--- a/client/tests/logs_pvc_test.yaml
+++ b/client/tests/logs_pvc_test.yaml
@@ -48,6 +48,17 @@ tests:
           path: spec.accessModes[0]
           value: ReadWriteMany
 
+  - it: should default the PVC access mode to ReadWriteOnce on hostPath (matches the PV)
+    set:
+      hostPath:
+        enabled: true
+      platform: bm
+    asserts:
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+        documentIndex: 1
+
   - it: should honour pvcAccessMode override on the PVC
     set:
       hostPath:

--- a/client/tests/mysql_storage_pvc_test.yaml
+++ b/client/tests/mysql_storage_pvc_test.yaml
@@ -48,6 +48,17 @@ tests:
           path: spec.accessModes[0]
           value: ReadWriteMany
 
+  - it: should default the PVC access mode to ReadWriteOnce on hostPath (matches the PV)
+    set:
+      hostPath:
+        enabled: true
+      platform: bm
+    asserts:
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+        documentIndex: 1
+
   - it: PVC requests the default 2Gi of storage
     set:
       hostPath:


### PR DESCRIPTION
Closes #559 (backlog cleanup epic backend#1588).

## Bug
The 3 storage PVCs defaulted \`pvcAccessMode\` to **ReadWriteMany**, but in **hostPath (single-node / bare-metal)** mode the paired PersistentVolume is hardcoded **ReadWriteOnce** — so the PVC could not bind to its own PV. values.yaml already documented the intent (RWM for dynamic, RWO for hostPath); the flat default just didn't honor it, and single-node installs don't set the override.

## Fix
Mode-derived default: \`ternary "ReadWriteOnce" "ReadWriteMany" .Values.hostPath.enabled\`. hostPath → RWO (matches the PV), dynamic/CSI → RWM (unchanged), explicit \`pvcAccessMode\` still wins.

## Verification
- \`helm template\`: RWO on hostPath, RWM on dynamic, override honored, PV unchanged.
- \`helm unittest\`: **363 tests pass**, including two new hostPath-default-RWO regression tests added here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted Helm template defaulting for storage binding on bare-metal; dynamic-cluster behavior and explicit overrides are unchanged.
> 
> **Overview**
> Fixes **hostPath / bare-metal installs** where logs, MySQL, and shared-images PVCs defaulted to **ReadWriteMany** while their paired PersistentVolumes stay **ReadWriteOnce**, so claims could not bind.
> 
> The chart now defaults `pvcAccessMode` with `ternary "ReadWriteOnce" "ReadWriteMany" .Values.hostPath.enabled` on those three PVC templates—**RWO** when `hostPath.enabled` is true (aligned with the PV), **RWM** for dynamic/CSI installs unchanged. An explicit `pvcAccessMode` in values still overrides.
> 
> Chart version is bumped to **1.9.29**, with new helm-unittest cases asserting RWO defaults on hostPath for logs and MySQL PVCs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d0b1bb85c5821d2fe55a806a188ed1f22c97669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->