### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/workflows/drift-checks.yaml
+++ b/.github/workflows/drift-checks.yaml
@@ -5,6 +5,18 @@ name: Drift checks
 # readiness-wait and --diagnose bundle grep for). Mocked unit tests can't see
 # these — a rename ships green and breaks in the field. This guards both sides.
 # Triggers on scripts/ OR client/ because either side moving is the drift.
+#
+# NO `paths:` ON pull_request, deliberately. `Source-of-truth drift` is a
+# REQUIRED status check on develop and on main, and a required check that is
+# path-filtered can never report on a PR outside those paths -- GitHub leaves it
+# at "Expected - waiting for status to be reported" and the PR is unmergeable
+# forever. Not hypothetical: on 2026-08-11 it was blocking client#651, #657 and
+# #660, none of which touch scripts/ or client/. standard-checks.yml's own
+# header spells out the same hazard. The job is ~10s, so running it on every PR
+# costs nothing next to a permanently stuck PR.
+#
+# `push` keeps its paths filter: pushes are not gated by required checks, so
+# path-scoping there is free and correct.
 on:
   push:
     branches: [main, develop, openshift]
@@ -14,10 +26,6 @@ on:
       - '.github/workflows/drift-checks.yaml'
   pull_request:
     branches: [main, develop, openshift]
-    paths:
-      - 'scripts/**'
-      - 'client/**'
-      - '.github/workflows/drift-checks.yaml'
   workflow_dispatch:
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Do not default the assignee to one person. This file used to name `saadqbal` unc
 ### Engineer kanban
 
 - Every ticket on the board carries a `Status` — no card sits at "No Status". New tickets start in `Backlog`. **Bugs are the exception:** label them `work-type:bug` (the Bug template does it) and put them straight into `Ready` — defects don't wait for refinement.
-- Picking up work: the team coordinates. `Ready` is the refined queue and the first choice when it's stocked; pulling from `Backlog` is normal when refinement hasn't caught up — say what you're taking.
+- Picking up work: the team coordinates. `Ready` is the refined queue — bugs excepted, per the line above — and the first choice when it's stocked; pulling from `Backlog` is normal when refinement hasn't caught up — say what you're taking.
 - Merging to `develop` moves the card to `On dev` automatically; there is no dev-side review.
 - Functional review happens once, on staging: when it passes, comment `/fr-pass` on the PR or drag the card to `Ready for prod`. Self-signoff is allowed.
 - `fr-gate` is a required check on promotions. If it blocks, the board or the work isn't ready — fix that. `skip-fr-gate` is audited, for emergencies only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Do not default the assignee to one person. This file used to name `saadqbal` unc
 
 ### Engineer kanban
 
+- Every ticket on the board carries a `Status` — no card sits at "No Status". New tickets start in `Backlog`. **Bugs are the exception:** label them `work-type:bug` (the Bug template does it) and put them straight into `Ready` — defects don't wait for refinement.
 - Picking up work: the team coordinates. `Ready` is the refined queue and the first choice when it's stocked; pulling from `Backlog` is normal when refinement hasn't caught up — say what you're taking.
 - Merging to `develop` moves the card to `On dev` automatically; there is no dev-side review.
 - Functional review happens once, on staging: when it passes, comment `/fr-pass` on the PR or drag the card to `Ready for prod`. Self-signoff is allowed.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@
 #
 #   make check      lint + fast tests.   Budget: under 60 s.
 #   make check-all  everything CI runs (bar the CI-only heavy suites).
-#   make setup      install what those targets need.
+#   make setup      install what those targets need, and a git pre-push hook
+#                   that runs `make check` (skip once with --no-verify).
 #
 # This file is a THIN WRAPPER. Every command below is copied from the
 # workflow that already runs it — standard-checks.yml, installer-tests.yaml
@@ -42,7 +43,8 @@ help:
 	@echo
 	@echo "  check       lint + fast checks (~4 s) — run this before every push"
 	@echo "  check-all   everything CI runs locally, including the 868-test bats suite"
-	@echo "  setup       check for / point at the tools these targets need"
+	@echo "  setup       check for / point at the tools these targets need; installs the pre-push hook"
+	@echo "  install-hooks  (re)install the git pre-push hook that runs 'make check'"
 	@echo
 	@echo "  individual: lint bats helm-lint helm-template helm-unittest drift"
 	@echo
@@ -70,8 +72,9 @@ check: lint drift helm-lint
 check-all: lint drift helm-lint bats helm-template helm-unittest
 	@echo "==> check-all: green"
 
-# setup: no dependency is installed and no hook is added (hooks are a
-# later step of backend#1606). This only tells you what is missing.
+# setup: no dependency is installed — this only tells you what is missing —
+# but it does install a git pre-push hook that runs `make check` (backend#1606
+# step 4), via the install-hooks target below.
 .PHONY: setup
 setup:
 	@missing=""; \
@@ -85,6 +88,49 @@ setup:
 	  exit 1; \
 	fi; \
 	echo "==> setup: shellcheck, bats and helm are all present; run 'make check'"
+	@$(MAKE) --no-print-directory install-hooks
+
+# install-hooks: put a pre-push hook in place that runs `make check`, so the
+# canon's "run the tests before you push" is carried by the tooling rather than
+# by memory. Factored out of `setup` so it is independently runnable and
+# testable, and so a contributor who only wants the hook need not rerun the
+# full `make setup`.
+#
+# Honest by design: the hook catches FORGETTING, not defiance — `git push
+# --no-verify` skips it and always will. And it refuses to clobber a pre-push
+# hook that is already there and not ours (e.g. one the pre-commit framework
+# manages), rather than silently stomping a contributor's setup.
+#
+# `git rev-parse --git-path hooks` (not a hard-coded `.git/hooks`) so it lands
+# in the right place inside a linked worktree or a submodule, where the git dir
+# is not `.git`.
+.PHONY: install-hooks
+install-hooks:
+	@if ! git rev-parse --git-dir >/dev/null 2>&1; then \
+	  echo "note: not a git checkout — skipping pre-push hook install"; \
+	else \
+	  hook="$$(git rev-parse --git-path hooks)/pre-push"; \
+	  if [ -e "$$hook" ] && ! grep -q 'tracebloc pre-push hook' "$$hook" 2>/dev/null; then \
+	    echo "note: $$hook already exists and is not ours — leaving it untouched."; \
+	    echo "      add 'make check' to it, or remove it and re-run 'make install-hooks'."; \
+	  else \
+	    mkdir -p "$$(dirname "$$hook")" && \
+	    printf '%s\n' \
+	      '#!/bin/sh' \
+	      '# tracebloc pre-push hook installed by make setup (backend#1606).' \
+	      '# Runs make check so a push that would be red in CI is caught locally first.' \
+	      '# It catches forgetting, not defiance: git push --no-verify skips it.' \
+	      '#' \
+	      '# Git exports GIT_DIR/GIT_WORK_TREE/etc into hook processes; a nested git' \
+	      '# (e.g. Go buildvcs under go test) then fails in a linked worktree with' \
+	      '# exit status 128. Clear them so make check runs as if from the shell.' \
+	      'unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY' \
+	      'exec make check' > "$$hook" && \
+	    chmod +x "$$hook" && \
+	    echo "==> pre-push hook installed at $$hook" && \
+	    echo "    'make check' now runs before each push (skip once with: git push --no-verify)"; \
+	  fi; \
+	fi
 
 # ---- individual targets ------------------------------------------
 

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.30
-appVersion: "1.9.30"
+version: 1.9.31
+appVersion: "1.9.31"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.29
-appVersion: "1.9.29"
+version: 1.9.30
+appVersion: "1.9.30"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -235,7 +235,10 @@ Image reference — defaults to docker.io when no registry is provided.
 When `digest` (sha256:...) is set, renders registry/repo@digest (immutable pin,
 preferred for security). Otherwise falls back to registry/repo:tag, where tag
 defaults to "prod" when CLIENT_ENV is omitted or empty.
-Usage: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.jobsManager.digest "registry" "docker.io") }}
+Usage: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" (include "tracebloc.clientEnv" .) "digest" .Values.images.jobsManager.digest "registry" "docker.io") }}
+NOTE the resolved tag. This example previously read `.Values.env.CLIENT_ENV`
+and all four image call sites were copied from it, so a documented alias
+became an image tag nothing publishes (backend#1723).
 */}}
 {{- define "tracebloc.image" -}}
 {{- $registry := .registry | default "docker.io" -}}

--- a/client/templates/egress-reachability-check.yaml
+++ b/client/templates/egress-reachability-check.yaml
@@ -22,7 +22,12 @@
   block them or the hourly auto-upgrade. Set egressReachabilityCheck.enabled=false
   to disable (e.g. a truly air-gapped cluster with no route to the backend).
 */ -}}
-{{- $env := .Values.env.CLIENT_ENV | default "prod" -}}
+{{- /* RESOLVED: the case statement below keys on dev|stg|prod and its
+     catch-all is PROD, so a documented alias like `staging` silently
+     probed api.tracebloc.io and passed for the wrong environment --
+     a reachability check that verifies a path the cluster never takes
+     (backend#1723). */ -}}
+{{- $env := include "tracebloc.clientEnv" . -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -408,7 +408,10 @@ spec:
                 - name: DEPLOYMENT_NAME
                   value: {{ printf "%s-jobs-manager" .Release.Name | quote }}
                 - name: IMAGE_TAG
-                  value: {{ .Values.env.CLIENT_ENV | default "prod" | quote }}
+                  # RESOLVED, not raw. This is the tag the refresh pulls, so a
+                  # documented alias here freezes the edge on a tag the publish
+                  # pipeline never writes (backend#1723).
+                  value: {{ include "tracebloc.clientEnv" . | quote }}
                 - name: ROLLOUT_TIMEOUT
                   value: {{ .Values.imageRefresh.rolloutTimeout | quote }}
                 # #563: consecutive failed-rollout threshold; stop + flag after this.

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -100,7 +100,7 @@ spec:
       {{- end }}
       containers:
       - name: api
-        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.jobsManager.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
+        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" (include "tracebloc.clientEnv" .) "digest" .Values.images.jobsManager.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
         imagePullPolicy: {{ if .Values.images.jobsManager.digest }}IfNotPresent{{ else }}Always{{ end }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -298,7 +298,7 @@ spec:
         - name: JOB_IMAGE_HOST
           value: {{ printf "%s/" (dig "imageRegistry" "docker.io" (.Values.global | default dict) | default "docker.io") | quote }}
         - name: CLIENT_ENV
-          value: {{ .Values.env.CLIENT_ENV | default "prod" | quote }}
+          value: {{ include "tracebloc.clientEnv" . | quote }}
         - name: RESOURCE_REQUESTS
           value: {{ if hasKey .Values.env "RESOURCE_REQUESTS" }}{{ .Values.env.RESOURCE_REQUESTS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         - name: RESOURCE_LIMITS
@@ -338,7 +338,7 @@ spec:
         {{- end }}
         {{- end }}
       - name: pods-monitor-container
-        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/pods-monitor" "tag" .Values.env.CLIENT_ENV "digest" .Values.images.podsMonitor.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
+        image: {{ include "tracebloc.image" (dict "repository" "tracebloc/pods-monitor" "tag" (include "tracebloc.clientEnv" .) "digest" .Values.images.podsMonitor.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
         imagePullPolicy: {{ if .Values.images.podsMonitor.digest }}IfNotPresent{{ else }}Always{{ end }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -379,7 +379,7 @@ spec:
         - name: JOB_IMAGE_HOST
           value: {{ printf "%s/" (dig "imageRegistry" "docker.io" (.Values.global | default dict) | default "docker.io") | quote }}
         - name: CLIENT_ENV
-          value: {{ .Values.env.CLIENT_ENV | default "prod" | quote }}
+          value: {{ include "tracebloc.clientEnv" . | quote }}
         - name: RESOURCE_REQUESTS
           value: {{ if hasKey .Values.env "RESOURCE_REQUESTS" }}{{ .Values.env.RESOURCE_REQUESTS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         - name: RESOURCE_LIMITS

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -55,8 +55,21 @@ spec:
       # Unlike mysql-data (one writer, UID 999), these have MULTIPLE non-root writers —
       # jobs-manager, the training/ingestor pods it spawns, and the CLI's ingest-staging pod,
       # whose UID this chart does not control — so they must be world-writable, not chowned to
-      # a single UID. Mode 3777 = setgid (2) so new files inherit GID 1000 + sticky (1) so one
-      # writer can't unlink or rename another writer's files (/tmp semantics); runs as root only
+      # a single UID. Both get setgid (2) so new entries inherit GID 1000. They differ in the
+      # sticky bit, deliberately:
+      #   /data/logs  = 3777 (setgid + sticky) — /tmp semantics: one writer can't unlink or
+      #                 rename another writer's files, and nothing has to.
+      #   /data/shared = 2777 (setgid, NO sticky) — because here something DOES have to.
+      #                 `data delete` removes a dataset the INGEST created: the ingestion Job
+      #                 writes as uid 65534 (or HOST_UID), while the CLI's teardown pod runs as
+      #                 uid 65532. Sticky permits an unlink only by the entry's owner, the
+      #                 directory's owner, or root — and the teardown pod is none of the three,
+      #                 so sticky made a documented product operation impossible: the table was
+      #                 dropped and the files stayed, leaving a half-deleted dataset. fsGroup
+      #                 cannot align those identities either, since kubelet ignores it on
+      #                 hostPath (kubernetes/kubernetes#138411). Keeping sticky on /data/shared
+      #                 protects writers from each other at the cost of never being able to
+      #                 clean up after them; runs as root only
       # long enough to fix the mounts. Caps: CHOWN for the chown; FOWNER so the chmod is idempotent
       # on re-install; FSETID so the setgid bit survives the chmod — after the chown to GID 1000 the
       # dir's group no longer matches the process (fsgid 0), and a root process without FSETID has
@@ -78,7 +91,7 @@ spec:
             add: ["CHOWN", "FOWNER", "FSETID"]
           seccompProfile:
             type: RuntimeDefault
-        command: ['sh', '-c', 'for d in /data/shared /data/logs; do chown 1000:1000 "$d" && chmod 3777 "$d" || echo "init-writable-data: could not adjust $d (pre-provisioned or root_squash mount?); leaving as-is"; done']
+        command: ['sh', '-c', 'for e in /data/shared:2777 /data/logs:3777; do d=${e%:*}; m=${e#*:}; chown 1000:1000 "$d" && chmod "$m" "$d" || echo "init-writable-data: could not adjust $d (pre-provisioned or root_squash mount?); leaving as-is"; done']
         volumeMounts:
         - name: shared-volume
           mountPath: /data/shared

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -128,6 +128,24 @@ spec:
                 secretKeyRef:
                   name: {{ include "tracebloc.secretName" . }}
                   key: POD_TOKEN_SIGNING_SECRET
+            {{- if .Values.serviceDbAccounts }}
+            # backend#1528 S2 (RFC-0003 D10 close-out): authenticate the proxy's
+            # metadata-DB access as the dedicated tb_meta identity instead of
+            # the root-equivalent edgeuser. Only the metadata identity is wired
+            # here — the proxy never touches the dataset DB. jobs-manager mints
+            # tb_meta at its startup; the proxy's bootstrap retries until it
+            # lands. Rendered only when enabled, so a default install stays
+            # byte-identical (mirrors the jobs-manager block).
+            - name: SERVICE_DB_ACCOUNTS
+              value: "1"
+            - name: TB_META_USER
+              value: "tb_meta"
+            - name: TB_META_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tracebloc.secretName" . }}
+                  key: TB_META_PASSWORD
+            {{- end }}
       {{- if include "tracebloc.useImagePullSecrets" . }}
       imagePullSecrets:
         - name: {{ include "tracebloc.registrySecretName" . }}

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: proxy
           {{- $rpDigest := (dig "requestsProxy" "digest" "" .Values.images) }}
-          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" .Values.env.CLIENT_ENV "digest" $rpDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
+          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" (include "tracebloc.clientEnv" .) "digest" $rpDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
           # digest set -> repo@digest + IfNotPresent (restart-safe offline); empty ->
           # repo:tag + Always. Was hardcoded Always, which ignored a pinned digest and
           # re-pulled on every restart even when the image was already cached (#552).

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -50,7 +50,7 @@ spec:
             entry). `dig` is not usable here — it rejects chartutil.Values.
           */}}
           {{- $rmDigest := (default (dict) (default (dict) .Values.images).resourceMonitor).digest | default "" }}
-          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" .Values.env.CLIENT_ENV "digest" $rmDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
+          image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" (include "tracebloc.clientEnv" .) "digest" $rmDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
           imagePullPolicy: {{ if $rmDigest }}IfNotPresent{{ else }}Always{{ end }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -80,7 +80,7 @@ spec:
             - name: MONITOR_INTERVAL
               value: "30"
             - name: CLIENT_ENV
-              value: {{ .Values.env.CLIENT_ENV | default "prod" | quote }}
+              value: {{ include "tracebloc.clientEnv" . | quote }}
             - name: CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/client/tests/client_env_alias_test.yaml
+++ b/client/tests/client_env_alias_test.yaml
@@ -1,0 +1,140 @@
+suite: CLIENT_ENV aliases resolve everywhere, not just where someone remembered (backend#1723)
+# WHY THIS SUITE EXISTS
+#
+# values.schema.json promises: "the documented aliases development/staging/
+# production are accepted and normalized", and calls CLIENT_ENV the "Docker
+# image tag". Both halves were true only for the ingestor channel tag and the
+# prod digest pin. Four control-plane image tags, the auto-upgrade CronJob's
+# IMAGE_TAG and the egress reachability check all read the RAW value.
+#
+# `CLIENT_ENV: staging` therefore pulled tracebloc/*:staging -- a tag the
+# publish pipeline never writes (it publishes :stg), last pushed 2026-06-22 --
+# so the client ran a 50-day-old jobs-manager that predated the alias fix,
+# authenticated against the wrong backend and crash-looped.
+#
+# THE EXISTING SUITES COULD NOT HAVE CAUGHT IT. They are thorough about dev,
+# stg, prod, unset and unknown -- and not one of them ever set `staging`. A
+# test written in the same vocabulary as the code cannot detect a vocabulary
+# mismatch with the docs. So this suite tests the ALIASES specifically.
+templates:
+  - templates/jobs-manager-deployment.yaml
+  - templates/requests-proxy-deployment.yaml
+  - templates/resource-monitor-daemonset.yaml
+  - templates/image-refresh-cronjob.yaml
+  - templates/egress-reachability-check.yaml
+release:
+  name: alias
+  namespace: tracebloc
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+  storageClass.create: false
+  # Unpinned so the image-refresh CronJob renders; a digest-pinned pair
+  # disables it (tracebloc.imageRefreshEnabled).
+  images.jobsManager.digest: ""
+  images.podsMonitor.digest: ""
+
+tests:
+  # ---- the image tags -------------------------------------------------
+  - it: "staging resolves to :stg for the jobs-manager image"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/jobs-manager:stg
+
+  - it: "staging resolves to :stg for the pods-monitor sidecar"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: docker.io/tracebloc/pods-monitor:stg
+
+  - it: "staging resolves to :stg for requests-proxy (which runs the jobs-manager image)"
+    template: templates/requests-proxy-deployment.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/jobs-manager:stg
+
+  - it: "staging resolves to :stg for the resource-monitor daemonset"
+    template: templates/resource-monitor-daemonset.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/resource-monitor:stg
+
+  - it: "production and development resolve too, not just staging"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: production
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/jobs-manager:prod
+
+  - it: "a canonical value is unchanged by resolution"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: stg
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/jobs-manager:stg
+
+  # ---- the auto-upgrade CronJob ---------------------------------------
+  # The most consequential site: this is what keeps an installed edge
+  # current, so an unpublished tag here freezes it on whatever that tag
+  # last held -- silently, forever.
+  - it: "the image-refresh CronJob refreshes against the RESOLVED tag"
+    template: templates/image-refresh-cronjob.yaml
+    # documentIndex 1: the file renders the auto-upgrade CronJob first and the
+    # image-refresh one second, same as image_refresh_test.yaml.
+    documentIndex: 1
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: IMAGE_TAG
+            value: "stg"
+
+  # ---- the egress reachability CHECK ----------------------------------
+  # Its case statement keys on dev|stg|prod with a catch-all of PROD, so an
+  # alias made it probe api.tracebloc.io and PASS for an environment the
+  # cluster never contacts. A check that verifies the wrong thing is worse
+  # than no check.
+  - it: "the egress check probes the environment the client actually uses"
+    template: templates/egress-reachability-check.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLIENT_ENV
+            value: "stg"
+
+  # ---- the value handed to the services -------------------------------
+  # client-runtime normalizes this itself, so these passed before. Pinned
+  # anyway: relying on the consumer to fix the producer's value is how the
+  # image tags -- which have no consumer to fix them -- got missed.
+  - it: "the CLIENT_ENV handed to jobs-manager is already canonical"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLIENT_ENV
+            value: "stg"

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -446,10 +446,23 @@ tests:
       - contains:
           path: spec.template.spec.initContainers[0].securityContext.capabilities.add
           content: FSETID
-      # each dir is fixed INDEPENDENTLY (a for-loop): chown 1000:1000 then chmod 3777
+      # each dir is fixed INDEPENDENTLY (a for-loop): chown 1000:1000 then chmod its OWN mode
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "for d in /data/shared /data/logs.*chown 1000:1000.*chmod 3777"
+          pattern: 'for e in /data/shared:2777 /data/logs:3777.*chown 1000:1000.*chmod'
+      # /data/shared must NOT be sticky. `data delete` removes a tree the INGEST wrote: the
+      # ingestion Job runs as uid 65534 (or HOST_UID), the CLI teardown pod as 65532. Sticky
+      # allows an unlink only by the entry's owner, the dir's owner, or root — none of which the
+      # teardown is — so sticky here made a documented operation impossible: table dropped, files
+      # stranded. fsGroup can't align them either (kubelet ignores it on hostPath, k8s#138411).
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "/data/shared:2777"
+      # ...while /data/logs KEEPS sticky: nothing has to delete another writer's logs, so the
+      # /tmp-style protection costs nothing there. Both keep setgid (2) for GID inheritance.
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "/data/logs:3777"
       # best-effort: a failing chown/chmod is logged, not fatal, so the other dir is still fixed
       # and jobs-manager still starts (e.g. /data/shared on an NFS root_squash export)
       - matchRegex:

--- a/client/tests/requests_proxy_test.yaml
+++ b/client/tests/requests_proxy_test.yaml
@@ -142,3 +142,49 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: 1Gi
+
+  # backend#1528 S2: the proxy authenticates its metadata-DB access as the
+  # dedicated tb_meta identity (metadata only — the proxy never touches the
+  # dataset DB, so no tb_ingest here). Flag-gated on serviceDbAccounts so a
+  # default install is byte-identical (mirrors the jobs-manager S1 block).
+  - it: service DB account env absent by default (byte-for-byte off)
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SERVICE_DB_ACCOUNTS
+            value: "1"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_META_USER
+            value: "tb_meta"
+
+  - it: wires the tb_meta metadata identity when serviceDbAccounts is on
+    set:
+      serviceDbAccounts: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SERVICE_DB_ACCOUNTS
+            value: "1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_META_USER
+            value: "tb_meta"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_META_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-secrets
+                key: TB_META_PASSWORD
+      # the proxy never touches the dataset DB — tb_ingest must NOT be wired here
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_INGEST_USER
+            value: "tb_ingest"

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -117,6 +117,24 @@ Training pods do **not** carry long-lived tracebloc backend credentials. The job
 
 The work to remove legacy `CLIENT_ID` / `CLIENT_PASSWORD` injection from training pods is in progress as a separate effort; see §8 for the residual risk until it lands.
 
+#### 4.1.1 MySQL database identity model
+
+The in-cluster MySQL (`mysql-client`, §3) holds two databases — `metadata` (pod tokens, Service Bus connection lookups, ingestion-run bookkeeping, per-experiment credential records) and `training_test_datasets` (the ingested dataset tables). Historically every component reached both through a single account, **`edgeuser`**, provisioned root-equivalent (`ALL PRIVILEGES ON *.* WITH GRANT OPTION`). A compromised component — or a training pod that reached MySQL — authenticating as `edgeuser` would hold the whole instance.
+
+The target model is least-privilege, one identity per job, with `edgeuser` retired. The identities:
+
+| Identity | Scope | Used by | Status |
+|---|---|---|---|
+| **per-experiment user** | `SELECT` on one experiment's physical table(s) only | training pods (injected via per-job Secret as `MYSQL_USER`/`MYSQL_PASSWORD`) | Shipped, opt-in `perExperimentDbCreds` (RFC-0003 D10, backend#1181) |
+| **`tb_credmgr`** | `CREATE USER` + `SELECT … WITH GRANT OPTION` on `training_test_datasets.*` — mints the per-experiment users, nothing else | jobs-manager | Shipped with `perExperimentDbCreds` |
+| **`tb_meta`** | `ALL PRIVILEGES` on `metadata.*` only (no `*.*`, no `GRANT OPTION`) | *(S2)* jobs-manager + requests-proxy metadata work | Minted under `serviceDbAccounts` (backend#1528 S1); not yet consumed |
+| **`tb_ingest`** | `ALL PRIVILEGES` on `training_test_datasets.*` only (no `*.*`, no `GRANT OPTION`) | *(S2)* jobs-manager dataset work + spawned ingestion Jobs | Minted under `serviceDbAccounts` (backend#1528 S1); not yet consumed |
+| **`edgeuser`** | `ALL PRIVILEGES ON *.*` — root-equivalent | jobs-manager, requests-proxy, ingestion pods (default) — **today** | Legacy; retirement in progress (§8.10) |
+
+The dedicated accounts are minted by jobs-manager at startup via runtime DDL (mirroring `ensure_tb_credmgr_account`), created `IDENTIFIED WITH mysql_native_password` so they survive the 5.7→8.4 datadir migration (backend#723), each reset to exactly its one-database grant on every startup. Minting is gated on `serviceDbAccounts` (default off) and is purely additive: until the consumers are switched over (S2), a default install authenticates exactly as it did before.
+
+**Staged retirement (backend#1528, RFC-0003 D10 close-out):** **S1** mint `tb_meta` + `tb_ingest` (done) → **S2** switch jobs-manager, requests-proxy, and spawned ingestion Jobs off the hardcoded `edgeuser` constants onto the injected identities, and re-parent the `tb_credmgr` bootstrap → **S3** `REVOKE` `edgeuser` to nothing and `DROP USER`, fleet-staged. `edgeuser` must retain `CREATE USER` + `GRANT OPTION` until the bootstrap is re-parented, so the revoke is deliberately last.
+
 ### 4.2 Network egress control (G2)
 
 **Mechanism:** Kubernetes `NetworkPolicy` selected on the `tracebloc.io/workload: training` label, which the jobs-manager attaches to every spawned training pod.
@@ -515,6 +533,19 @@ from the OS package manager (or an internal mirror) before running the
 installer, so the bootstrap uses a cosign you already trust. Documented in
 [docs/SUPPLY_CHAIN.md §6](SUPPLY_CHAIN.md#6-operator-guidance--verifying-a-release-by-hand).
 
+### 8.10 `edgeuser` MySQL root-equivalence (G1) — **security / platform, rollout in progress**
+
+The in-cluster MySQL identity `edgeuser` is provisioned root-equivalent (`ALL PRIVILEGES ON *.* WITH GRANT OPTION`) and is still, by default, the account jobs-manager, requests-proxy, and the ingestion pods authenticate as (§4.1.1). Any of those components compromised while holding `edgeuser` holds the whole MySQL instance — both the metadata DB and every customer's dataset tables.
+
+**Mechanism (backend#1528, RFC-0003 D10 close-out):** dedicated least-privilege identities — `tb_meta` (metadata DB) and `tb_ingest` (dataset DB) — that each own exactly one database, plus the already-shipped `tb_credmgr` (mints per-experiment users) and per-experiment training-pod users. See §4.1.1 for the full model.
+
+**Rollout (per fleet, staged, each step reversible until S3):**
+1. **S1 — mint (done, `serviceDbAccounts`, default off).** jobs-manager mints `tb_meta` + `tb_ingest` at startup. Additive: nothing consumes them yet, so a default install is byte-identical.
+2. **S2 — switch consumers.** Move jobs-manager and requests-proxy off the hardcoded `edgeuser` constants onto `tb_meta`/`tb_ingest`; stamp `tb_ingest` onto spawned ingestion Jobs (`DB_USER`/`DB_PASSWORD`); re-parent the `tb_credmgr` bootstrap. Verify heartbeat `information_schema` dataset visibility, not just "no exceptions" — over-revoking degrades silently.
+3. **S3 — retire.** With `perExperimentDbCreds` + `serviceDbAccounts` universally on and S2 shipped, `REVOKE` `edgeuser` to nothing and `DROP USER`. Prod-irreversible; gated on a `SHOW GRANTS FOR 'edgeuser'@'%'` snapshot as the rollback reference.
+
+**Residual until S3 completes fleet-wide:** the root-equivalent account still exists and is still the default authentication identity. `edgeuser` intentionally retains `CREATE USER` + `GRANT OPTION` until the `tb_credmgr` bootstrap is re-parented (S2), so the revoke is deliberately the last step.
+
 ---
 
 ## 9. If you suspect compromise
@@ -555,12 +586,15 @@ Cross-reference for reviewers and contributors.
 | Namespace PSA labels | [`client:templates/namespace.yaml`](../client/templates/namespace.yaml) (opt-in) |
 | Experiment scratch-path env | [`tracebloc-client:core/utils/general.py`](https://github.com/tracebloc/tracebloc-client/blob/develop/core/utils/general.py) |
 | Stripped Dockerfile CMD credentials | [`tracebloc-client:*.cpu.Dockerfile`, `*.gpu.Dockerfile`](https://github.com/tracebloc/tracebloc-client) |
+| MySQL identity minting (`tb_credmgr` / `tb_meta` / `tb_ingest`, per-experiment users) | [`client-runtime:sql_utils.ensure_*_account`](https://github.com/tracebloc/client-runtime/blob/develop/sql_utils.py) |
+| Service-account minting gate (`serviceDbAccounts`) | [`client:templates/jobs-manager-deployment.yaml`, `templates/secrets.yaml`](../client/templates/jobs-manager-deployment.yaml) |
 
 ---
 
 ## 11. Document history
 
 - **2026-04** — Initial version. Documents the training-pod sandbox as shipped in client chart ≥ 1.0.4 and client-runtime images built from `develop` at that date. Reflects the narrow threat model (trusted platform, untrusted external data scientist submissions).
+- **2026-08** — Documented the MySQL database identity model (§4.1.1) and the `edgeuser` root-equivalence retirement (§8.10) — RFC-0003 D10 close-out, backend#1528.
 
 ---
 


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Chart template changes affect image tags, auto-upgrade behavior, egress checks, and hostPath permissions on edges; service DB wiring is flag-gated but mis-enabling serviceDbAccounts depends on runtime support not fully in this diff.
> 
> **Overview**
> **Helm chart 1.9.31** fixes **`CLIENT_ENV` alias handling** (backend#1723): image tags, auto-refresh `IMAGE_TAG`, egress reachability, and injected `CLIENT_ENV` now go through **`tracebloc.clientEnv`** so values like `staging` resolve to **`stg`** instead of pulling nonexistent `:staging` images or probing the wrong API host. A dedicated **`client_env_alias_test.yaml`** suite locks this in.
> 
> **hostPath** installs change the **`init-writable-data`** init: **`/data/shared` is `2777` (setgid, no sticky)** so CLI **`data delete`** can remove ingest-owned trees across mismatched UIDs; **`/data/logs` stays `3777`**.
> 
> With **`serviceDbAccounts: true`**, **requests-proxy** gets **`tb_meta`** env (backend#1528 S2 wiring); default installs stay unchanged.
> 
> **CI/docs/tooling:** drift-checks runs on **every PR** (no `paths` filter) so the required drift status always reports; **`make install-hooks`** adds a pre-push **`make check`** hook; **CLAUDE.md** kanban notes for ticket status and bugs; **SECURITY.md** documents the MySQL identity model and **`edgeuser`** retirement path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c6e38eb7c888200e1eee1e1b490d38dc01bab4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->