### PR TITLE
fix(ci): a required check cannot be path-filtered — drop paths on the PR trigger (backend#1681)

### DIFF
--- a/.github/workflows/drift-checks.yaml
+++ b/.github/workflows/drift-checks.yaml
@@ -5,6 +5,18 @@ name: Drift checks
 # readiness-wait and --diagnose bundle grep for). Mocked unit tests can't see
 # these — a rename ships green and breaks in the field. This guards both sides.
 # Triggers on scripts/ OR client/ because either side moving is the drift.
+#
+# NO `paths:` ON pull_request, deliberately. `Source-of-truth drift` is a
+# REQUIRED status check on develop and on main, and a required check that is
+# path-filtered can never report on a PR outside those paths -- GitHub leaves it
+# at "Expected - waiting for status to be reported" and the PR is unmergeable
+# forever. Not hypothetical: on 2026-08-11 it was blocking client#651, #657 and
+# #660, none of which touch scripts/ or client/. standard-checks.yml's own
+# header spells out the same hazard. The job is ~10s, so running it on every PR
+# costs nothing next to a permanently stuck PR.
+#
+# `push` keeps its paths filter: pushes are not gated by required checks, so
+# path-scoping there is free and correct.
 on:
   push:
     branches: [main, develop, openshift]
@@ -14,10 +26,6 @@ on:
       - '.github/workflows/drift-checks.yaml'
   pull_request:
     branches: [main, develop, openshift]
-    paths:
-      - 'scripts/**'
-      - 'client/**'
-      - '.github/workflows/drift-checks.yaml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## The bug

`Source-of-truth drift` is a **required status check** on `develop` and `main`, but `drift-checks.yaml` only fires on PRs touching `scripts/**`, `client/**` or itself.

A PR outside those paths therefore **never produces the check**. GitHub leaves it at *"Expected — waiting for status to be reported"*, and the PR is unmergeable — with no failing check to point at, which is why it reads as "approved but stuck".

## It is blocking three PRs right now

Measured 2026-08-11, all on `develop`, none touching the filtered paths:

| PR | | |
|---|---|---|
| [#651](https://github.com/tracebloc/client/pull/651) | org-standards sync (backend#1602) | BLOCKED |
| [#657](https://github.com/tracebloc/client/pull/657) | Makefile pre-push hook | BLOCKED, **approved** |
| [#660](https://github.com/tracebloc/client/pull/660) | docs | BLOCKED |

## The fix

`pull_request` loses its `paths:` filter, so the required check always reports. The job is **~10s** (measured across its last three runs) — nothing next to a permanently stuck PR.

`push` **keeps** its filter: pushes aren't gated by required checks, so path-scoping there is free and correct.

## Note

This repo already documents the exact hazard, in `standard-checks.yml`'s own header:

> a required status check must report on EVERY PR to the protected branch, or the PR sits forever at "Expected — waiting for status to be reported", blocking the merge

This applies that rule to the workflow that broke it.

## Test plan

- `yaml.safe_load` confirms `pull_request` now carries only `branches`, and `push` still carries `paths`.
- `actionlint` clean.
- The real proof is this PR itself: it touches only `.github/workflows/drift-checks.yaml`, which **is** in the old filter — so to verify the fix, check that #657 (which touches neither path) reports `Source-of-truth drift` once this merges.

Found by the round-2 pipeline audit, backend#1681. Parent epic: backend#1680.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change; the drift job still runs the same script, with slightly more PR runs (~10s each).
> 
> **Overview**
> Fixes PRs stuck at *Expected — waiting for status to be reported* when they do not touch `scripts/**`, `client/**`, or the workflow file. **Source-of-truth drift** is required on `develop` and `main`, but a path-filtered workflow never runs on out-of-scope PRs, so GitHub never gets a status.
> 
> The `pull_request` trigger in `.github/workflows/drift-checks.yaml` now only lists branches; the `paths` filter is removed. Inline comments document why required checks must not be path-scoped on PRs. **`push`** still uses `paths` because pushes are not blocked by that required-check behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9691d431d00d96d7f911cc93c98f6e5df2a59e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->