### PR TITLE
docs(claude): sync org-standards block (backend#1602)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Do not default the assignee to one person. This file used to name `saadqbal` unc
 ### Engineer kanban
 
 - Every ticket on the board carries a `Status` — no card sits at "No Status". New tickets start in `Backlog`. **Bugs are the exception:** label them `work-type:bug` (the Bug template does it) and put them straight into `Ready` — defects don't wait for refinement.
-- Picking up work: the team coordinates. `Ready` is the refined queue and the first choice when it's stocked; pulling from `Backlog` is normal when refinement hasn't caught up — say what you're taking.
+- Picking up work: the team coordinates. `Ready` is the refined queue — bugs excepted, per the line above — and the first choice when it's stocked; pulling from `Backlog` is normal when refinement hasn't caught up — say what you're taking.
 - Merging to `develop` moves the card to `On dev` automatically; there is no dev-side review.
 - Functional review happens once, on staging: when it passes, comment `/fr-pass` on the PR or drag the card to `Ready for prod`. Self-signoff is allowed.
 - `fr-gate` is a required check on promotions. If it blocks, the board or the work isn't ready — fix that. `skip-fr-gate` is audited, for emergencies only.


### PR DESCRIPTION
Managed sync of the org-standards block into this repo's `CLAUDE.md` — canonical
source: `tracebloc/.github/org-standards.md`. Do not hand-edit the block; to change
a rule, open a PR against tracebloc/.github and the sync propagates it.

Part of tracebloc/backend#1602 (org-wide engineering standards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only sync of org-wide prose; no runtime, security, or data-handling impact.
> 
> **Overview**
> Managed sync of the org-standards block from `tracebloc/.github/org-standards.md` into this repo’s `CLAUDE.md` (do not hand-edit the block locally).
> 
> The only substantive change is in **Engineer kanban**: the “picking up work” bullet now explicitly notes that **bugs are excepted** when treating `Ready` as the first-choice queue — aligning that line with the bug rule in the bullet above, without changing any other standards text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a58f07279384945cc97556878440c042038673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->