### PR TITLE
fix(chart): drop the sticky bit on /data/shared so a dataset can be deleted

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.29
-appVersion: "1.9.29"
+version: 1.9.30
+appVersion: "1.9.30"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -55,8 +55,21 @@ spec:
       # Unlike mysql-data (one writer, UID 999), these have MULTIPLE non-root writers —
       # jobs-manager, the training/ingestor pods it spawns, and the CLI's ingest-staging pod,
       # whose UID this chart does not control — so they must be world-writable, not chowned to
-      # a single UID. Mode 3777 = setgid (2) so new files inherit GID 1000 + sticky (1) so one
-      # writer can't unlink or rename another writer's files (/tmp semantics); runs as root only
+      # a single UID. Both get setgid (2) so new entries inherit GID 1000. They differ in the
+      # sticky bit, deliberately:
+      #   /data/logs  = 3777 (setgid + sticky) — /tmp semantics: one writer can't unlink or
+      #                 rename another writer's files, and nothing has to.
+      #   /data/shared = 2777 (setgid, NO sticky) — because here something DOES have to.
+      #                 `data delete` removes a dataset the INGEST created: the ingestion Job
+      #                 writes as uid 65534 (or HOST_UID), while the CLI's teardown pod runs as
+      #                 uid 65532. Sticky permits an unlink only by the entry's owner, the
+      #                 directory's owner, or root — and the teardown pod is none of the three,
+      #                 so sticky made a documented product operation impossible: the table was
+      #                 dropped and the files stayed, leaving a half-deleted dataset. fsGroup
+      #                 cannot align those identities either, since kubelet ignores it on
+      #                 hostPath (kubernetes/kubernetes#138411). Keeping sticky on /data/shared
+      #                 protects writers from each other at the cost of never being able to
+      #                 clean up after them; runs as root only
       # long enough to fix the mounts. Caps: CHOWN for the chown; FOWNER so the chmod is idempotent
       # on re-install; FSETID so the setgid bit survives the chmod — after the chown to GID 1000 the
       # dir's group no longer matches the process (fsgid 0), and a root process without FSETID has
@@ -78,7 +91,7 @@ spec:
             add: ["CHOWN", "FOWNER", "FSETID"]
           seccompProfile:
             type: RuntimeDefault
-        command: ['sh', '-c', 'for d in /data/shared /data/logs; do chown 1000:1000 "$d" && chmod 3777 "$d" || echo "init-writable-data: could not adjust $d (pre-provisioned or root_squash mount?); leaving as-is"; done']
+        command: ['sh', '-c', 'for e in /data/shared:2777 /data/logs:3777; do d=${e%:*}; m=${e#*:}; chown 1000:1000 "$d" && chmod "$m" "$d" || echo "init-writable-data: could not adjust $d (pre-provisioned or root_squash mount?); leaving as-is"; done']
         volumeMounts:
         - name: shared-volume
           mountPath: /data/shared

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -446,10 +446,23 @@ tests:
       - contains:
           path: spec.template.spec.initContainers[0].securityContext.capabilities.add
           content: FSETID
-      # each dir is fixed INDEPENDENTLY (a for-loop): chown 1000:1000 then chmod 3777
+      # each dir is fixed INDEPENDENTLY (a for-loop): chown 1000:1000 then chmod its OWN mode
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "for d in /data/shared /data/logs.*chown 1000:1000.*chmod 3777"
+          pattern: 'for e in /data/shared:2777 /data/logs:3777.*chown 1000:1000.*chmod'
+      # /data/shared must NOT be sticky. `data delete` removes a tree the INGEST wrote: the
+      # ingestion Job runs as uid 65534 (or HOST_UID), the CLI teardown pod as 65532. Sticky
+      # allows an unlink only by the entry's owner, the dir's owner, or root — none of which the
+      # teardown is — so sticky here made a documented operation impossible: table dropped, files
+      # stranded. fsGroup can't align them either (kubelet ignores it on hostPath, k8s#138411).
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "/data/shared:2777"
+      # ...while /data/logs KEEPS sticky: nothing has to delete another writer's logs, so the
+      # /tmp-style protection costs nothing there. Both keep setgid (2) for GID inheritance.
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "/data/logs:3777"
       # best-effort: a failing chown/chmod is logged, not fatal, so the other dir is still fixed
       # and jobs-manager still starts (e.g. /data/shared on an NFS root_squash export)
       - matchRegex:


### PR DESCRIPTION
The chart half of a `data delete` that strands its files. The ingestor half is
tracebloc/data-ingestors#476.

## The bug

`data delete` drops the table, then fails to remove the files — leaving a half-deleted dataset:
gone from the database, still occupying storage, and un-retryable because the table the retry
looks for no longer exists.

## Root cause

`init-writable-data` set **both** shared dirs to `3777` — setgid **plus sticky**, /tmp semantics,
so one writer can't unlink another writer's files. That protection is correct for `/data/logs` and
wrong for `/data/shared`, because on `/data/shared` something legitimately *has* to: `data delete`
removes a tree the ingest wrote, and the two run as different identities.

| Actor | Identity |
|---|---|
| ingestion Job (writes the dataset) | uid 65534 (`nobody`), or `HOST_UID` |
| CLI staging/teardown pod (removes it) | uid 65532, `fsGroup` 65532 |
| the mount itself | chowned `1000:1000` |

The sticky bit permits an unlink only by the entry's owner, the directory's owner, or root — and
the teardown pod is none of the three. `fsGroup`, which normally aligns identities like this by
making kubelet recursively `chgrp` the volume, does nothing here: **kubelet ignores `fsGroup` on
hostPath volumes** ([kubernetes#138411](https://github.com/kubernetes/kubernetes/issues/138411)),
the layout every installer-provisioned cluster uses.

## The change

The mode becomes per-directory instead of one value for both:

| Dir | Mode | Why |
|---|---|---|
| `/data/shared` | **`2777`** — setgid, no sticky | the teardown must be able to clean up after the ingest |
| `/data/logs` | `3777` — setgid + sticky | unchanged; nothing deletes another writer's logs, so the protection is free |

Both keep setgid, so new entries still inherit GID 1000, and each dir is still fixed independently
and best-effort — a `root_squash` export still degrades to a logged skip rather than blocking
startup.

I removed the protection only where it provably blocks a required operation, rather than
everywhere: keeping sticky on `/data/shared` would mean protecting writers from each other at the
cost of never being able to clean up after them.

## Verification

- **Executed the generated shell**, rather than only asserting on its text: `/data/shared` comes
  out `drwxrwsrwx` and `/data/logs` `drwxrwsrwt`. Valid under both `sh -n` and `dash -n`.
- `helm unittest` `jobs_manager`: **34/34**.
- **The two new assertions were proved to bite** — putting `/data/shared` back to `3777` fails
  `asserts[6]` and `asserts[7]`.
- Full chart suite and `helm lint` are **unchanged from develop** — both have the same pre-existing
  5 failed / 5 errored and the `clientId`/`clientPassword` `minLength` lint errors, which need
  real values. I verified this by stashing and re-running on clean `develop`.
- Chart version + appVersion bumped in lockstep (1.9.29 → 1.9.30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hostPath volume permissions for a multi-writer data path; lowers unlink protection on /data/shared while fixing a broken delete path—behavior change on upgrade/re-init, not auth or payment logic.
> 
> **Overview**
> Fixes **`data delete`** leaving dataset files on disk after the DB row is gone on **hostPath** installs, by changing how **`init-writable-data`** chmods the shared volume.
> 
> Previously both **`/data/shared`** and **`/data/logs`** were set to **`3777`** (setgid + sticky). Sticky blocked the CLI teardown pod (uid 65532) from unlinking trees written by the ingest job (uid 65534), because neither is owner of those entries. **`/data/shared`** is now **`2777`** (setgid only); **`/data/logs`** stays **`3777`**. The init loop applies per-path modes via **`/data/shared:2777 /data/logs:3777`**.
> 
> Chart **version/appVersion** bump to **1.9.30**, with **helm unittest** updates so regressions to **`3777`** on shared fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 392a82a52e74d7ec06242b50196eea199bdd971c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->