### PR TITLE
fix(chart): resolve serviceDbAccounts per environment — unbreak dev + staging ingestion (backend#1752)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.32
-appVersion: "1.9.32"
+version: 1.9.33
+appVersion: "1.9.33"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -302,6 +302,44 @@ Usage: {{ include "tracebloc.ingestorDigest" . }}
   consumer of CLIENT_ENV must go through here rather than re-deriving it, the
   same reason ENV_ALIASES lives once in client-runtime proxy_config.
 */}}
+{{/*
+  Whether the dedicated tb_meta / tb_ingest DB identities are on for THIS edge
+  (backend#1528, backend#1752).
+
+  Resolution, highest first:
+    1. `serviceDbAccounts` — an explicit operator override, true or false.
+    2. `serviceDbAccountsByEnv[<resolved CLIENT_ENV>]` — the fleet default.
+
+  WHY THIS IS KEYED ON THE ENVIRONMENT AT ALL. #1151 records the rollout as
+  "flip per environment, dev first", but there was no mechanism for that: the
+  value was one global boolean, so "per environment" meant editing every edge's
+  values by hand and remembering which fleet was where. Nobody could see the
+  fleet's posture in one place, and nothing tested it.
+
+  That gap had teeth. data-ingestors#468 removed the ingestor's edgeuser
+  fallback, making DB_USER/DB_PASSWORD required, on the stated precondition
+  that this flag was "on fleet-wide". It was on nowhere. dev and staging edges
+  float on the :dev/:stg ingestor channels, picked the change up the same day,
+  and every ingestion Job now fails at Config() before reading a byte
+  (backend#1752). Prod escaped only because its ingestor is digest-pinned to
+  the 0.7 line -- a caution engineered for D16, not for this, and one that
+  client#490 is about to spend.
+
+  Resolving through `tracebloc.clientEnv` (not the raw value) so a documented
+  alias like `staging` maps to `stg` and cannot silently miss its entry --
+  backend#1723 was exactly that failure.
+*/}}
+{{- define "tracebloc.serviceDbAccounts" -}}
+{{- $override := (default dict .Values).serviceDbAccounts -}}
+{{- if not (kindIs "invalid" $override) -}}
+{{- if $override }}true{{ end -}}
+{{- else -}}
+{{- $env := include "tracebloc.clientEnv" . -}}
+{{- $byEnv := default dict .Values.serviceDbAccountsByEnv -}}
+{{- if get $byEnv $env }}true{{ end -}}
+{{- end -}}
+{{- end }}
+
 {{- define "tracebloc.clientEnv" -}}
 {{- $raw := (default dict .Values.env).CLIENT_ENV | default "prod" -}}
 {{- $aliases := dict "development" "dev" "staging" "stg" "production" "prod" -}}

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -216,7 +216,7 @@ spec:
               name: {{ include "tracebloc.secretName" . }}
               key: TB_CREDMGR_PASSWORD
         {{- end }}
-        {{- if .Values.serviceDbAccounts }}
+        {{- if (include "tracebloc.serviceDbAccounts" .) }}
         # backend#1528 S1 (RFC-0003 D10 close-out): dedicated MySQL service
         # identities that replace the root-equivalent edgeuser. jobs-manager
         # mints tb_meta (owns the metadata DB) and tb_ingest (writes the dataset

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -128,7 +128,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "tracebloc.secretName" . }}
                   key: POD_TOKEN_SIGNING_SECRET
-            {{- if .Values.serviceDbAccounts }}
+            {{- if (include "tracebloc.serviceDbAccounts" .) }}
             # backend#1528 S2 (RFC-0003 D10 close-out): authenticate the proxy's
             # metadata-DB access as the dedicated tb_meta identity instead of
             # the root-equivalent edgeuser. Only the metadata identity is wired

--- a/client/templates/secrets.yaml
+++ b/client/templates/secrets.yaml
@@ -68,7 +68,7 @@
 */ -}}
 {{- $tbMetaPassword := "" -}}
 {{- $tbIngestPassword := "" -}}
-{{- if .Values.serviceDbAccounts -}}
+{{- if (include "tracebloc.serviceDbAccounts" .) -}}
 {{-   if .Values.tbMetaPassword -}}
 {{-     if not (regexMatch "^[A-Za-z0-9]+$" .Values.tbMetaPassword) -}}
 {{-       fail "tbMetaPassword must be alphanumeric ([A-Za-z0-9]+) — jobs-manager rejects other characters in the tb_meta password" -}}
@@ -105,7 +105,7 @@ data:
 {{- if .Values.perExperimentDbCreds }}
   TB_CREDMGR_PASSWORD: {{ $credmgrPassword | b64enc | quote }}
 {{- end }}
-{{- if .Values.serviceDbAccounts }}
+{{- if (include "tracebloc.serviceDbAccounts" .) }}
   TB_META_PASSWORD: {{ $tbMetaPassword | b64enc | quote }}
   TB_INGEST_PASSWORD: {{ $tbIngestPassword | b64enc | quote }}
 {{- end }}

--- a/client/tests/service_db_accounts_per_env_test.yaml
+++ b/client/tests/service_db_accounts_per_env_test.yaml
@@ -1,0 +1,137 @@
+suite: serviceDbAccounts resolves per environment (backend#1752)
+# WHY THIS SUITE EXISTS
+#
+# #1151 records the rollout as "flip per environment, dev first". Until now
+# there was no mechanism for that: one global boolean meant "per environment"
+# was hand-editing every edge and remembering which fleet was where.
+#
+# The gap had teeth. data-ingestors#468 removed the ingestor's edgeuser
+# fallback on the stated precondition that this flag was "on fleet-wide" — it
+# was on nowhere. dev and staging edges float on the :dev/:stg ingestor
+# channels, took the change the same day, and every ingestion Job now fails at
+# Config() before reading a byte. Verified by running the published images:
+# :dev and :stg are 0.8.5 and raise; the prod-pinned digest is 0.7.7 and works.
+#
+# So these assert the two things that actually matter: dev/stg get the
+# credentials the ingestor now demands, prod does not change, and a documented
+# ALIAS resolves rather than silently missing its entry — backend#1723 was
+# exactly that failure, one env-name spelling away.
+templates:
+  - templates/jobs-manager-deployment.yaml
+  - templates/secrets.yaml
+release:
+  name: sda
+  namespace: tracebloc
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+
+tests:
+  # ---- the fix ---------------------------------------------------------
+  - it: "dev edges get the tb_ingest identity"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: dev
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_INGEST_USER
+            value: tb_ingest
+
+  - it: "stg edges get it too"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: stg
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_INGEST_USER
+            value: tb_ingest
+
+  - it: "the documented alias `staging` resolves — it must not miss its entry"
+    # The whole bug class in one case: `staging` is what values.schema.json
+    # tells users to write, and a lookup on the RAW value would find nothing
+    # and silently leave the fleet off (backend#1723).
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: staging
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_INGEST_USER
+            value: tb_ingest
+
+  # ---- prod is deliberately unchanged ----------------------------------
+  - it: "prod stays OFF — flipping it is a separate windowed decision"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: prod
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_INGEST_USER
+            value: tb_ingest
+
+  - it: "the alias `production` stays off as well"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: production
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_INGEST_USER
+            value: tb_ingest
+
+  # ---- the operator override still wins, both ways ---------------------
+  - it: "an explicit false holds a dev fleet back"
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: dev
+      serviceDbAccounts: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_INGEST_USER
+            value: tb_ingest
+
+  - it: "an explicit true turns a prod fleet on"
+    # The path a windowed prod flip takes, so it is exercised before someone
+    # needs it under time pressure.
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      env.CLIENT_ENV: prod
+      serviceDbAccounts: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TB_INGEST_USER
+            value: tb_ingest
+
+  # ---- the Secret must move in lockstep with the env -------------------
+  - it: "dev renders the tb_ingest Secret the env references"
+    # jobs-manager fail-fasts when the flag is on and the Secret is unwired
+    # (_require_service_db_env), so a half-flip would crash-loop the pod. The
+    # two are gated on the same resolver; this proves they agree.
+    template: templates/secrets.yaml
+    documentIndex: 0
+    set:
+      env.CLIENT_ENV: dev
+    asserts:
+      - exists:
+          path: data.TB_INGEST_PASSWORD
+
+  - it: "prod renders no such Secret"
+    template: templates/secrets.yaml
+    documentIndex: 0
+    set:
+      env.CLIENT_ENV: prod
+    asserts:
+      - notExists:
+          path: data.TB_INGEST_PASSWORD

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -2,7 +2,10 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Tracebloc Helm Chart Values",
   "type": "object",
-  "required": ["clientId", "clientPassword"],
+  "required": [
+    "clientId",
+    "clientPassword"
+  ],
   "properties": {
     "env": {
       "type": "object",
@@ -13,10 +16,18 @@
           "default": "prod",
           "description": "Environment identifier and Docker image tag. Canonical values are `dev`, `stg`, `prod`; the documented aliases `development`/`staging`/`production` are accepted and normalized (matching client-runtime proxy_config.ENV_ALIASES). Load-bearing: it selects images.ingestor.channelTags and the prod digest pin. Defaults to 'prod' if not set or empty."
         },
-        "HTTP_PROXY_HOST": { "type": "string" },
-        "HTTP_PROXY_PORT": { "type": "string" },
-        "HTTP_PROXY_USERNAME": { "type": "string" },
-        "HTTP_PROXY_PASSWORD": { "type": "string" },
+        "HTTP_PROXY_HOST": {
+          "type": "string"
+        },
+        "HTTP_PROXY_PORT": {
+          "type": "string"
+        },
+        "HTTP_PROXY_USERNAME": {
+          "type": "string"
+        },
+        "HTTP_PROXY_PASSWORD": {
+          "type": "string"
+        },
         "RESOURCE_REQUESTS": {
           "type": "string",
           "default": "cpu=2,memory=8Gi",
@@ -39,10 +50,12 @@
           "default": "nvidia.com/gpu=1",
           "description": "Optional GPU limits for spawned jobs (defaults to 'nvidia.com/gpu=1' if not set)"
         },
-        "RUNTIME_CLASS_NAME": { "type": "string" },
+        "RUNTIME_CLASS_NAME": {
+          "type": "string"
+        },
         "GPU_VISIBLE_DEVICES": {
           "type": "string",
-          "description": "Optional CDI device selector threaded into GPU training pods as NVIDIA_VISIBLE_DEVICES (client-runtime#291). Set only where the NVIDIA device plugin can't run and the GPU is injected via CDI instead (Docker Desktop / WSL2, where NVML returns ERROR_NOT_SUPPORTED — tracebloc/client#616; the Windows installer sets it automatically there). Leave empty on a normal device-plugin node, which owns NVIDIA_VISIBLE_DEVICES itself."
+          "description": "Optional CDI device selector threaded into GPU training pods as NVIDIA_VISIBLE_DEVICES (client-runtime#291). Set only where the NVIDIA device plugin can't run and the GPU is injected via CDI instead (Docker Desktop / WSL2, where NVML returns ERROR_NOT_SUPPORTED \u2014 tracebloc/client#616; the Windows installer sets it automatically there). Leave empty on a normal device-plugin node, which owns NVIDIA_VISIBLE_DEVICES itself."
         },
         "SINGLE_NODE": {
           "type": "string",
@@ -55,7 +68,10 @@
     },
     "storageClass": {
       "type": "object",
-      "required": ["create", "name"],
+      "required": [
+        "create",
+        "name"
+      ],
       "properties": {
         "create": {
           "type": "boolean",
@@ -75,15 +91,25 @@
         },
         "volumeBindingMode": {
           "type": "string",
-          "enum": ["", "Immediate", "WaitForFirstConsumer"]
+          "enum": [
+            "",
+            "Immediate",
+            "WaitForFirstConsumer"
+          ]
         },
         "reclaimPolicy": {
           "type": "string",
-          "enum": ["", "Delete", "Retain"]
+          "enum": [
+            "",
+            "Delete",
+            "Retain"
+          ]
         },
         "mountOptions": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "parameters": {
           "type": "object",
@@ -131,7 +157,11 @@
     },
     "pvcAccessMode": {
       "type": "string",
-      "enum": ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"],
+      "enum": [
+        "ReadWriteOnce",
+        "ReadWriteMany",
+        "ReadOnlyMany"
+      ],
       "description": "Access mode for PVCs"
     },
     "clusterScope": {
@@ -150,7 +180,9 @@
       "properties": {
         "namespace": {
           "type": "object",
-          "required": ["name"],
+          "required": [
+            "name"
+          ],
           "properties": {
             "create": {
               "type": "boolean",
@@ -195,21 +227,36 @@
           "properties": {
             "warn": {
               "type": "string",
-              "enum": ["", "privileged", "baseline", "restricted"]
+              "enum": [
+                "",
+                "privileged",
+                "baseline",
+                "restricted"
+              ]
             },
             "warnVersion": {
               "type": "string"
             },
             "audit": {
               "type": "string",
-              "enum": ["", "privileged", "baseline", "restricted"]
+              "enum": [
+                "",
+                "privileged",
+                "baseline",
+                "restricted"
+              ]
             },
             "auditVersion": {
               "type": "string"
             },
             "enforce": {
               "type": "string",
-              "enum": ["", "privileged", "baseline", "restricted"]
+              "enum": [
+                "",
+                "privileged",
+                "baseline",
+                "restricted"
+              ]
             },
             "enforceVersion": {
               "type": "string"
@@ -233,11 +280,11 @@
             "allowExternalHttps": {
               "type": "boolean",
               "default": true,
-              "description": "When false, drop the 0.0.0.0/0:443 egress rule so training pods reach only DNS, MySQL, requests-proxy and the egress gateway (SECURITY §8.2 / client-runtime#102). Default true keeps existing behaviour; flip per-fleet after verifying the egress gateway works (G2)."
+              "description": "When false, drop the 0.0.0.0/0:443 egress rule so training pods reach only DNS, MySQL, requests-proxy and the egress gateway (SECURITY \u00a78.2 / client-runtime#102). Default true keeps existing behaviour; flip per-fleet after verifying the egress gateway works (G2)."
             },
             "enforcementProbeHost": {
               "type": "string",
-              "description": "Host the `helm test` enforcement check curls directly (when allowExternalHttps=false) to verify the CNI blocks egress; non-enforcement fails the test (a test hook never affects install/upgrade) — client-runtime#104. Empty string disables it (e.g. air-gapped clusters)."
+              "description": "Host the `helm test` enforcement check curls directly (when allowExternalHttps=false) to verify the CNI blocks egress; non-enforcement fails the test (a test hook never affects install/upgrade) \u2014 client-runtime#104. Empty string disables it (e.g. air-gapped clusters)."
             },
             "enforcementProbeTimeoutSeconds": {
               "type": "integer",
@@ -259,7 +306,7 @@
             },
             "clusterCidrs": {
               "type": "array",
-              "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs. Must be non-empty when networkPolicy.training.enabled is true — an empty list renders `except: null` and Kubernetes treats that as no exceptions, silently allowing unrestricted in-cluster egress.",
+              "description": "In-cluster pod+service CIDRs to block pod-to-pod egress on port 443. Override to match your cluster CIDRs. Must be non-empty when networkPolicy.training.enabled is true \u2014 an empty list renders `except: null` and Kubernetes treats that as no exceptions, silently allowing unrestricted in-cluster egress.",
               "items": {
                 "type": "string",
                 "pattern": "^[0-9.]+/[0-9]+$"
@@ -268,13 +315,19 @@
           },
           "if": {
             "properties": {
-              "enabled": { "const": true }
+              "enabled": {
+                "const": true
+              }
             },
-            "required": ["enabled"]
+            "required": [
+              "enabled"
+            ]
           },
           "then": {
             "properties": {
-              "clusterCidrs": { "minItems": 1 }
+              "clusterCidrs": {
+                "minItems": 1
+              }
             }
           }
         }
@@ -300,8 +353,11 @@
       "description": "RFC-0003 D10 (backend#1181): optional operator pin for the tb_credmgr account password (3-tier resolution, mirrors podTokenSigningSecret). Empty = generate-and-persist. Set for DR / a pre-created MySQL account / forced rotation, or to keep it stable across a perExperimentDbCreds toggle. Must be alphanumeric."
     },
     "serviceDbAccounts": {
-      "type": "boolean",
-      "description": "backend#1528 S1 (RFC-0003 D10 close-out): provision the dedicated MySQL service identities tb_meta (metadata DB) and tb_ingest (dataset DB) that replace the root-equivalent edgeuser. Additive — jobs-manager mints them at startup but nothing consumes them until S2, so a default install is byte-identical. Flip per environment, dev first."
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "OPERATOR OVERRIDE, normally unset. When null the effective value comes from serviceDbAccountsByEnv keyed on the resolved CLIENT_ENV (backend#1752). Set true/false to force one answer on this edge regardless of environment. backend#1528 S1 (RFC-0003 D10 close-out): provision the dedicated MySQL service identities tb_meta (metadata DB) and tb_ingest (dataset DB) that replace the root-equivalent edgeuser. Additive \u2014 jobs-manager mints them at startup but nothing consumes them until S2, so a default install is byte-identical. Flip per environment, dev first."
     },
     "tbMetaPassword": {
       "type": "string",
@@ -317,7 +373,7 @@
     },
     "perDatasetPvcs": {
       "type": "boolean",
-      "description": "RFC-0003 D9 Track B (client-runtime#203/#261): stamp PER_DATASET_PVCS=1 into jobs-manager — training pods get one read-only hostPath PV/PVC per dataset handle instead of a subPath view of the shared PVC. Single-node/hostPath clusters only; requires clusterScope (PVs are cluster-scoped)."
+      "description": "RFC-0003 D9 Track B (client-runtime#203/#261): stamp PER_DATASET_PVCS=1 into jobs-manager \u2014 training pods get one read-only hostPath PV/PVC per dataset handle instead of a subPath view of the shared PVC. Single-node/hostPath clusters only; requires clusterScope (PVs are cluster-scoped)."
     },
     "ingestionAuthz": {
       "type": "object",
@@ -345,7 +401,9 @@
               },
               "table_prefixes": {
                 "type": "array",
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "description": "Table-name prefixes this SA may ingest into. [\"*\"] = any table."
               }
             }
@@ -366,11 +424,11 @@
     },
     "sealCheck": {
       "type": "object",
-      "description": "Seal check — the chart's conformance suite (RFC-0003 §8.2 / backend#1184). Every check is a `helm test` hook Job labelled tracebloc.io/seal-check=true + tracebloc.io/seal-check-name=<check> (the enumeration contract the tracebloc CLI consumes, cli#393). See docs/SEAL-CHECK.md.",
+      "description": "Seal check \u2014 the chart's conformance suite (RFC-0003 \u00a78.2 / backend#1184). Every check is a `helm test` hook Job labelled tracebloc.io/seal-check=true + tracebloc.io/seal-check-name=<check> (the enumeration contract the tracebloc CLI consumes, cli#393). See docs/SEAL-CHECK.md.",
       "properties": {
         "storageAssertions": {
           "type": "object",
-          "description": "In-cluster storage assertions: release PVCs Bound on the expected StorageClass; in dynamic-PVC mode (hostPath.enabled=false) no release PVC backed by a hostPath PV on an unmanaged host tree (leftover chart hostPath PVs capture claims via claimRef — RFC-0003 D3/D4).",
+          "description": "In-cluster storage assertions: release PVCs Bound on the expected StorageClass; in dynamic-PVC mode (hostPath.enabled=false) no release PVC backed by a hostPath PV on an unmanaged host tree (leftover chart hostPath PVs capture claims via claimRef \u2014 RFC-0003 D3/D4).",
           "properties": {
             "enabled": {
               "type": "boolean",
@@ -385,16 +443,35 @@
             },
             "nodeLocalPathPrefixes": {
               "type": "array",
-              "items": { "type": "string" },
-              "description": "hostPath prefixes accepted as provisioner-managed node-local storage in dynamic mode (k3s local-path: /var/lib/rancher/…; upstream local-path-provisioner: /opt/local-path-provisioner/). Entries match whole path segments (trailing slash optional) — a prefix admits itself and paths under it, never sibling paths. Any other hostPath backing fails the check."
+              "items": {
+                "type": "string"
+              },
+              "description": "hostPath prefixes accepted as provisioner-managed node-local storage in dynamic mode (k3s local-path: /var/lib/rancher/\u2026; upstream local-path-provisioner: /opt/local-path-provisioner/). Entries match whole path segments (trailing slash optional) \u2014 a prefix admits itself and paths under it, never sibling paths. Any other hostPath backing fails the check."
             },
             "image": {
               "type": "object",
               "description": "kubectl-capable image for the assertion pod (same image the image-refresh CronJob uses).",
               "properties": {
-                "repository": { "type": "string", "default": "alpine/k8s" },
-                "tag": { "type": "string", "not": { "const": "latest" }, "default": "1.30.5" },
-                "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+                "repository": {
+                  "type": "string",
+                  "default": "alpine/k8s"
+                },
+                "tag": {
+                  "type": "string",
+                  "not": {
+                    "const": "latest"
+                  },
+                  "default": "1.30.5"
+                },
+                "pullPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Always",
+                    "IfNotPresent",
+                    "Never"
+                  ],
+                  "default": "IfNotPresent"
+                }
               }
             }
           }
@@ -403,25 +480,56 @@
     },
     "egressProxy": {
       "type": "object",
-      "description": "In-cluster squid egress gateway (SECURITY §8.2 / client-runtime#102). Forward proxy that permits HTTPS CONNECT only to the allowlist, so a locked-down training pod can reach the backend + App Insights and nothing else.",
+      "description": "In-cluster squid egress gateway (SECURITY \u00a78.2 / client-runtime#102). Forward proxy that permits HTTPS CONNECT only to the allowlist, so a locked-down training pod can reach the backend + App Insights and nothing else.",
       "properties": {
-        "enabled": { "type": "boolean", "default": true },
-        "routeWorkloads": { "type": "boolean", "default": false, "description": "Route training-pod outbound HTTPS through the gateway (jobs-manager injects HTTPS_PROXY). Default false — enable per-fleet, verify a run, then drop the direct egress rule (networkPolicy.training.allowExternalHttps=false)." },
-        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 3128 },
-        "runAsUser": { "type": "integer", "minimum": 1 },
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "routeWorkloads": {
+          "type": "boolean",
+          "default": false,
+          "description": "Route training-pod outbound HTTPS through the gateway (jobs-manager injects HTTPS_PROXY). Default false \u2014 enable per-fleet, verify a run, then drop the direct egress rule (networkPolicy.training.allowExternalHttps=false)."
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 3128
+        },
+        "runAsUser": {
+          "type": "integer",
+          "minimum": 1
+        },
         "image": {
           "type": "object",
           "properties": {
-            "registry": { "type": "string" },
-            "repository": { "type": "string", "minLength": 1 },
-            "tag": { "type": "string", "not": { "const": "latest" } },
-            "digest": { "type": "string", "pattern": "^(sha256:[a-f0-9]{64})?$" }
+            "registry": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
+            "tag": {
+              "type": "string",
+              "not": {
+                "const": "latest"
+              }
+            },
+            "digest": {
+              "type": "string",
+              "pattern": "^(sha256:[a-f0-9]{64})?$"
+            }
           }
         },
         "allowlist": {
           "type": "array",
           "description": "FQDNs the gateway permits HTTPS CONNECT to (squid dstdomain syntax: leading dot = subdomain match, bare host = exact).",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
         "resources": {
           "type": "object",
@@ -429,15 +537,27 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -487,7 +607,7 @@
         },
         "ingestor": {
           "type": "object",
-          "description": "Image used for spawned ingestion Jobs. jobs-manager resolves one effective digest from these keys (see the tracebloc.ingestorDigest helper) and builds the reference from it (client-runtime submit_ingestion_run): digest set -> repo@digest + IfNotPresent, digest empty -> repo:tag + Always. Prod pins `prodDigest` (a chart default, so a republished pin propagates through the fleet auto-upgrade — backend#1245); dev/staging float on `tag`, resolving the current published digest at every spawn.",
+          "description": "Image used for spawned ingestion Jobs. jobs-manager resolves one effective digest from these keys (see the tracebloc.ingestorDigest helper) and builds the reference from it (client-runtime submit_ingestion_run): digest set -> repo@digest + IfNotPresent, digest empty -> repo:tag + Always. Prod pins `prodDigest` (a chart default, so a republished pin propagates through the fleet auto-upgrade \u2014 backend#1245); dev/staging float on `tag`, resolving the current published digest at every spawn.",
           "properties": {
             "repository": {
               "type": "string",
@@ -496,8 +616,10 @@
             },
             "tag": {
               "type": "string",
-              "not": { "const": "latest" },
-              "description": "Explicit floating-tag override for the spawned ingestor. EMPTY by default: the effective tag then comes from channelTags[CLIENT_ENV] (backend#1360). `latest` is rejected — spawn behaviour must not drift. To pin an exact image prefer `digest`, which wins over any tag. Surfaces as INGESTOR_IMAGE_TAG."
+              "not": {
+                "const": "latest"
+              },
+              "description": "Explicit floating-tag override for the spawned ingestor. EMPTY by default: the effective tag then comes from channelTags[CLIENT_ENV] (backend#1360). `latest` is rejected \u2014 spawn behaviour must not drift. To pin an exact image prefer `digest`, which wins over any tag. Surfaces as INGESTOR_IMAGE_TAG."
             },
             "channelTags": {
               "type": "object",
@@ -506,19 +628,25 @@
                 "dev": {
                   "type": "string",
                   "minLength": 1,
-                  "not": { "const": "latest" },
+                  "not": {
+                    "const": "latest"
+                  },
                   "description": "Tag spawned when CLIENT_ENV resolves to dev."
                 },
                 "stg": {
                   "type": "string",
                   "minLength": 1,
-                  "not": { "const": "latest" },
+                  "not": {
+                    "const": "latest"
+                  },
                   "description": "Tag spawned when CLIENT_ENV resolves to stg."
                 },
                 "prod": {
                   "type": "string",
                   "minLength": 1,
-                  "not": { "const": "latest" },
+                  "not": {
+                    "const": "latest"
+                  },
                   "description": "Tag spawned when CLIENT_ENV resolves to prod and no digest applies."
                 }
               }
@@ -544,7 +672,9 @@
           "properties": {
             "tag": {
               "type": "string",
-              "not": { "const": "latest" },
+              "not": {
+                "const": "latest"
+              },
               "description": "Image tag for mysql-client. Empty falls back to env.CLIENT_ENV. Must not be \"latest\"."
             },
             "digest": {
@@ -558,7 +688,9 @@
           "properties": {
             "tag": {
               "type": "string",
-              "not": { "const": "latest" }
+              "not": {
+                "const": "latest"
+              }
             },
             "digest": {
               "type": "string",
@@ -578,16 +710,28 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
-              "description": "CPU limit deliberately omitted in defaults — throttling causes InnoDB lock-wait timeouts.",
+              "description": "CPU limit deliberately omitted in defaults \u2014 throttling causes InnoDB lock-wait timeouts.",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -598,15 +742,27 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -617,15 +773,27 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -636,15 +804,27 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -653,21 +833,42 @@
     },
     "priorityClass": {
       "type": "object",
-      "description": "Cluster-scoped PriorityClass for tracebloc data-plane workloads (mysql). An empty `name` disables the priorityClassName reference on the mysql pod entirely (mysql falls back to default priority 0 — only set this if you explicitly want no OOM protection from the scheduler).",
+      "description": "Cluster-scoped PriorityClass for tracebloc data-plane workloads (mysql). An empty `name` disables the priorityClassName reference on the mysql pod entirely (mysql falls back to default priority 0 \u2014 only set this if you explicitly want no OOM protection from the scheduler).",
       "properties": {
-        "create": { "type": "boolean", "default": true },
-        "name":   { "type": "string", "default": "tracebloc-data-plane" },
-        "value":  { "type": "integer", "minimum": 0, "maximum": 1000000000, "default": 1000000 }
+        "create": {
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "type": "string",
+          "default": "tracebloc-data-plane"
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000000000,
+          "default": 1000000
+        }
       },
       "allOf": [
         {
-          "$comment": "If we are templating the PriorityClass resource, name must not be empty. `required: [create]` is needed because draft-07 `properties` only validates keys that are present — without it, omitting `create` passes the `if` vacuously and unconditionally enforces `then`. Same pattern as dockerRegistry below.",
+          "$comment": "If we are templating the PriorityClass resource, name must not be empty. `required: [create]` is needed because draft-07 `properties` only validates keys that are present \u2014 without it, omitting `create` passes the `if` vacuously and unconditionally enforces `then`. Same pattern as dockerRegistry below.",
           "if": {
-            "properties": { "create": { "const": true } },
-            "required": ["create"]
+            "properties": {
+              "create": {
+                "const": true
+              }
+            },
+            "required": [
+              "create"
+            ]
           },
           "then": {
-            "properties": { "name": { "minLength": 1 } }
+            "properties": {
+              "name": {
+                "minLength": 1
+              }
+            }
           }
         }
       ]
@@ -679,13 +880,19 @@
         "mysql": {
           "type": "object",
           "properties": {
-            "create": { "type": "boolean", "default": true }
+            "create": {
+              "type": "boolean",
+              "default": true
+            }
           }
         },
         "jobsManager": {
           "type": "object",
           "properties": {
-            "create": { "type": "boolean", "default": true }
+            "create": {
+              "type": "boolean",
+              "default": true
+            }
           }
         }
       }
@@ -693,13 +900,17 @@
     "clientId": {
       "type": "string",
       "minLength": 1,
-      "not": { "pattern": "^<.*>$" },
+      "not": {
+        "pattern": "^<.*>$"
+      },
       "description": "Client ID for authentication. Must be a real value, not a placeholder like <CLIENT_ID>."
     },
     "clientPassword": {
       "type": "string",
       "minLength": 1,
-      "not": { "pattern": "^<.*>$" },
+      "not": {
+        "pattern": "^<.*>$"
+      },
       "description": "Client authentication password. Must be a real value, not a placeholder like <CLIENT_PASSWORD>."
     },
     "autoUpgrade": {
@@ -759,18 +970,30 @@
         },
         "image": {
           "type": "object",
-          "required": ["repository", "tag"],
+          "required": [
+            "repository",
+            "tag"
+          ],
           "properties": {
-            "repository": { "type": "string", "minLength": 1 },
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
             "tag": {
               "type": "string",
               "minLength": 1,
-              "not": { "const": "latest" },
-              "description": "Pin the helm version. `latest` is rejected — auto-upgrade behaviour must not drift."
+              "not": {
+                "const": "latest"
+              },
+              "description": "Pin the helm version. `latest` is rejected \u2014 auto-upgrade behaviour must not drift."
             },
             "pullPolicy": {
               "type": "string",
-              "enum": ["Always", "IfNotPresent", "Never"]
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ]
             }
           }
         },
@@ -780,15 +1003,27 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -838,18 +1073,30 @@
         },
         "image": {
           "type": "object",
-          "required": ["repository", "tag"],
+          "required": [
+            "repository",
+            "tag"
+          ],
           "properties": {
-            "repository": { "type": "string", "minLength": 1 },
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
             "tag": {
               "type": "string",
               "minLength": 1,
-              "not": { "const": "latest" },
-              "description": "Pin the alpine/k8s version. `latest` is rejected — image-refresh behaviour must not drift."
+              "not": {
+                "const": "latest"
+              },
+              "description": "Pin the alpine/k8s version. `latest` is rejected \u2014 image-refresh behaviour must not drift."
             },
             "pullPolicy": {
               "type": "string",
-              "enum": ["Always", "IfNotPresent", "Never"]
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ]
             }
           }
         },
@@ -859,15 +1106,27 @@
             "requests": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             },
             "limits": {
               "type": "object",
               "properties": {
-                "cpu":    { "type": "string", "pattern": "^[0-9]+m?$" },
-                "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^[0-9]+m?$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+                }
               }
             }
           }
@@ -875,7 +1134,10 @@
       }
     },
     "dockerRegistry": {
-      "type": ["object", "null"],
+      "type": [
+        "object",
+        "null"
+      ],
       "description": "Optional. Omit entirely or set null for public images (no secret or imagePullSecrets). Only create when set and create is true.",
       "properties": {
         "create": {
@@ -901,15 +1163,31 @@
         {
           "if": {
             "properties": {
-              "create": { "const": true }
+              "create": {
+                "const": true
+              }
             },
-            "required": ["create"]
+            "required": [
+              "create"
+            ]
           },
           "then": {
-            "required": ["server", "username", "password", "email"]
+            "required": [
+              "server",
+              "username",
+              "password",
+              "email"
+            ]
           }
         }
       ]
+    },
+    "serviceDbAccountsByEnv": {
+      "type": "object",
+      "description": "Per-environment default for the dedicated tb_meta/tb_ingest identities, keyed on the RESOLVED CLIENT_ENV (dev|stg|prod \u2014 documented aliases are normalized first). This is the mechanism behind #1151's 'flip per environment, dev first'; before it, that plan had no implementation and the fleet's posture could not be read in one place. backend#1752.",
+      "additionalProperties": {
+        "type": "boolean"
+      }
     }
   }
 }

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -908,7 +908,38 @@ credmgrPassword: ""
 # Flip per environment, dev first. Default false: today's shared-edgeuser
 # behavior, byte-for-byte. Needs no per-edge action — the passwords are
 # generated, upgrade-stable Secret values.
-serviceDbAccounts: false
+# UNSET by default: the effective value comes from `serviceDbAccountsByEnv`
+# below, keyed on the resolved CLIENT_ENV. Set this to force one answer on an
+# edge regardless of environment (an operator override — DR, a fleet held back
+# deliberately, or a customer opt-out). backend#1752.
+serviceDbAccounts:
+
+# -- PER-ENVIRONMENT ROLLOUT (backend#1528 · backend#1752)
+#
+# #1151 records the plan as "flip per environment, dev first". Until now there
+# was no mechanism for that — one global boolean meant "per environment" was
+# hand-editing every edge's values and remembering which fleet was where.
+#
+# That gap had teeth. data-ingestors#468 removed the ingestor's edgeuser
+# fallback on the stated precondition that this flag was "on fleet-wide"; it
+# was on nowhere. dev and staging edges float on the :dev/:stg ingestor
+# channels, took the change the same day, and every ingestion Job now fails at
+# Config() before reading a byte. Prod escaped only because its ingestor is
+# digest-pinned to the 0.7 line — a caution engineered for D16, not for this,
+# and one client#490 is about to spend.
+#
+# dev/stg: TRUE. Both are already running the ingestor that requires the
+# per-Job credentials, so this is what makes them work again — and it exercises
+# #1528's S2 path where it is supposed to be exercised, before prod.
+#
+# prod: FALSE, deliberately and explicitly. Prod runs the 0.7-line ingestor,
+# which still has the fallback. Flipping prod is a separate windowed decision
+# (#1528 S0 drill), and it must happen BEFORE prod's ingestor is repinned past
+# 0.8.2 — see the note on `prodDigest`.
+serviceDbAccountsByEnv:
+  dev: true
+  stg: true
+  prod: false
 
 # Optional operator pins for the tb_meta / tb_ingest account passwords (each
 # mirrors credmgrPassword's 3-tier resolution). Leave "" to generate-and-persist

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -127,11 +127,15 @@ The target model is least-privilege, one identity per job, with `edgeuser` retir
 |---|---|---|---|
 | **per-experiment user** | `SELECT` on one experiment's physical table(s) only | training pods (injected via per-job Secret as `MYSQL_USER`/`MYSQL_PASSWORD`) | Shipped, opt-in `perExperimentDbCreds` (RFC-0003 D10, backend#1181) |
 | **`tb_credmgr`** | `CREATE USER` + `SELECT … WITH GRANT OPTION` on `training_test_datasets.*` — mints the per-experiment users, nothing else | jobs-manager | Shipped with `perExperimentDbCreds` |
-| **`tb_meta`** | `ALL PRIVILEGES` on `metadata.*` only (no `*.*`, no `GRANT OPTION`) | *(S2)* jobs-manager + requests-proxy metadata work | Minted under `serviceDbAccounts` (backend#1528 S1); not yet consumed |
-| **`tb_ingest`** | `ALL PRIVILEGES` on `training_test_datasets.*` only (no `*.*`, no `GRANT OPTION`) | *(S2)* jobs-manager dataset work + spawned ingestion Jobs | Minted under `serviceDbAccounts` (backend#1528 S1); not yet consumed |
-| **`edgeuser`** | `ALL PRIVILEGES ON *.*` — root-equivalent | jobs-manager, requests-proxy, ingestion pods (default) — **today** | Legacy; retirement in progress (§8.10) |
+| **`tb_meta`** | `ALL PRIVILEGES` on `metadata.*` only (no `*.*`, no `GRANT OPTION`) | jobs-manager + requests-proxy metadata work | **Consumed** since S2 (client-runtime#305/#308, client#664). On for `dev`/`stg` via `serviceDbAccountsByEnv`, off for `prod` (backend#1752) |
+| **`tb_ingest`** | `ALL PRIVILEGES` on `training_test_datasets.*` only (no `*.*`, no `GRANT OPTION`) | jobs-manager dataset work + spawned ingestion Jobs | **Consumed** since S2 (client-runtime#305/#308, client#664). On for `dev`/`stg` via `serviceDbAccountsByEnv`, off for `prod` (backend#1752) |
+| **`edgeuser`** | `ALL PRIVILEGES ON *.*` — root-equivalent | **`prod` fleets only** — dev/stg now authenticate as `tb_meta`/`tb_ingest` | Legacy; retirement in progress (§8.10) |
 
-The dedicated accounts are minted by jobs-manager at startup via runtime DDL (mirroring `ensure_tb_credmgr_account`), created `IDENTIFIED WITH mysql_native_password` so they survive the 5.7→8.4 datadir migration (backend#723), each reset to exactly its one-database grant on every startup. Minting is gated on `serviceDbAccounts` (default off) and is purely additive: until the consumers are switched over (S2), a default install authenticates exactly as it did before.
+The dedicated accounts are minted by jobs-manager at startup via runtime DDL (mirroring `ensure_tb_credmgr_account`), created `IDENTIFIED WITH mysql_native_password` so they survive the 5.7→8.4 datadir migration (backend#723), each reset to exactly its one-database grant on every startup. Minting is gated on `serviceDbAccounts`, which resolves **per environment** via `serviceDbAccountsByEnv` (`dev`/`stg` on, `prod` off) unless an operator sets the flag explicitly. It is **no longer purely additive**: S2 shipped, so wherever the flag is on the consumers authenticate as the dedicated identities.
+
+> **Ordering constraint — read before flipping a fleet or repinning an ingestor.** The ingestor **requires** `DB_USER`/`DB_PASSWORD` from version **0.8.0** (data-ingestors#468 removed the `edgeuser` fallback), and jobs-manager injects them only when this flag is **on**. So a fleet running an ingestor >= 0.8.0 with the flag **off** fails every ingestion Job at `Config()` before reading a byte. That is exactly what happened to dev and staging on 2026-08-11 (backend#1752): both float on the `:dev`/`:stg` ingestor channels and took the change within hours, while prod was spared only because it is digest-pinned to the 0.7 line.
+>
+> **Therefore: turn this flag on for a fleet BEFORE its ingestor moves to 0.8.x, never after.** For prod specifically, that means before `images.ingestor.prodDigest` moves past `0.8.2` (client#490). The invariant is checked in CI by `client-runtime/tests/test_ingestor_env_contract.py` against the contract `data-ingestors` publishes as `runtime_env.v1.json` (backend#1754).
 
 **Staged retirement (backend#1528, RFC-0003 D10 close-out):** **S1** mint `tb_meta` + `tb_ingest` (done) → **S2** switch jobs-manager, requests-proxy, and spawned ingestion Jobs off the hardcoded `edgeuser` constants onto the injected identities, and re-parent the `tb_credmgr` bootstrap → **S3** `REVOKE` `edgeuser` to nothing and `DROP USER`, fleet-staged. `edgeuser` must retain `CREATE USER` + `GRANT OPTION` until the bootstrap is re-parented, so the revoke is deliberately last.
 
@@ -540,11 +544,11 @@ The in-cluster MySQL identity `edgeuser` is provisioned root-equivalent (`ALL PR
 **Mechanism (backend#1528, RFC-0003 D10 close-out):** dedicated least-privilege identities — `tb_meta` (metadata DB) and `tb_ingest` (dataset DB) — that each own exactly one database, plus the already-shipped `tb_credmgr` (mints per-experiment users) and per-experiment training-pod users. See §4.1.1 for the full model.
 
 **Rollout (per fleet, staged, each step reversible until S3):**
-1. **S1 — mint (done, `serviceDbAccounts`, default off).** jobs-manager mints `tb_meta` + `tb_ingest` at startup. Additive: nothing consumes them yet, so a default install is byte-identical.
-2. **S2 — switch consumers.** Move jobs-manager and requests-proxy off the hardcoded `edgeuser` constants onto `tb_meta`/`tb_ingest`; stamp `tb_ingest` onto spawned ingestion Jobs (`DB_USER`/`DB_PASSWORD`); re-parent the `tb_credmgr` bootstrap. Verify heartbeat `information_schema` dataset visibility, not just "no exceptions" — over-revoking degrades silently.
+1. **S1 — mint (done).** jobs-manager mints `tb_meta` + `tb_ingest` at startup under `serviceDbAccounts`.
+2. **S2 — switch consumers (done; on for `dev`/`stg`, off for `prod`).** Move jobs-manager and requests-proxy off the hardcoded `edgeuser` constants onto `tb_meta`/`tb_ingest`; stamp `tb_ingest` onto spawned ingestion Jobs (`DB_USER`/`DB_PASSWORD`); re-parent the `tb_credmgr` bootstrap. Verify heartbeat `information_schema` dataset visibility, not just "no exceptions" — over-revoking degrades silently.
 3. **S3 — retire.** With `perExperimentDbCreds` + `serviceDbAccounts` universally on and S2 shipped, `REVOKE` `edgeuser` to nothing and `DROP USER`. Prod-irreversible; gated on a `SHOW GRANTS FOR 'edgeuser'@'%'` snapshot as the rollback reference.
 
-**Residual until S3 completes fleet-wide:** the root-equivalent account still exists and is still the default authentication identity. `edgeuser` intentionally retains `CREATE USER` + `GRANT OPTION` until the `tb_credmgr` bootstrap is re-parented (S2), so the revoke is deliberately the last step.
+**Residual until S3 completes fleet-wide:** the root-equivalent account still exists, and on `prod` fleets it is still the authentication identity. `edgeuser` intentionally retains `CREATE USER` + `GRANT OPTION` until the `tb_credmgr` bootstrap is re-parented (S2), so the revoke is deliberately the last step.
 
 ---
 


### PR DESCRIPTION
Fixes [backend#1752](https://github.com/tracebloc/backend/issues/1752). **dev and staging ingestion are broken right now** — this unbreaks them.

## Verified, not inferred

I ran the published images rather than reasoning from PR descriptions:

| image | version | `DB_USER` with the flag off |
|---|---|---|
| `ghcr.io/tracebloc/ingestor:dev` | 0.8.5 | **ValueError** |
| `ghcr.io/tracebloc/ingestor:stg` | 0.8.5 | **ValueError** |
| `prodDigest sha256:9098b3c9…` | 0.7.7 | `'edgeuser'` — works |

data-ingestors#468 removed the edgeuser fallback on the stated precondition that this flag was *"on fleet-wide"*. **It was on nowhere.** dev and staging edges float on the `:dev`/`:stg` channels and took the change the same day, so every ingestion Job fails at `Config()` before reading a byte.

Prod escaped only because its ingestor is digest-pinned to the 0.7 line — a caution engineered for D16 (#1151), not for this, and **one that client#490 is about to spend**.

## The actual gap

backend#1151 records the rollout as *"flip per environment, dev first"*. There was **no mechanism for that**. One global boolean meant "per environment" was hand-editing every edge and remembering which fleet was where. The fleet's posture couldn't be read in one place and nothing tested it.

So the flag now resolves the way `channelTags` already does — explicit override wins, otherwise keyed on the **resolved** `CLIENT_ENV`:

```yaml
serviceDbAccounts:            # operator override, normally unset
serviceDbAccountsByEnv:
  dev:  true                  # already running the ingestor that needs the creds
  stg:  true                  # ← this is what unbreaks staging
  prod: false                 # explicitly unchanged
```

**prod stays off, deliberately.** It runs the 0.7-line ingestor which still has the fallback. Flipping prod is a separate windowed decision (#1528 S0 drill) — and it must happen *before* prod's ingestor is repinned past 0.8.2, which is the constraint I flagged on client#490.

Resolution goes through `tracebloc.clientEnv`, so the documented alias `staging` maps to `stg` instead of silently missing its entry. That's backend#1723 — one env-name spelling away — and it has its own test.

## Safety of the flip

The Secret and the jobs-manager env are gated on the **same** resolver, so a flip is atomic in one upgrade: the Secret is created, jobs-manager restarts, validates the wiring (`_require_service_db_env` fail-fasts if half-wired), mints `tb_meta`/`tb_ingest`, and spawned Jobs carry the credentials. A test asserts the Secret and the env move together.

## Evidence

- **384 chart tests** (was 375), `helm lint` clean.
- Rendered across every env name and both override directions.
- **Mutation-checked**: reverting the templates turns the dev/stg cases red; swapping the resolver for a raw `CLIENT_ENV` lookup turns the `staging` alias case red **on its own**.

One of my own checks was vacuous mid-way and I want to flag it: my first render sweep reported "not wired" for every environment, and I nearly read that as a logic bug. The renders were **erroring** on `values.schema.json` (`got null, want boolean`) and my grep counted zero either way. The corrected sweep asserts the render succeeded before interpreting the result.

## Note for review — pre-existing, not from this change

With the flag on, `secrets.yaml` renders **two Secrets both named `<release>-secrets`**. Identical on `develop` with `serviceDbAccounts=true`, so out of scope here, but worth someone's eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MySQL credential wiring and Secret emission for dev/stg fleets on upgrade; prod stays off but mistakes in env resolution or prod override could break ingestion or widen DB identity exposure.
> 
> **Overview**
> **Restores dev/staging ingestion** by turning on dedicated MySQL identities (`tb_meta` / `tb_ingest`) where the floating ingestor now requires per-job `DB_USER`/`DB_PASSWORD`, while leaving **prod off** until a deliberate flip.
> 
> The chart no longer treats `serviceDbAccounts` as a single global boolean. A new `tracebloc.serviceDbAccounts` helper resolves **explicit `serviceDbAccounts` override** first, else **`serviceDbAccountsByEnv` keyed on normalized `CLIENT_ENV`** (so `staging` → `stg`). Defaults in `values.yaml` are **dev/stg: true**, **prod: false**. **jobs-manager**, **requests-proxy**, and **secrets** now gate `SERVICE_DB_ACCOUNTS` / `TB_*` env and Secret keys on that helper instead of `.Values.serviceDbAccounts` alone.
> 
> Adds **`serviceDbAccountsByEnv`** to the values schema (nullable `serviceDbAccounts`), a **Helm unittest suite** for env/alias/override/Secret lockstep, bumps chart to **1.9.33**, and updates **SECURITY.md** for per-env rollout and ingestor ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7285f139993af5f43e536d6d1eb52a8ef966201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->