### PR TITLE
fix(chart): the ingestor tag fallback is per-environment, not always prod's

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.34
-appVersion: "1.9.34"
+version: 1.9.35
+appVersion: "1.9.35"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -356,11 +356,9 @@ Usage: {{ include "tracebloc.ingestorDigest" . }}
   Precedence, mirroring tracebloc.ingestorDigest:
     1. `images.ingestor.tag`          explicit override, any environment
     2. `images.ingestor.channelTags[CLIENT_ENV]`   per-environment channel
-    3. "0.8"                          last-resort literal, so a release that
+    3. `$fallbacks[CLIENT_ENV]`       last-resort literals, so a release that
                                       predates these keys still renders under
-                                      `--reuse-values`. Track the current prod
-                                      line: an older literal here would spawn a
-                                      pre-D16 ingestor on such a release.
+                                      `--reuse-values`
 
   Only consulted when no digest applies: jobs-manager builds `repo@digest`
   when tracebloc.ingestorDigest is non-empty, and `repo:tag` otherwise
@@ -368,6 +366,32 @@ Usage: {{ include "tracebloc.ingestorDigest" . }}
 
   dev/stg resolve to the UNSIGNED internal channels. Prod is a semver float,
   not a `:prod` tag — none is published.
+
+  WHY THE FALLBACK IS KEYED ON THE ENVIRONMENT, not a single literal.
+
+  This used to be a bare `"0.8"` for every environment, which made a dev or
+  staging edge whose `channelTags` are absent — the `--reuse-values` replay
+  this branch exists for — spawn the PROD line. That inverts the entire point
+  of backend#1360: dev/stg channels exist so an ingestor change can be
+  validated on a real edge without a prod release, and an edge silently
+  validating prod's image reports on the wrong artifact. It also crosses the
+  signing boundary in the safe direction only by accident.
+
+  It is worse than a wrong tag today. The prod float has moved past the
+  ordering ceiling documented at values.yaml `prodDigest` (backend#1853): the
+  0.8 line no longer carries the ingestor's `edgeuser` DB_USER default that
+  data-ingestors#468 removed. `serviceDbAccountsByEnv` supplies DB_USER on
+  dev/stg, so those two survive it — but the coupling is accidental, and the
+  same literal is what an out-of-vocabulary CLIENT_ENV lands on, where
+  `serviceDbAccountsByEnv` misses too and nothing supplies DB_USER. That is
+  backend#1752 reconstructed from a typo.
+
+  KEEP THE `prod` ENTRY IN SYNC with values.yaml `channelTags.prod`. It is a
+  second copy of the same float and there is no way to read the first from
+  here: `--reuse-values` (unlike `--reset-then-reuse-values`) does not adopt
+  new chart defaults, so a values lookup would be nil on exactly the releases
+  this branch serves. ingestor_channel_tag_test.yaml pins both, so a bump that
+  touches only one fails CI rather than drifting.
 */}}
 {{- define "tracebloc.ingestorTag" -}}
 {{- $ing := default dict .Values.images.ingestor -}}
@@ -381,7 +405,8 @@ Usage: {{ include "tracebloc.ingestorDigest" . }}
 {{- if $channel -}}
 {{- $channel -}}
 {{- else -}}
-{{- "0.8" -}}
+{{- $fallbacks := dict "dev" "dev" "stg" "stg" "prod" "0.8" -}}
+{{- get $fallbacks $clientEnv | default "0.8" -}}
 {{- end -}}
 {{- end -}}
 {{- end }}

--- a/client/tests/ingestor_channel_tag_test.yaml
+++ b/client/tests/ingestor_channel_tag_test.yaml
@@ -67,10 +67,71 @@ tests:
             name: INGESTOR_IMAGE_TAG
             value: "0.8"
 
-  - it: renders for a release predating channelTags (--reuse-values replay)
+  # ---- the last-resort fallback is per-environment ---------------------
+  #
+  # These four replace a single case that asserted `0.8` for a DEV edge with
+  # `channelTags` absent. That was the bug, written down as an expectation: the
+  # `--reuse-values` replay this branch exists for made a dev/stg edge spawn the
+  # PROD line, which is the opposite of what dev/stg channels are for
+  # (backend#1360 — validate an ingestor change on a real edge without a prod
+  # release). See the fallback rationale in _helpers.tpl.
+  - it: a dev edge predating channelTags falls back to its OWN channel, not prod's
     set:
       env.CLIENT_ENV: dev
       images.ingestor.channelTags: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "dev"
+
+  - it: a stg edge predating channelTags falls back to its OWN channel
+    set:
+      env.CLIENT_ENV: stg
+      images.ingestor.channelTags: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "stg"
+
+  # The control for the two above: the same missing-channelTags input on a PROD
+  # edge must still yield the prod float. Without this, "dev falls back to dev"
+  # would also pass if the fallback simply echoed the resolved environment.
+  - it: a prod edge predating channelTags still falls back to the prod float
+    set:
+      env.CLIENT_ENV: prod
+      images.ingestor.channelTags: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "0.8"
+
+  # The alias must reach the fallback too — the fallback dict is keyed on the
+  # RESOLVED env, so this passes only because it reads tracebloc.clientEnv and
+  # not .Values.env.CLIENT_ENV. backend#1723 was that exact class of miss.
+  - it: an alias resolves before the fallback is keyed
+    set:
+      env.CLIENT_ENV: development
+      images.ingestor.channelTags: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTOR_IMAGE_TAG
+            value: "dev"
+
+  # The prod fallback literal is a SECOND copy of values.yaml channelTags.prod
+  # and cannot read the first (see _helpers.tpl). Pinning both in one suite is
+  # what makes a half-done bump fail CI instead of drifting: the case above
+  # pins the literal, this one pins the values.yaml default they must match.
+  - it: the values.yaml prod channel and the prod fallback literal agree
+    set:
+      env.CLIENT_ENV: prod
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -430,6 +430,12 @@ images:
     # the current release line for the same submit-vs-run reasons noted above.
     #
     # These are unsigned internal images. Do not point a prod edge at them.
+    #
+    # THESE THREE VALUES ARE MIRRORED as last-resort literals in the
+    # `tracebloc.ingestorTag` helper, for the `--reuse-values` replay where
+    # this key is absent and no chart default is adopted. Bump `prod` here and
+    # you must bump it there; ingestor_channel_tag_test.yaml pins both so a
+    # half-done bump fails CI. Read that helper's comment before touching prod.
     channelTags:
       dev: "dev"
       stg: "stg"


### PR DESCRIPTION
## Summary

`tracebloc.ingestorTag`'s last-resort literal was a bare `"0.8"` for **every**
environment. On the `--reuse-values` replay it exists for — a release predating
`channelTags`, where no chart default is adopted — a **dev or staging edge
spawned the PROD ingestor line**.

That inverts the whole point of backend#1360: dev/stg channels exist so an
ingestor change can be validated on a real edge *without* a prod release. An
edge silently validating prod's image reports on the wrong artifact.

**It is no longer merely a wrong tag.** The prod float has moved past the
ordering ceiling documented at `values.yaml` `prodDigest`: the 0.8 line no
longer carries the ingestor's `edgeuser` `DB_USER` default that
data-ingestors#468 removed (**backend#1853**). `serviceDbAccountsByEnv` supplies
`DB_USER` on dev/stg, so those two survive it — but the coupling is accidental,
and the same literal is where an out-of-vocabulary `CLIENT_ENV` lands, where
`serviceDbAccountsByEnv` misses too and nothing supplies `DB_USER`. That is
backend#1752 reconstructed from a typo.

Fallback is now keyed on the **resolved** environment (`dev`→`dev`, `stg`→`stg`,
`prod`→`0.8`), so the documented aliases reach it too.

## Verified on the real chart — input reaching output, with a control

Rendered against `client/ci/bm-values.yaml`, `helm v4.1.1`.

**Before (`origin/develop` @ `ead58c6`)** — `channelTags: null`, i.e. the replay
this branch serves:

```
channelTags:null CLIENT_ENV=dev  -> INGESTOR_IMAGE_TAG value: "0.8"   <-- prod line on a dev edge
channelTags:null CLIENT_ENV=stg  -> INGESTOR_IMAGE_TAG value: "0.8"   <-- prod line on a stg edge
channelTags:null CLIENT_ENV=prod -> INGESTOR_IMAGE_TAG value: "0.8"
```

Control proving the opposite input differs (same command, `channelTags` present):

```
channelTags present, CLIENT_ENV=dev -> INGESTOR_IMAGE_TAG value: "dev"
```

**After (this branch):**

```
dev          channelTags:null -> value:"dev"
stg          channelTags:null -> value:"stg"
prod         channelTags:null -> value:"0.8"      <-- control: prod unchanged
development  channelTags:null -> value:"dev"      <-- alias reaches the fallback
staging      channelTags:null -> value:"stg"
production   channelTags:null -> value:"0.8"
produktion   channelTags:null -> value:"0.8"      <-- unknown still renders, unchanged
```

## The duplication is now documented in both directions

The `prod` literal is a second copy of `values.yaml` `channelTags.prod` and
**cannot** read the first: `--reuse-values` (unlike `--reset-then-reuse-values`)
does not adopt new chart defaults, so a values lookup is nil on exactly the
releases this branch serves. So each copy now points at the other, and the suite
pins both — a bump that touches only one fails CI instead of drifting.

## Tests

An existing case asserted `0.8` for a **dev** edge with `channelTags` absent —
the bug written down as an expectation. Replaced by four cases plus a **prod
control**, so "dev falls back to dev" cannot pass by merely echoing the
environment.

`make check` (lint + drift guards + helm lint, all 4 platform value files):

```
1 chart(s) linted, 0 chart(s) failed          (x5: default, aks, bm, eks, oc)
==> check: green (bats + helm unit tests are in 'make check-all')
```

`make helm-template` — all four platforms render:

```
=== Rendering aks ===
=== Rendering bm ===
=== Rendering eks ===
=== Rendering oc ===
```

`make helm-unittest`:

```
Charts:      1 passed, 1 total
Test Suites: 30 passed, 30 total
Tests:       388 passed, 388 total
Time:        2.04795475s
```

**Mutation-checked** — the new cases actually catch the bug rather than
describing it:

```
MUTATION 1: restore the old bare "0.8" literal
  Tests: 3 failed, 385 passed, 388 total

MUTATION 2: fallback echoes the resolved env (naive fix — breaks prod)
  Tests: 2 failed, 386 passed, 388 total   <-- the prod control earns its place

restored -> Tests: 388 passed, 388 total
```

`scripts/gen-manifest.sh --check` passes unchanged: the manifest covers
`scripts/**` only, and this PR touches no file it hashes.

## Type

- [x] Bug fix (non-breaking)

## Notes for the reviewer

- **Not a breaking change.** Prod behaviour is byte-identical; only dev/stg
  edges *whose `channelTags` are absent* change, and they change from "prod's
  image" to "their own channel", which is what the schema already promises.
- Chart version bumped 1.9.34 → 1.9.35 (`values.yaml` + `templates/**` are
  chart content per `scripts/chart-version-guard.sh`).
- Sibling PR closes the `CLIENT_ENV` / `channelTags` vocabulary that lets an
  edge reach this fallback by typo in the first place. That one is breaking and
  is flagged for your decision; this one is independent and safe on its own.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which ingestor image tag dev/stg edges use when `channelTags` is absent; prod behavior is unchanged but ingestion spawn paths are operationally sensitive.
> 
> **Overview**
> **`tracebloc.ingestorTag`** no longer uses a single last-resort `"0.8"` when `images.ingestor.channelTags` is missing (typical `--reuse-values` upgrades). It now maps **resolved** `CLIENT_ENV` to `dev`→`dev`, `stg`→`stg`, `prod`→`0.8`, with unknown envs still defaulting to `0.8`.
> 
> That stops dev/staging from spawning the **prod** ingestor line when channel tags were never stored—restoring backend#1360’s intent and avoiding accidental prod-image validation on non-prod edges (including DB_USER coupling with the 0.8 line).
> 
> **Docs and tests:** `_helpers.tpl` and `values.yaml` document the duplicated `prod` literal vs `channelTags.prod`; `ingestor_channel_tag_test.yaml` replaces the old “dev gets 0.8” expectation with per-env fallback, prod control, alias, and sync checks. Chart version **1.9.37 → 1.9.38**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d26e0b455bc6b16761613daa62815569b5eea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->