### PR TITLE
feat(#1528): wire tb_meta env into the requests-proxy deployment (S2)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.29
-appVersion: "1.9.29"
+version: 1.9.30
+appVersion: "1.9.30"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -128,6 +128,24 @@ spec:
                 secretKeyRef:
                   name: {{ include "tracebloc.secretName" . }}
                   key: POD_TOKEN_SIGNING_SECRET
+            {{- if .Values.serviceDbAccounts }}
+            # backend#1528 S2 (RFC-0003 D10 close-out): authenticate the proxy's
+            # metadata-DB access as the dedicated tb_meta identity instead of
+            # the root-equivalent edgeuser. Only the metadata identity is wired
+            # here — the proxy never touches the dataset DB. jobs-manager mints
+            # tb_meta at its startup; the proxy's bootstrap retries until it
+            # lands. Rendered only when enabled, so a default install stays
+            # byte-identical (mirrors the jobs-manager block).
+            - name: SERVICE_DB_ACCOUNTS
+              value: "1"
+            - name: TB_META_USER
+              value: "tb_meta"
+            - name: TB_META_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tracebloc.secretName" . }}
+                  key: TB_META_PASSWORD
+            {{- end }}
       {{- if include "tracebloc.useImagePullSecrets" . }}
       imagePullSecrets:
         - name: {{ include "tracebloc.registrySecretName" . }}

--- a/client/tests/requests_proxy_test.yaml
+++ b/client/tests/requests_proxy_test.yaml
@@ -142,3 +142,49 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: 1Gi
+
+  # backend#1528 S2: the proxy authenticates its metadata-DB access as the
+  # dedicated tb_meta identity (metadata only — the proxy never touches the
+  # dataset DB, so no tb_ingest here). Flag-gated on serviceDbAccounts so a
+  # default install is byte-identical (mirrors the jobs-manager S1 block).
+  - it: service DB account env absent by default (byte-for-byte off)
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SERVICE_DB_ACCOUNTS
+            value: "1"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_META_USER
+            value: "tb_meta"
+
+  - it: wires the tb_meta metadata identity when serviceDbAccounts is on
+    set:
+      serviceDbAccounts: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SERVICE_DB_ACCOUNTS
+            value: "1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_META_USER
+            value: "tb_meta"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_META_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-secrets
+                key: TB_META_PASSWORD
+      # the proxy never touches the dataset DB — tb_ingest must NOT be wired here
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_INGEST_USER
+            value: "tb_ingest"


### PR DESCRIPTION
## What

Wires the `tb_meta` service-account env into the **requests-proxy** Deployment, gated on `.Values.serviceDbAccounts` and default-off. S1 (already merged) wired only jobs-manager; this is the chart half of backend#1528 S2 for the proxy.

When the flag is on the proxy container gets:
- `SERVICE_DB_ACCOUNTS=1`
- `TB_META_USER=tb_meta`
- `TB_META_PASSWORD` via `secretKeyRef` -> `TB_META_PASSWORD` (the key added by client#643 in `templates/secrets.yaml`)

## Why

So the requests-proxy authenticates its metadata-DB access as the dedicated `tb_meta` identity instead of the root-equivalent `edgeuser` (RFC-0003 D10 close-out). **Metadata identity only** — the proxy never touches the dataset DB, so `tb_ingest` is deliberately not wired here. jobs-manager mints `tb_meta` at startup; the proxy's bootstrap retries until it lands.

Default-off means a standard install renders byte-identical (mirrors the jobs-manager S1 block).

## Verification

- `helm unittest ./client` — 366 passed (new assertions in `requests_proxy_test.yaml`: the three keys render when the flag is on, none render when off, `tb_ingest` never rendered).
- `helm lint --strict`.
- `helm template` with and without `--set serviceDbAccounts=true` — block renders only when enabled, valid YAML.
- Chart `version`/`appVersion` bumped 1.9.29 -> 1.9.30 for the chart-version-guard.

## Pairing / deps

- Pairs with **client-runtime#308**, which switches the proxy data plane onto `tb_meta`.
- Depends on **client#643**'s `TB_META_PASSWORD` Secret key.

Refs backend#1528 S2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag-gated Helm env wiring and tests only; default installs are unchanged and no auth logic runs in this repo.
> 
> **Overview**
> **Extends backend#1528 S2 (RFC-0003 D10)** so the **requests-proxy** can use the dedicated **`tb_meta`** MySQL identity for metadata DB access instead of the root-equivalent `edgeuser`, matching the jobs-manager S1 pattern.
> 
> When `.Values.serviceDbAccounts` is enabled, the proxy container gets `SERVICE_DB_ACCOUNTS=1`, `TB_META_USER=tb_meta`, and `TB_META_PASSWORD` from the chart secret. The block is **default-off** so unchanged installs stay byte-identical. **`tb_ingest` is intentionally omitted** because the proxy only touches the metadata DB.
> 
> Chart **`version` / `appVersion`** bump **1.9.29 → 1.9.30**. **`requests_proxy_test.yaml`** adds regression tests for env absent by default, correct wiring when the flag is on, and no dataset identity on the proxy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fe4a9c8cdc10c4b47deee8c6dea52a5079411fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->