### PR TITLE
fix(scripts): refuse a prod digest refresh past the edgeuser ceiling (backend#1528)

### DIFF
--- a/scripts/resolve-ingestor-digest.sh
+++ b/scripts/resolve-ingestor-digest.sh
@@ -105,6 +105,24 @@ read_ingestor_prod_channel() {
   ' "$file"
 }
 
+# Portable, yq-free reader for `serviceDbAccountsByEnv.prod` (true/false).
+# Same shape as the readers above: scoped to the top-level block so a
+# sibling `prod:` leaf (channelTags.prod, imageTags.prod, ...) can never be
+# mistaken for it. Prints nothing when the key is absent.
+read_prod_service_db_accounts() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+  awk '
+    /^serviceDbAccountsByEnv:[[:space:]]*$/ { in_block = 1; next }
+    /^[^[:space:]#]/                        { in_block = 0 }
+    in_block && $0 ~ /^[[:space:]]+prod:[[:space:]]*(true|false)[[:space:]]*$/ {
+      sub(/^[[:space:]]+prod:[[:space:]]*/, "")
+      sub(/[[:space:]]*$/, "")
+      print; exit
+    }
+  ' "$file"
+}
+
 if [[ -z "$tag" ]]; then
   # No explicit TAG arg → default to the chart's images.ingestor.tag so this
   # helper always resolves the SAME line the chart ships. NEVER hardcode a
@@ -144,6 +162,49 @@ if [[ -z "$tag" ]]; then
 fi
 
 ref="${repo}:${tag}"
+
+# Fail fast, BEFORE any registry work: refusing after resolution wastes the
+# round-trip and hides the reason behind network output.
+if [[ "$write" == 1 ]]; then
+  # THE ORDERING CEILING (backend#1528). While prod still runs the shared
+  # `edgeuser`, the ingestor it runs must be a release that still HAS the
+  # edgeuser fallback. data-ingestors#468 removed that fallback, so a prod pin
+  # refreshed past it authenticates as an account prod has not minted yet and
+  # ingestion fails on every prod edge.
+  #
+  # This helper resolves a CHANNEL FLOAT and knows nothing about that ceiling,
+  # so following values.yaml's own "use the helper, never pin by hand" advice
+  # silently produces the wrong answer while prod is pre-flag. That nearly
+  # shipped in client#490. Fail closed instead.
+  #
+  # Read the flag from values.yaml rather than hardcoding a version, so the
+  # guard tracks the real state: once prod flips to `true` the ceiling is gone
+  # and this stops firing on its own. Anything that is not a definite `true`
+  # fails CLOSED — an absent or unparseable flag is not evidence the ceiling
+  # lifted, and treating it as permission would let a chart edit silently
+  # disarm the guard.
+  prod_flag="$(read_prod_service_db_accounts "$chart_values" || true)"
+  if [[ "$prod_flag" != "true" && "${INGESTOR_PIN_ALLOW_PRE_FLAG:-0}" != "1" ]]; then
+    if [[ -n "$prod_flag" ]]; then
+      echo "ERROR: refusing to refresh the prod pin while serviceDbAccountsByEnv.prod is $prod_flag." >&2
+    else
+      echo "ERROR: refusing to refresh the prod pin: could not read serviceDbAccountsByEnv.prod" >&2
+      echo "       from $chart_values, so the ordering ceiling below cannot be ruled out." >&2
+    fi
+    echo "       Prod authenticates as the shared edgeuser, so its ingestor must be a release" >&2
+    echo "       that still carries the edgeuser fallback (data-ingestors#468 removed it)." >&2
+    echo "       Resolving the channel float here can pin past that ceiling and break ingestion" >&2
+    echo "       on every prod edge — client#490 nearly shipped exactly this." >&2
+    echo "" >&2
+    echo "       Do ONE of:" >&2
+    echo "         1. Flip serviceDbAccountsByEnv.prod to true first (the #1528 S0 windowed" >&2
+    echo "            drill), confirm jobs-manager mints tb_ingest and stamps the creds onto" >&2
+    echo "            spawned Jobs, then re-run — this guard disappears on its own." >&2
+    echo "         2. If you have VERIFIED the target release still has the fallback, re-run" >&2
+    echo "            with INGESTOR_PIN_ALLOW_PRE_FLAG=1 and say so in the PR." >&2
+    exit 1
+  fi
+fi
 
 # Resolve the top-level (index) digest. Prefer buildx imagetools (prints the
 # manifest-list/index digest directly); fall back to `docker manifest inspect`.

--- a/scripts/tests/ingestor-pin-ceiling.bats
+++ b/scripts/tests/ingestor-pin-ceiling.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+# Tests for the ordering ceiling in scripts/resolve-ingestor-digest.sh --write.
+#
+# backend#1528: while `serviceDbAccountsByEnv.prod` is false, prod still
+# authenticates as the shared `edgeuser`, so its ingestor must be a release that
+# still HAS the edgeuser fallback. data-ingestors#468 removed that fallback, and
+# `channelTags.prod` floats past it — values.yaml pins prodDigest DELIBERATELY
+# behind the float and says so in prose. The helper resolves that float and knew
+# nothing about the ceiling, so following values.yaml's own "use the helper,
+# never pin by hand" advice silently produced the wrong answer. client#490
+# nearly shipped exactly that.
+#
+# The guard must also fail BEFORE the registry round-trip: refusing afterwards
+# wastes the call and buries the reason under network output. The docker stub
+# records every invocation so that ordering is asserted, not assumed.
+
+RESOLVE_SH=""
+
+setup() {
+  cd "$BATS_TEST_TMPDIR" || return 1
+  rm -rf repo && mkdir -p repo/scripts repo/client repo/bin || return 1
+  cp "${BATS_TEST_DIRNAME}/../resolve-ingestor-digest.sh" repo/scripts/
+  RESOLVE_SH="$BATS_TEST_TMPDIR/repo/scripts/resolve-ingestor-digest.sh"
+
+  seed_values false
+  seed_docker_stub
+  PATH="$BATS_TEST_TMPDIR/repo/bin:$PATH"
+}
+
+# values.yaml shaped like the real chart: a floating channel tag for prod, a
+# prodDigest deliberately behind it, and decoy `prod:` leaves that the reader
+# must not mistake for serviceDbAccountsByEnv.prod.
+seed_values() {
+  cat >"$BATS_TEST_TMPDIR/repo/client/values.yaml" <<YAML
+images:
+  ingestor:
+    repository: "ghcr.io/tracebloc/ingestor"
+    tag: ""
+    channelTags:
+      dev: "dev"
+      stg: "stg"
+      prod: "0.8"
+    prodDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    prodPin: true
+
+serviceDbAccountsByEnv:
+  dev: true
+  stg: true
+  prod: $1
+YAML
+}
+
+# Stub buildx so the non-refusing paths never touch the network, and so a test
+# can prove whether the registry was contacted at all.
+seed_docker_stub() {
+  cat >"$BATS_TEST_TMPDIR/repo/bin/docker" <<'SH'
+#!/usr/bin/env bash
+echo "docker $*" >>"$DOCKER_CALLS"
+case "$*" in
+  *imagetools*inspect*--raw*) echo '{"manifests":[]}' ;;
+  *imagetools*inspect*)
+    echo "Name:      ghcr.io/tracebloc/ingestor:0.8"
+    echo "MediaType: application/vnd.oci.image.index.v1+json"
+    echo "Digest:    sha256:2222222222222222222222222222222222222222222222222222222222222222"
+    echo ""
+    echo "Manifests:"
+    echo "  Platform:  linux/amd64"
+    echo "  Platform:  linux/arm64"
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$BATS_TEST_TMPDIR/repo/bin/docker"
+  export DOCKER_CALLS="$BATS_TEST_TMPDIR/docker.calls"
+  : >"$DOCKER_CALLS"
+}
+
+pin() { grep -o 'sha256:[0-9a-f]\{64\}' "$BATS_TEST_TMPDIR/repo/client/values.yaml" | head -1; }
+
+@test "refuses --write while serviceDbAccountsByEnv.prod is false" {
+  run bash "$RESOLVE_SH" --write
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"refusing to refresh the prod pin"* ]] || return 1
+}
+
+@test "the refusal names both escape hatches" {
+  run bash "$RESOLVE_SH" --write
+  [[ "$output" == *"serviceDbAccountsByEnv.prod to true"* ]] || return 1
+  [[ "$output" == *"INGESTOR_PIN_ALLOW_PRE_FLAG=1"* ]] || return 1
+}
+
+@test "refusal leaves the existing pin untouched" {
+  run bash "$RESOLVE_SH" --write
+  [ "$status" -eq 1 ] || return 1
+  [ "$(pin)" = "sha256:1111111111111111111111111111111111111111111111111111111111111111" ] || return 1
+}
+
+@test "refusal happens BEFORE any registry round-trip" {
+  run bash "$RESOLVE_SH" --write
+  [ "$status" -eq 1 ] || return 1
+  [ ! -s "$DOCKER_CALLS" ] || return 1
+}
+
+@test "INGESTOR_PIN_ALLOW_PRE_FLAG=1 allows the refresh" {
+  run env INGESTOR_PIN_ALLOW_PRE_FLAG=1 bash "$RESOLVE_SH" --write
+  [ "$status" -eq 0 ] || return 1
+  [[ "$output" != *"refusing to refresh"* ]] || return 1
+  [ "$(pin)" = "sha256:2222222222222222222222222222222222222222222222222222222222222222" ] || return 1
+}
+
+@test "guard disappears once prod flips to true" {
+  seed_values true
+  run bash "$RESOLVE_SH" --write
+  [ "$status" -eq 0 ] || return 1
+  [[ "$output" != *"refusing to refresh"* ]] || return 1
+  [ "$(pin)" = "sha256:2222222222222222222222222222222222222222222222222222222222222222" ] || return 1
+}
+
+@test "read-only resolution is never blocked" {
+  run bash "$RESOLVE_SH"
+  [ "$status" -eq 0 ] || return 1
+  [[ "$output" != *"refusing to refresh"* ]] || return 1
+  # untouched: the read-only path must not write
+  [ "$(pin)" = "sha256:1111111111111111111111111111111111111111111111111111111111111111" ] || return 1
+}
+
+@test "a sibling prod: leaf cannot be mistaken for the flag" {
+  # channelTags.prod is "0.8" (not true/false) and dev/stg are true; if the
+  # reader escaped its block it would read one of those and stop firing.
+  run bash "$RESOLVE_SH" --write
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"refusing to refresh the prod pin"* ]] || return 1
+}
+
+@test "fails closed when the flag key is absent entirely" {
+  # Deleting the key must not disarm the guard: absence is not evidence the
+  # ceiling lifted. Only a definite `true` unlocks the write.
+  cat >"$BATS_TEST_TMPDIR/repo/client/values.yaml" <<'YAML'
+images:
+  ingestor:
+    repository: "ghcr.io/tracebloc/ingestor"
+    tag: "0.8"
+    prodDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    prodPin: true
+YAML
+  run bash "$RESOLVE_SH" --write
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"could not read serviceDbAccountsByEnv.prod"* ]] || return 1
+  [ ! -s "$DOCKER_CALLS" ] || return 1
+}
+
+@test "fails closed on an unparseable flag value" {
+  seed_values "maybe"
+  run bash "$RESOLVE_SH" --write
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"refusing to refresh the prod pin"* ]] || return 1
+}


### PR DESCRIPTION
## Summary

`scripts/resolve-ingestor-digest.sh --write` resolves the `channelTags.prod` float and knew nothing about the ordering ceiling that float sits above. This makes the ceiling executable instead of prose.

While `serviceDbAccountsByEnv.prod` is `false`, prod still authenticates as the shared `edgeuser`, so the ingestor it runs must be a release that still **has** the edgeuser fallback. `data-ingestors#468` removed that fallback.

`client/values.yaml` pins `prodDigest` *deliberately* behind the float and says so in prose — but it also instructs you to refresh the pin **"with the helper, never by hand"**, and the helper resolved straight past the ceiling. `client#490` nearly shipped exactly that.

### Being precise about the current risk

Running `--write` **today** would in fact be safe, and it is worth saying so plainly rather than overselling this:

| | |
|---|---|
| `channelTags.prod: "0.8"` resolves to | `sha256:02da1eb…` (v0.8.4) |
| `images.ingestor.prodDigest` is pinned at | `sha256:05e1249…` (v0.8.2, set by client#490) |

I checked every published tag: **v0.8.2, v0.8.3 and v0.8.4 all predate #468.** It is merged on `data-ingestors` `develop`/`staging` but is not on `main`, so no released build carries it yet. The helper would currently move the pin from one safe build to another.

The problem is what happens next. `channelTags.prod` is a **float**, and the first 0.8.x release cut from that line ships #468. On that day the float silently crosses the ceiling and the helper's output changes meaning with no signal at all — same command, same chart, now a prod-breaking pin. Nobody re-reads a values.yaml comment before running a helper that the file itself tells them to run.

So this guard is preventative, not a fix for something broken right now. It converts a comment that must be remembered into a check that cannot be forgotten, and it removes itself once prod flips.

## What changed

- **Refuse `--write` unless `serviceDbAccountsByEnv.prod` is a definite `true`.** Absent or unparseable reads also refuse — a chart edit must not be able to silently disarm the guard.
- **Refuse *before* the registry round-trip**, so the reason is not buried under network output and no call is wasted.
- **`INGESTOR_PIN_ALLOW_PRE_FLAG=1`** overrides for a target release you have verified still carries the fallback.
- The guard **reads the live flag** rather than hardcoding a version, so it stops firing on its own once prod flips (the #1528 S0 windowed drill). No follow-up cleanup ticket needed.
- Read-only resolution is untouched.

The new `read_prod_service_db_accounts()` reader follows the same block-scoping discipline as the two readers above it, so a sibling `prod:` leaf (`channelTags.prod`, `imageTags.prod`, …) can never be mistaken for the flag.

## Test plan

New `scripts/tests/ingestor-pin-ceiling.bats` (10 tests), picked up automatically by CI's `bats scripts/tests/*.bats`:

- refuses `--write` while the flag is `false`; refusal names both escape hatches
- refusal leaves the existing pin byte-identical
- **refusal happens before any registry contact** — asserted via a docker stub that records every invocation, not assumed
- `INGESTOR_PIN_ALLOW_PRE_FLAG=1` allows the refresh
- guard disappears once the flag flips to `true`
- read-only resolution never blocked, and never writes
- a sibling `prod:` leaf cannot be mistaken for the flag
- fails closed when the key is absent, and on an unparseable value

Evidence, run locally on this branch's base (`6ed024a`):

- `bats scripts/tests/*.bats` → **956 ok / 0 failures** (mine at 367–376)
- `bats scripts/tests/bats-hygiene.bats` → passes (all 24 assertions hardened with `|| return 1` per the house rule)
- `shellcheck --severity=error` → clean; full shellcheck identical to HEAD (4 pre-existing SC2295, on untouched lines)
- `scripts/gen-manifest.sh --check` → up to date (this helper is not manifest-covered)
- **Negative test:** deleting the guard turns 7 of the 10 red

## Notes for the reviewer

Two bugs were caught during testing and are fixed here, mentioned so you know where to look hardest:

1. The guard originally sat *above* the reader function — it called `read_prod_service_db_accounts` before definition and would have failed on every invocation.
2. The condition originally fired only on `== "false"`, so **deleting the key left it fail-open**. It now requires a definite `true`, matching `fr-gate`'s fail-closed posture.

Related: backend#1528 (ceiling), data-ingestors#468 (removed fallback), client#490 (near-miss).
