### PR TITLE
fix(k3s-cuda): stop the --exclude diagnostic from killing its own error path (#656)

### DIFF
--- a/docker/k3s-cuda/build.sh
+++ b/docker/k3s-cuda/build.sh
@@ -48,7 +48,18 @@ docker export "${cid}" | tar -tf - > "${rootfs}"
 docker rm -f "${cid}" >/dev/null
 if grep -qE '(^|/)--exclude' "${rootfs}"; then
   echo "ERROR: image contains a '--exclude' path — COPY --exclude was mis-parsed as a destination:" >&2
-  grep -E '(^|/)--exclude' "${rootfs}" | head >&2
+  # Here-string, NOT `grep … | head >&2`: under this script's `set -euo pipefail`
+  # head closes the pipe after its 10th line, so a rootfs with enough matching
+  # paths to push grep's output past the ~64KB pipe buffer makes grep take
+  # SIGPIPE → the pipeline exits 141 → errexit aborts HERE, skipping the
+  # `rm -f` below and the intended `exit 1`: the diagnostic killed the error
+  # path it exists to explain, leaking the extracted rootfs and reporting 141
+  # instead of 1. Measured: 50 matching lines exit 1 (fits the buffer, no
+  # signal), 20k exit 141. Same idiom and reasoning as
+  # scripts/lib/install-client-helm.sh (see its herestring note) and the rc=141
+  # case in .github's conformance-gate.
+  matches="$(grep -E '(^|/)--exclude' "${rootfs}" || true)"
+  head -n 10 <<< "${matches}" >&2
   rm -f "${rootfs}"; exit 1
 fi
 # k3s lands at usr/bin/k3s (copied into /usr/bin via the kept /bin symlink) or bin/k3s.


### PR DESCRIPTION
Closes #656. The ticket's **flap-lockout half is already fixed** on develop (`image-refresh-cronjob.yaml` clears the flap annotation once a rollout settles), so this is the remaining pipefail half.

## The bug

`docker/k3s-cuda/build.sh` runs under `set -euo pipefail`, and the verify branch printed its findings with:

```sh
grep -E '(^|/)--exclude' "${rootfs}" | head >&2
rm -f "${rootfs}"; exit 1
```

`head` closes the pipe after 10 lines. Once the matching set outgrows the ~64KB pipe buffer, `grep` takes **SIGPIPE (141)**, `pipefail` propagates it, and `errexit` aborts **before** the `rm -f` cleanup and before the intended `exit 1`.

So the diagnostic killed the error path it was added to explain: the extracted rootfs leaks, and the build reports **141 instead of 1**.

**Why it hid: it's size-dependent.** Measured — 50 matching lines exit **1** (output fits the buffer, no signal), 20k matching lines exit **141**. A small corrupted image looks fine; a badly corrupted one loses both the cleanup and the exit code.

## The fix

Switched to the **house here-string idiom** rather than bolting `|| true` onto the pipeline. This repo already documents this precise mechanism in four places — `scripts/lib/install-client-helm.sh` ("Herestring, NOT `printf … | head -n 3`", same ~64KB / rc=141 reasoning), `scripts/lib/cluster.sh`, `scripts/check-facts.sh`, and `.github`'s conformance-gate. `build.sh` was simply a straggler that missed the memo, so it now matches the established pattern instead of inventing a second one.

## Verification

| | |
|---|---|
| new shape, 20k matching lines | **exit 1**, rootfs cleaned up ✅ |
| old shape, same input | exit 141, cleanup skipped |
| `shellcheck -S warning` / `bash -n` | clean |

## Follow-up (not in this PR)

The same scan turned up other `\| head` pipelines under `pipefail` that may carry the same hazard — `scripts/install.sh:538`, `scripts/tests/check-drift.sh:77,123`, `docs/migration-tools/migrate-tenant.sh:242`. Most look benign (tiny outputs), but "benign because the output is small today" is exactly how this one survived. Filed separately rather than widened into this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow shell fix on a build-script error diagnostic only; verification logic and success path are unchanged.
> 
> **Overview**
> Fixes the k3s-CUDA image rootfs verify error path so a large `--exclude` match set no longer aborts under `pipefail` before cleanup.
> 
> In `docker/k3s-cuda/build.sh`, replaces `grep … | head` with the repo’s here-string idiom (`matches="$(grep … || true)"` then `head <<< "${matches}"`). That stops `head` from SIGPIPEing `grep` (exit **141**), so the path still prints diagnostics, removes the temp rootfs, and exits **1** as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e19fdd949e523b6c0228f47565b11cce031e165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->