### PR TITLE
fix(chart): resolve CLIENT_ENV everywhere, not only where someone remembered (backend#1723)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.30
-appVersion: "1.9.30"
+version: 1.9.31
+appVersion: "1.9.31"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -235,7 +235,10 @@ Image reference — defaults to docker.io when no registry is provided.
 When `digest` (sha256:...) is set, renders registry/repo@digest (immutable pin,
 preferred for security). Otherwise falls back to registry/repo:tag, where tag
 defaults to "prod" when CLIENT_ENV is omitted or empty.
-Usage: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.jobsManager.digest "registry" "docker.io") }}
+Usage: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" (include "tracebloc.clientEnv" .) "digest" .Values.images.jobsManager.digest "registry" "docker.io") }}
+NOTE the resolved tag. This example previously read `.Values.env.CLIENT_ENV`
+and all four image call sites were copied from it, so a documented alias
+became an image tag nothing publishes (backend#1723).
 */}}
 {{- define "tracebloc.image" -}}
 {{- $registry := .registry | default "docker.io" -}}

--- a/client/templates/egress-reachability-check.yaml
+++ b/client/templates/egress-reachability-check.yaml
@@ -22,7 +22,12 @@
   block them or the hourly auto-upgrade. Set egressReachabilityCheck.enabled=false
   to disable (e.g. a truly air-gapped cluster with no route to the backend).
 */ -}}
-{{- $env := .Values.env.CLIENT_ENV | default "prod" -}}
+{{- /* RESOLVED: the case statement below keys on dev|stg|prod and its
+     catch-all is PROD, so a documented alias like `staging` silently
+     probed api.tracebloc.io and passed for the wrong environment --
+     a reachability check that verifies a path the cluster never takes
+     (backend#1723). */ -}}
+{{- $env := include "tracebloc.clientEnv" . -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -408,7 +408,10 @@ spec:
                 - name: DEPLOYMENT_NAME
                   value: {{ printf "%s-jobs-manager" .Release.Name | quote }}
                 - name: IMAGE_TAG
-                  value: {{ .Values.env.CLIENT_ENV | default "prod" | quote }}
+                  # RESOLVED, not raw. This is the tag the refresh pulls, so a
+                  # documented alias here freezes the edge on a tag the publish
+                  # pipeline never writes (backend#1723).
+                  value: {{ include "tracebloc.clientEnv" . | quote }}
                 - name: ROLLOUT_TIMEOUT
                   value: {{ .Values.imageRefresh.rolloutTimeout | quote }}
                 # #563: consecutive failed-rollout threshold; stop + flag after this.

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -100,7 +100,7 @@ spec:
       {{- end }}
       containers:
       - name: api
-        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.jobsManager.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
+        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" (include "tracebloc.clientEnv" .) "digest" .Values.images.jobsManager.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
         imagePullPolicy: {{ if .Values.images.jobsManager.digest }}IfNotPresent{{ else }}Always{{ end }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -298,7 +298,7 @@ spec:
         - name: JOB_IMAGE_HOST
           value: {{ printf "%s/" (dig "imageRegistry" "docker.io" (.Values.global | default dict) | default "docker.io") | quote }}
         - name: CLIENT_ENV
-          value: {{ .Values.env.CLIENT_ENV | default "prod" | quote }}
+          value: {{ include "tracebloc.clientEnv" . | quote }}
         - name: RESOURCE_REQUESTS
           value: {{ if hasKey .Values.env "RESOURCE_REQUESTS" }}{{ .Values.env.RESOURCE_REQUESTS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         - name: RESOURCE_LIMITS
@@ -338,7 +338,7 @@ spec:
         {{- end }}
         {{- end }}
       - name: pods-monitor-container
-        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/pods-monitor" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.podsMonitor.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
+        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/pods-monitor" "tag" (include "tracebloc.clientEnv" .) "digest" .Values.images.podsMonitor.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
         imagePullPolicy: {{ if .Values.images.podsMonitor.digest }}IfNotPresent{{ else }}Always{{ end }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -379,7 +379,7 @@ spec:
         - name: JOB_IMAGE_HOST
           value: {{ printf "%s/" (dig "imageRegistry" "docker.io" (.Values.global | default dict) | default "docker.io") | quote }}
         - name: CLIENT_ENV
-          value: {{ .Values.env.CLIENT_ENV | default "prod" | quote }}
+          value: {{ include "tracebloc.clientEnv" . | quote }}
         - name: RESOURCE_REQUESTS
           value: {{ if hasKey .Values.env "RESOURCE_REQUESTS" }}{{ .Values.env.RESOURCE_REQUESTS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         - name: RESOURCE_LIMITS

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: proxy
           {{- $rpDigest := (dig "requestsProxy" "digest" "" .Values.images) }}
-          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" $rpDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
+          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" (include "tracebloc.clientEnv" .) "digest" $rpDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
           # digest set -> repo@digest + IfNotPresent (restart-safe offline); empty ->
           # repo:tag + Always. Was hardcoded Always, which ignored a pinned digest and
           # re-pulled on every restart even when the image was already cached (#552).

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -50,7 +50,7 @@ spec:
             entry). `dig` is not usable here — it rejects chartutil.Values.
           */}}
           {{- $rmDigest := (default (dict) (default (dict) .Values.images).resourceMonitor).digest | default "" }}
-          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" .Values.env.CLIENT_ENV "digest" $rmDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
+          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" (include "tracebloc.clientEnv" .) "digest" $rmDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
           imagePullPolicy: {{ if $rmDigest }}IfNotPresent{{ else }}Always{{ end }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -80,7 +80,7 @@ spec:
             - name: MONITOR_INTERVAL
               value: "30"
             - name: CLIENT_ENV
-              value: {{ .Values.env.CLIENT_ENV | default "prod" | quote }}
+              value: {{ include "tracebloc.clientEnv" . | quote }}
             - name: CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/client/tests/client_env_alias_test.yaml
+++ b/client/tests/client_env_alias_test.yaml
@@ -1,0 +1,140 @@
+suite: CLIENT_ENV aliases resolve everywhere, not just where someone remembered (backend#1723)
+# WHY THIS SUITE EXISTS
+#
+# values.schema.json promises: "the documented aliases development/staging/
+# production are accepted and normalized", and calls CLIENT_ENV the "Docker
+# image tag". Both halves were true only for the ingestor channel tag and the
+# prod digest pin. Four control-plane image tags, the auto-upgrade CronJob's
+# IMAGE_TAG and the egress reachability check all read the RAW value.
+#
+# `CLIENT_ENV: staging` therefore pulled tracebloc/*:staging -- a tag the
+# publish pipeline never writes (it publishes :stg), last pushed 2026-06-22 --
+# so the client ran a 50-day-old jobs-manager that predated the alias fix,
+# authenticated against the wrong backend and crash-looped.
+#
+# THE EXISTING SUITES COULD NOT HAVE CAUGHT IT. They are thorough about dev,
+# stg, prod, unset and unknown -- and not one of them ever set `staging`. A
+# test written in the same vocabulary as the code cannot detect a vocabulary
+# mismatch with the docs. So this suite tests the ALIASES specifically.
+templates:
+  - templates/jobs-manager-deployment.yaml
+  - templates/requests-proxy-deployment.yaml
+  - templates/resource-monitor-daemonset.yaml
+  - templates/image-refresh-cronjob.yaml
+  - templates/egress-reachability-check.yaml
+release:
+  name: alias
+  namespace: tracebloc
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+  storageClass.create: false
+  # Unpinned so the image-refresh CronJob renders; a digest-pinned pair
+  # disables it (tracebloc.imageRefreshEnabled).
+  images.jobsManager.digest: ""
+  images.podsMonitor.digest: ""
+
+tests:
+  # ---- the image tags -------------------------------------------------
+  - it: "staging resolves to :stg for the jobs-manager image"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/jobs-manager:stg
+
+  - it: "staging resolves to :stg for the pods-monitor sidecar"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: docker.io/tracebloc/pods-monitor:stg
+
+  - it: "staging resolves to :stg for requests-proxy (which runs the jobs-manager image)"
+    template: templates/requests-proxy-deployment.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/jobs-manager:stg
+
+  - it: "staging resolves to :stg for the resource-monitor daemonset"
+    template: templates/resource-monitor-daemonset.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/resource-monitor:stg
+
+  - it: "production and development resolve too, not just staging"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: production
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/jobs-manager:prod
+
+  - it: "a canonical value is unchanged by resolution"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: stg
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/jobs-manager:stg
+
+  # ---- the auto-upgrade CronJob ---------------------------------------
+  # The most consequential site: this is what keeps an installed edge
+  # current, so an unpublished tag here freezes it on whatever that tag
+  # last held -- silently, forever.
+  - it: "the image-refresh CronJob refreshes against the RESOLVED tag"
+    template: templates/image-refresh-cronjob.yaml
+    # documentIndex 1: the file renders the auto-upgrade CronJob first and the
+    # image-refresh one second, same as image_refresh_test.yaml.
+    documentIndex: 1
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: IMAGE_TAG
+            value: "stg"
+
+  # ---- the egress reachability CHECK ----------------------------------
+  # Its case statement keys on dev|stg|prod with a catch-all of PROD, so an
+  # alias made it probe api.tracebloc.io and PASS for an environment the
+  # cluster never contacts. A check that verifies the wrong thing is worse
+  # than no check.
+  - it: "the egress check probes the environment the client actually uses"
+    template: templates/egress-reachability-check.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLIENT_ENV
+            value: "stg"
+
+  # ---- the value handed to the services -------------------------------
+  # client-runtime normalizes this itself, so these passed before. Pinned
+  # anyway: relying on the consumer to fix the producer's value is how the
+  # image tags -- which have no consumer to fix them -- got missed.
+  - it: "the CLIENT_ENV handed to jobs-manager is already canonical"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLIENT_ENV
+            value: "stg"


### PR DESCRIPTION
Fixes [backend#1723](https://github.com/tracebloc/backend/issues/1723). Found by the autonomous E2E agent while chasing [backend#1707](https://github.com/tracebloc/backend/issues/1707).

## The promise the chart wasn't keeping

`values.schema.json` says of `CLIENT_ENV`:

> "Environment identifier **and Docker image tag**. Canonical values are `dev`, `stg`, `prod`; the documented aliases `development`/`staging`/`production` are **accepted and normalized**"

Both halves were true only for the ingestor channel tag and the prod digest pin. **Six other sites read the raw value.**

So `CLIENT_ENV: staging` — a value the schema explicitly blesses — pulled `tracebloc/*:staging`, a tag the publish pipeline never writes. `client-runtime/.github/workflows/publish-images.yml` maps branch `staging` → **`:stg`**. Docker Hub, read 2026-08-11:

```
dev     pushed 2026-08-11
stg     pushed 2026-08-11
prod    pushed 2026-08-11
staging pushed 2026-06-22   ← what the chart pulled
```

A staging install therefore ran a **50-day-old** jobs-manager that predated `normalize_client_env`, authenticated against the wrong backend, and crash-looped — reporting a *configuration* error as a *credentials* error.

## What changed

Everything now goes through the chart's own `tracebloc.clientEnv`:

| site | why it matters |
|---|---|
| jobs-manager, pods-monitor, resource-monitor, requests-proxy image tags | the stale-image bug itself (requests-proxy runs the jobs-manager image) |
| **image-refresh CronJob `IMAGE_TAG`** | the worst one — this is what keeps an installed edge current, so an unpublished tag freezes it on whatever that tag last held, silently and forever |
| **egress-reachability-check host selection** | its `case` keys on `dev\|stg\|prod` with a **catch-all of prod**, so a `staging` install *passed* its reachability check by probing `api.tracebloc.io` — an environment that cluster never contacts |
| `CLIENT_ENV` handed to the three services | these already worked, since client-runtime normalizes internally. Included because relying on the consumer to repair the producer's value is exactly how the image tags — which have no consumer to repair them — got missed |

The helper already demanded this: *"Any future consumer of CLIENT_ENV must go through here rather than re-deriving it."* Its **own usage example** showed the raw read, and all four image call sites are copies of it. Example fixed.

## Why the existing suites couldn't catch it

This is the part worth taking away. `ingestor_channel_tag_test.yaml` is genuinely thorough — `dev`, `stg`, `prod`, unset, *and* unknown. `egress_reachability_check_test.yaml` covers each backend. `image_refresh_test.yaml` covers prod.

**Not one of them ever sets `staging`.**

A test written in the same vocabulary as the code cannot detect a vocabulary mismatch with the docs. The new suite tests the **aliases** specifically, which is the axis nothing covered.

## Evidence

- **375 tests pass** (was 366).
- `helm lint` clean.
- **Mutation-checked**: against the unfixed templates, **8 of the 9 new cases fail**. The ninth is a deliberate positive control — a canonical `stg` is unchanged by resolution — so it passes both before and after, by design.
- Verified by rendering: every alias (`staging`/`production`/`development`) and every canonical value now yields the right tag, `IMAGE_TAG`, and probe target.

## Scope note

This fixes the chart. The orphaned `tracebloc/*:staging` tags on Docker Hub (last pushed 2026-06-22) should still be **deleted or repointed** rather than left to rot — a tag that only some tooling updates is a trap for the next person. Tracked in backend#1723; not done here because it's a registry action, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches control-plane image selection and auto-upgrade refresh tags fleet-wide; behavior change is intentional but wrong resolution would affect every edge using alias values.
> 
> **Overview**
> **Routes all `CLIENT_ENV` consumers through `tracebloc.clientEnv`** so documented aliases (`staging` → `stg`, etc.) match published Docker tags and canonical backend hosts, fixing installs that pulled nonexistent `:staging` images and mis-probed prod APIs.
> 
> Image tags for jobs-manager, pods-monitor, requests-proxy, and resource-monitor now use the resolved env instead of raw `env.CLIENT_ENV`. The image-refresh CronJob’s `IMAGE_TAG`, egress reachability check host selection, and `CLIENT_ENV` env vars passed into workloads are updated the same way. Chart version bumps to **1.9.31**; `_helpers.tpl` documents the corrected `tracebloc.image` usage.
> 
> Adds **`client_env_alias_test.yaml`** to assert alias resolution on images, `IMAGE_TAG`, egress probe env, and jobs-manager `CLIENT_ENV`—coverage the existing dev/stg/prod-only tests did not provide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df2f42ae8109ac95d1d1718b0039b27bc704e600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->