### PR TITLE
chore(makefile): derive the bats test count instead of hardcoding it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,23 @@ SHELLCHECK_FILES := \
 	scripts/tests/lib/e2e-common.sh \
 	scripts/tests/path-persist.sh
 
+# The bats total, DERIVED — never written down. It moves on most PRs that add a
+# test, nothing enforces it, and the help text had drifted from its hardcoded
+# 868 to a real 946 with nobody noticing. A number that is wrong is worse than
+# no number, and re-hardcoding today's value only resets the drift clock.
+#
+# `=`, not `:=`: recursively expanded, so the grep runs only when `help` actually
+# prints it. `make check` is the pre-push path with a sub-60 s budget and never
+# pays for it. bats declares one test per `@test` at line start, so this matches
+# `bats`'s own count exactly (verified: 946 = 946).
+BATS_TEST_COUNT = $(shell grep -h '^@test' scripts/tests/*.bats 2>/dev/null | wc -l | tr -d ' ')
+
 .PHONY: help
 help:
 	@echo "tracebloc/client — make targets"
 	@echo
 	@echo "  check       lint + fast checks (~4 s) — run this before every push"
-	@echo "  check-all   everything CI runs locally, including the 868-test bats suite"
+	@echo "  check-all   everything CI runs locally, including the $(BATS_TEST_COUNT)-test bats suite"
 	@echo "  setup       check for / point at the tools these targets need; installs the pre-push hook"
 	@echo "  install-hooks  (re)install the git pre-push hook that runs 'make check'"
 	@echo
@@ -58,12 +69,12 @@ help:
 # drift guards 0.2 s, helm lint 0.7 s.
 #
 # The bats suite is deliberately NOT here. It is the repo's real unit
-# suite (868 tests) and it takes ~2 min serially on macOS — three times
-# over the budget — and it does not parallelise without GNU parallel,
-# which is not a thing every dev machine has. Splitting it into a fast
-# tier is real work, not a Makefile line, so it lives in `check-all`
-# until someone does it. A `check` that quietly took two minutes would
-# be a `check` nobody runs.
+# suite and it takes ~2 min serially on macOS — three times over the
+# budget — and it does not parallelise without GNU parallel, which is
+# not a thing every dev machine has. Splitting it into a fast tier is
+# real work, not a Makefile line, so it lives in `check-all` until
+# someone does it. A `check` that quietly took two minutes would be a
+# `check` nobody runs.
 .PHONY: check
 check: lint drift helm-lint
 	@echo "==> check: green (bats + helm unit tests are in 'make check-all')"


### PR DESCRIPTION
## The problem

`make help` advertised a **"868-test bats suite"**. The real total on `develop` is **946**, and nothing enforces the two agree — so the number drifts on every PR that adds a test, and had been wrong for a long time.

It also appeared a **second** time, in the `check` rationale comment ("the repo's real unit suite (868 tests)"), which the original report didn't mention. Both are fixed here; a `grep` confirms no hardcoded suite count remains in the repo.

## The fix

Derived from the source of truth rather than written down:

```make
BATS_TEST_COUNT = $(shell grep -h '^@test' scripts/tests/*.bats 2>/dev/null | wc -l | tr -d ' ')
```

bats declares one test per `@test` at line start, so this matches its own count exactly. **Verified against a real run: 946 derived, 946 reported by `bats`.**

Deliberately **not** re-hardcoded to today's value — that would just reset the drift clock, which is the actual failure mode here.

For the prose comment there is nothing to derive, so the count is simply dropped. The sentence is about the ~2-minute runtime, which is the part that actually justifies keeping bats out of `check`.

## Why `=` and not `:=`

Recursively expanded, so only `help` pays for the grep — `make check` is the pre-push path with a sub-60 s budget and shouldn't shell out for a string it never prints.

I checked this rather than assuming it, and the first two ways I tried were both confounded, so for anyone verifying later:

- `--eval='BATS_TEST_COUNT = …'` is evaluated **before** the makefile is read, so the file's own assignment overrides it — every result was a false negative.
- A command-line override (`make check BATS_TEST_COUNT=…`) is expanded regardless, because make propagates it through `MAKEFLAGS` — a false positive.

The test that actually isolates it is a copy of the real Makefile with only the variable's body swapped for a marker-touching shell:

| invocation | marker created? |
|---|---|
| `make check` (`=`) | no — pays nothing |
| `make help` (`=`) | yes — as intended |
| `make check` (`:=`) | yes — why `:=` was not used |

## Test plan

- `make check` — green.
- `make help` — prints `946-test bats suite`.
- `make bats` — 946 tests, 0 failures; matches the derived number.
- `grep -nE '\b[0-9]{3}[- ]?tests?\b' Makefile` — no matches.

## Note

No issue was filed for this — it came in as a direct report. Recent history has precedent for small chores carrying only the PR number (e.g. #684, #667), so I followed that rather than opening a ticket to close it immediately. Happy to file one if you'd rather it were tracked on the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only developer UX change with no runtime, CI behavior, or test logic impact beyond accurate help text.
> 
> **Overview**
> Fixes **stale bats suite counts** in the Makefile by deriving the total from `scripts/tests/*.bats` (`^@test` lines) into `BATS_TEST_COUNT`, so `make help` always shows the current size (e.g. 946) instead of the old hardcoded **868**.
> 
> Uses **recursive `=`** so the grep runs only when `help` prints the string—`make check` stays on its fast path without an extra shell invocation. The `check` target comment no longer cites a fixed test count; it only explains why the full bats run stays in `check-all`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b856c9f76b2f7c0aa52e4e142cd073a16260714a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->