### PR TITLE
fix(chart): close the CLIENT_ENV + channelTags vocabularies, and correct a false schema doc

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -10,6 +10,7 @@ on:
       - 'scripts/tests/e2e-seal-check.sh'
       - 'scripts/tests/e2e-full-seal.sh'
       - 'scripts/tests/lib/e2e-common.sh'
+      - 'scripts/tests/chart-env-vocabulary.sh'
       - 'scripts/lib/**'
       - '.github/workflows/helm-ci.yaml'
   pull_request:
@@ -21,6 +22,7 @@ on:
       - 'scripts/tests/e2e-seal-check.sh'
       - 'scripts/tests/e2e-full-seal.sh'
       - 'scripts/tests/lib/e2e-common.sh'
+      - 'scripts/tests/chart-env-vocabulary.sh'
       - 'scripts/lib/**'
       - '.github/workflows/helm-ci.yaml'
   # Manual runs — mainly to fire full-seal-e2e on demand (e.g. right after the

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -65,6 +65,21 @@ jobs:
         # now packages both charts).
         run: helm lint --strict ./ingestor
 
+      - name: CLIENT_ENV + channelTags vocabularies are closed
+        # `helm lint` does not exercise the values.schema.json `enum` /
+        # `additionalProperties` against out-of-vocabulary inputs, and
+        # helm-unittest structurally cannot: it reports a schema violation as a
+        # plugin-level error rather than a template failure, and exposes no flag
+        # to skip validation and reach the `fail` in tracebloc.clientEnv. So
+        # both gates are asserted from outside the plugin, every rejection
+        # paired with an accept control on the same command line. ~2 s.
+        #
+        # The helper-backstop cases self-skip when helm predates
+        # --skip-schema-validation (3.16); the pin above is v3.15.4, so they are
+        # skipped here today and run for anyone local on 3.16+. Bumping the pin
+        # turns them on with no change to this file.
+        run: bash scripts/tests/chart-env-vocabulary.sh
+
   template:
     timeout-minutes: 10
     name: Template render

--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -77,11 +77,11 @@ jobs:
           # below for visibility but don't fail the gate.
           shellcheck --severity=error --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/gen-manifest.sh scripts/check-facts.sh scripts/check-style.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
-            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-full-seal.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/lib/e2e-common.sh scripts/tests/path-persist.sh
+            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-full-seal.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/lib/e2e-common.sh scripts/tests/path-persist.sh scripts/tests/chart-env-vocabulary.sh
           echo "── shellcheck warnings (advisory, non-blocking) ──"
           shellcheck --severity=warning --shell=bash \
             scripts/install.sh scripts/install-k8s.sh scripts/gen-manifest.sh scripts/check-facts.sh scripts/check-style.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
-            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-full-seal.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/lib/e2e-common.sh scripts/tests/path-persist.sh || true
+            scripts/tests/check-drift.sh scripts/tests/distro-prereqs.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/e2e-full-seal.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-journey.sh scripts/tests/e2e-proxy.sh scripts/tests/lib/e2e-common.sh scripts/tests/path-persist.sh scripts/tests/chart-env-vocabulary.sh || true
 
       - name: Installer manifest is current (supply-chain, R8)
         # The bootstrap verifies each sub-script against scripts/manifest.sha256

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ SHELLCHECK_FILES := \
 	scripts/tests/e2e-journey.sh \
 	scripts/tests/e2e-proxy.sh \
 	scripts/tests/lib/e2e-common.sh \
-	scripts/tests/path-persist.sh
+	scripts/tests/path-persist.sh \
+	scripts/tests/chart-env-vocabulary.sh
 
 # The bats total, DERIVED — never written down. It moves on most PRs that add a
 # test, nothing enforces it, and the help text had drifted from its hardcoded
@@ -57,7 +58,7 @@ help:
 	@echo "  setup       check for / point at the tools these targets need; installs the pre-push hook"
 	@echo "  install-hooks  (re)install the git pre-push hook that runs 'make check'"
 	@echo
-	@echo "  individual: lint bats helm-lint helm-template helm-unittest drift"
+	@echo "  individual: lint bats helm-lint helm-vocab helm-template helm-unittest drift"
 	@echo
 	@echo "  NOT here (CI-only, by name): the 9-distro prereq matrix, e2e-cluster"
 	@echo "  (k3d), e2e-proxy (squid), path-persist, Pester, windows-e2e,"
@@ -76,11 +77,11 @@ help:
 # someone does it. A `check` that quietly took two minutes would be a
 # `check` nobody runs.
 .PHONY: check
-check: lint drift helm-lint
+check: lint drift helm-lint helm-vocab
 	@echo "==> check: green (bats + helm unit tests are in 'make check-all')"
 
 .PHONY: check-all
-check-all: lint drift helm-lint bats helm-template helm-unittest
+check-all: lint drift helm-lint helm-vocab bats helm-template helm-unittest
 	@echo "==> check-all: green"
 
 # setup: no dependency is installed — this only tells you what is missing —
@@ -185,6 +186,16 @@ helm-lint:
 	  helm lint --strict ./client -f "$$f" || exit 1; \
 	done
 	helm lint --strict ./ingestor
+
+# helm-vocab: helm-ci.yaml `lint` job's vocabulary step. The CLIENT_ENV and
+# channelTags vocabularies are closed by a values.schema.json `enum` /
+# `additionalProperties` plus a `fail` in tracebloc.clientEnv, and helm-unittest
+# can assert NEITHER: it treats a schema violation as a plugin-level error
+# rather than a template failure, and offers no way to skip validation and reach
+# the helper. So the gates are exercised from outside the plugin. ~2 s.
+.PHONY: helm-vocab
+helm-vocab:
+	bash scripts/tests/chart-env-vocabulary.sh
 
 # helm-template: helm-ci.yaml `template`. kubeconform is pinned by
 # version AND digest in CI; rather than re-implement that download here,

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.34
-appVersion: "1.9.34"
+version: 1.9.36
+appVersion: "1.9.36"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -301,6 +301,33 @@ Usage: {{ include "tracebloc.ingestorDigest" . }}
   (backend#1028/#1245) on an edge that looked correctly configured. Any future
   consumer of CLIENT_ENV must go through here rather than re-deriving it, the
   same reason ENV_ALIASES lives once in client-runtime proxy_config.
+
+  THE VOCABULARY IS CLOSED, and this is the second of two guards.
+
+  values.schema.json carries the `enum` -- that is the primary gate and it
+  gives the better error. This `fail` is the backstop: the enum is only checked
+  where the packaged schema is read, and `helm template/install/upgrade
+  --skip-schema-validation` skips it, as does a chart repackaged without the
+  schema. This helper is the single chokepoint every consumer already goes
+  through (see the paragraph above), so an unrecognized value that gets past
+  the enum still cannot reach an image tag. Verified both ways in
+  scripts/tests/chart-env-vocabulary.sh -- and it has to live there rather than
+  in client/tests/: helm-unittest validates values against the packaged schema
+  and reports a violation as a plugin-level ERROR, so `failedTemplate` cannot
+  assert the enum, and it offers no flag to skip validation and reach this
+  `fail`.
+
+  WHY FAIL AT ALL, rather than pass the value through. Passing through was not
+  a graceful degradation, it was a silent reconfiguration of the edge in four
+  places at once -- three control-plane image tags pointing at tags no producer
+  publishes, a missed `channelTags` lookup, a missed `serviceDbAccountsByEnv`
+  lookup, and a dropped prod digest pin (the pin applies only where the env
+  resolves to exactly "prod"). The only validator that existed was
+  client-runtime jobs_manager.py's `sys.exit(1)` on "Unknown CLIENT_ENV", which
+  lives INSIDE the container that cannot start, so it cannot help. Failing at
+  `helm upgrade` is consistent with the chart's own conventions: it already
+  fails on placeholder clientId, empty training CIDRs, non-alphanumeric service
+  passwords, perDatasetPvcs without clusterScope, and a missing metrics API.
 */}}
 {{/*
   Whether the dedicated tb_meta / tb_ingest DB identities are on for THIS edge
@@ -343,11 +370,14 @@ Usage: {{ include "tracebloc.ingestorDigest" . }}
 {{- define "tracebloc.clientEnv" -}}
 {{- $raw := (default dict .Values.env).CLIENT_ENV | default "prod" -}}
 {{- $aliases := dict "development" "dev" "staging" "stg" "production" "prod" -}}
+{{- $resolved := $raw -}}
 {{- if hasKey $aliases $raw -}}
-{{- get $aliases $raw -}}
-{{- else -}}
-{{- $raw -}}
+{{- $resolved = get $aliases $raw -}}
 {{- end -}}
+{{- if not (has $resolved (list "dev" "stg" "prod")) -}}
+{{- fail (printf "env.CLIENT_ENV: %q is not a recognized environment. Accepted: dev, stg, prod (canonical) or development, staging, production (aliases); empty/unset means prod. This value is the tag for the jobs-manager, pods-monitor and resource-monitor images, and it keys images.ingestor.channelTags, serviceDbAccountsByEnv and the prod digest pin -- an unrecognized value would pull unpublished tags, miss every one of those lookups and silently drop the pin. Note dev/stg are abbreviated: `develop` and `production` differ, and only the six listed spellings resolve." $raw) -}}
+{{- end -}}
+{{- $resolved -}}
 {{- end }}
 
 {{/*

--- a/client/tests/ingestor_channel_tag_test.yaml
+++ b/client/tests/ingestor_channel_tag_test.yaml
@@ -57,9 +57,29 @@ tests:
             name: INGESTOR_IMAGE_TAG
             value: "0.8.0"
 
-  - it: an unknown CLIENT_ENV falls back to the literal rather than rendering empty
+  # An "unknown CLIENT_ENV falls back to the literal" case lived here, setting
+  # `produktion`. It is gone because the input is gone: the CLIENT_ENV
+  # vocabulary is now closed by a values.schema.json `enum` plus a `fail` in
+  # tracebloc.clientEnv, so `produktion` is refused at install time instead of
+  # becoming a literal image tag.
+  #
+  # It could not simply be re-pointed at the new behaviour: helm-unittest
+  # validates values against the packaged schema and reports a violation as a
+  # plugin-level ERROR, so `failedTemplate` cannot assert it and there is no
+  # flag to skip validation and reach the helper's `fail`. Both gates are
+  # covered from outside the plugin, in scripts/tests/chart-env-vocabulary.sh,
+  # which pairs every rejection with an accept control on the same command line.
+  #
+  # What remains testable here is that the fallback is still reached by a legal
+  # route — an env whose channelTags ENTRY is absent, rather than an env that is
+  # itself illegal. Deliberately asserted on prod, whose fallback is the same
+  # `0.8` on this branch and on the sibling PR that makes the fallback
+  # per-environment, so this case does not depend on their merge order.
+  - it: an env with no channelTags entry still falls back rather than rendering empty
     set:
-      env.CLIENT_ENV: produktion
+      env.CLIENT_ENV: prod
+      images.ingestor.channelTags:
+        dev: "dev"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/client/tests/mysql_test.yaml
+++ b/client/tests/mysql_test.yaml
@@ -236,6 +236,92 @@ tests:
             name: TB_EXPECTED_ENGINE
             value: "8.0"
 
+  # ---- the empty-tag fallback is `prod`, NOT env.CLIENT_ENV ------------
+  #
+  # values.schema.json claimed "Empty falls back to env.CLIENT_ENV" until
+  # backend#1723's follow-up. The template is `... | default "prod"`, so every
+  # environment gets `:prod`. The doc was not merely imprecise, it was an
+  # instruction to break the edge: tracebloc/mysql-client publishes 8.0, 8.4,
+  # four 8.4-<sha> builds, latest and prod — there is no `dev` or `stg` tag
+  # (checked against Docker Hub 2026-08-12). These cases pin the behaviour the
+  # corrected description now describes, so the two cannot drift apart again.
+  - it: an empty tag renders :prod on a dev edge, not :dev
+    template: templates/mysql-deployment.yaml
+    set:
+      env:
+        CLIENT_ENV: dev
+      images:
+        mysqlClient:
+          tag: ""
+          digest: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/mysql-client:prod
+
+  - it: an empty tag renders :prod on a stg edge, not :stg
+    template: templates/mysql-deployment.yaml
+    set:
+      env:
+        CLIENT_ENV: stg
+      images:
+        mysqlClient:
+          tag: ""
+          digest: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/mysql-client:prod
+
+  # The control for the two above: prod renders the same thing, which is what
+  # makes "CLIENT_ENV is not consulted" the only explanation for them.
+  - it: an empty tag renders :prod on a prod edge too
+    template: templates/mysql-deployment.yaml
+    set:
+      env:
+        CLIENT_ENV: prod
+      images:
+        mysqlClient:
+          tag: ""
+          digest: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/mysql-client:prod
+
+  # Why the false doc had teeth beyond a failed pull: an env-derived tag is
+  # unrecognized by tracebloc.mysqlEngineMajor, so the mysql-format-guard
+  # stands down silently. `prod` (the real fallback) keeps it armed at 5.7.
+  - it: believing the old doc would also disarm the mysql-format-guard
+    template: templates/mysql-deployment.yaml
+    set:
+      env:
+        CLIENT_ENV: dev
+      images:
+        mysqlClient:
+          tag: "dev"
+          digest: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: TB_EXPECTED_ENGINE
+            value: "unknown"
+
+  - it: the real fallback keeps the guard armed at 5.7
+    template: templates/mysql-deployment.yaml
+    set:
+      images:
+        mysqlClient:
+          tag: ""
+          digest: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: TB_EXPECTED_ENGINE
+            value: "5.7"
+
   - it: a custom digest pin disarms the guard (engine unknown)
     template: templates/mysql-deployment.yaml
     set:

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -14,7 +14,16 @@
         "CLIENT_ENV": {
           "type": "string",
           "default": "prod",
-          "description": "Environment identifier and Docker image tag. Canonical values are `dev`, `stg`, `prod`; the documented aliases `development`/`staging`/`production` are accepted and normalized (matching client-runtime proxy_config.ENV_ALIASES). Load-bearing: it selects images.ingestor.channelTags and the prod digest pin. Defaults to 'prod' if not set or empty."
+          "enum": [
+            "",
+            "dev",
+            "stg",
+            "prod",
+            "development",
+            "staging",
+            "production"
+          ],
+          "description": "Environment identifier and Docker image tag. Canonical values are `dev`, `stg`, `prod`; the documented aliases `development`/`staging`/`production` are accepted and normalized (matching client-runtime proxy_config.ENV_ALIASES). Empty means 'unset' and resolves to prod. THE LIST IS CLOSED (enum above): anything else is rejected at install/upgrade time rather than passed through as a literal image tag. It was open until backend#1723's follow-up, and an out-of-vocabulary value did not degrade -- it silently reconfigured the edge: it became the tag for three control-plane images (no `:prd`/`:qa` tag is published), it missed `images.ingestor.channelTags` so the ingestor fell to the last-resort literal, it missed `serviceDbAccountsByEnv` so no service DB account was provisioned, AND it dropped the prod digest pin, which applies only where the env resolves to exactly `prod`. Load-bearing in four places, validated in none."
         },
         "HTTP_PROXY_HOST": {
           "type": "string"
@@ -623,7 +632,8 @@
             },
             "channelTags": {
               "type": "object",
-              "description": "Per-environment floating tags, keyed on the resolved CLIENT_ENV, used when `tag` is empty. `dev`/`stg` track the UNSIGNED internal channels published from the matching data-ingestors branch; `prod` stays a semver float because no :prod tag is published. backend#1360.",
+              "description": "Per-environment floating tags, keyed on the resolved CLIENT_ENV, used when `tag` is empty. `dev`/`stg` track the UNSIGNED internal channels published from the matching data-ingestors branch; `prod` stays a semver float because no :prod tag is published. backend#1360. KEYS ARE CLOSED (`additionalProperties: false`): the lookup is on the RESOLVED env, so only `dev`/`stg`/`prod` can ever match. Before this, `channelTags.staging: \"0.8.2\"` on a staging edge validated fine and was then ignored -- CLIENT_ENV=staging normalizes to `stg` and read `channelTags.stg` -- so the same word was normalized one key over and meaningless here. Write the canonical key even when you wrote the alias in CLIENT_ENV.",
+              "additionalProperties": false,
               "properties": {
                 "dev": {
                   "type": "string",
@@ -675,7 +685,7 @@
               "not": {
                 "const": "latest"
               },
-              "description": "Image tag for mysql-client. Empty falls back to env.CLIENT_ENV. Must not be \"latest\"."
+              "description": "Image tag for mysql-client. Empty falls back to the literal `prod` in EVERY environment -- NOT to env.CLIENT_ENV, which is what this said until backend#1723's follow-up. The template is `.Values.images.mysqlClient.tag | default \"prod\"`, and dev/stg/prod edges all render `mysql-client:prod`. The doc was not merely imprecise, it was an instruction to break the edge: tracebloc/mysql-client publishes 8.0, 8.4, four 8.4-<sha> builds, latest and prod -- there is no `dev` or `stg` tag -- so a reader who believed it and set an env-derived tag would pull a nonexistent image AND disarm the mysql-format-guard, since tracebloc.mysqlEngineMajor maps an unrecognized tag to \"unknown\" and the guard stands down. Must not be \"latest\"."
             },
             "digest": {
               "type": "string",

--- a/scripts/tests/chart-env-vocabulary.sh
+++ b/scripts/tests/chart-env-vocabulary.sh
@@ -97,9 +97,13 @@ echo "== env.CLIENT_ENV: everything else is refused at install time =="
 # capitalisation, and an alias that is one letter off `development`. Each used
 # to render `tracebloc/*:<the raw value>`, miss channelTags AND
 # serviceDbAccountsByEnv, and drop the prod digest pin.
-for bad in prd qa Prod PROD produktion develop stage test ""$'\t'; do
-  [[ -n "${bad// /}" ]] || continue
-  expect_reject "CLIENT_ENV=$bad" "$SCHEMA_ERR" --set env.CLIENT_ENV="$bad"
+BAD_ENVS=(prd qa Prod PROD produktion develop stage test)
+# Whitespace-only is its own case: it is NOT the empty string (which is legal and
+# means "unset"), and a hand-edited values.yaml is where it comes from. Kept out
+# of the array above so the tab survives being read back as a word.
+BAD_ENVS+=($'\t')
+for bad in "${BAD_ENVS[@]}"; do
+  expect_reject "CLIENT_ENV=${bad//$'\t'/<tab>}" "$SCHEMA_ERR" --set env.CLIENT_ENV="$bad"
 done
 
 echo "== the template fail is a real backstop, not decoration =="

--- a/scripts/tests/chart-env-vocabulary.sh
+++ b/scripts/tests/chart-env-vocabulary.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+#  chart-env-vocabulary.sh — the CLIENT_ENV / channelTags vocabularies are CLOSED
+#
+#  WHY THIS IS A SHELL TEST AND NOT A helm-unittest SUITE.
+#
+#  helm-unittest cannot assert either half of this. It validates values against
+#  the packaged values.schema.json (verified against plugin 0.5.2) and treats a
+#  schema violation as a plugin-level ERROR, not as a template failure — so
+#  `failedTemplate` cannot catch it, and the suite reports "1 errored" instead of
+#  a pass. It also exposes no flag to skip schema validation, so the template's
+#  `fail` backstop is equally unreachable from there: the schema rejects the
+#  value before a template renders. Both gates are therefore only observable
+#  from outside the plugin, which is what this script is for.
+#
+#  WHAT IT PROVES, in both directions. A rejection test that never rendered
+#  anything for an unrelated reason (a missing required value, a typo in the
+#  chart path) passes for free, so every reject case is paired with an accept
+#  control on the SAME command line, and the reject is matched against the
+#  specific error text rather than merely a non-zero exit.
+#
+#  Usage: bash scripts/tests/chart-env-vocabulary.sh
+#
+set -euo pipefail
+
+CHART="${CHART:-./client}"
+VALUES="${VALUES:-client/ci/bm-values.yaml}"
+
+cd "$(dirname "$0")/../.."
+
+if [[ ! -f "$CHART/Chart.yaml" ]]; then
+  echo "FATAL: no chart at $CHART/Chart.yaml (run from the repo root)" >&2
+  exit 1
+fi
+if [[ ! -f "$VALUES" ]]; then
+  echo "FATAL: no values file at $VALUES" >&2
+  exit 1
+fi
+
+fails=0
+checks=0
+
+render() { # $@ = extra helm args; prints combined output, returns helm's status
+  helm template vocab "$CHART" -f "$VALUES" "$@" 2>&1
+}
+
+pass() { checks=$((checks + 1)); echo "  ok    $1"; }
+fail() { checks=$((checks + 1)); fails=$((fails + 1)); echo "  FAIL  $1"; }
+
+# accepts <label> <helm args...> — must render, and must render the tag we expect
+expect_render() {
+  local label="$1" want="$2"; shift 2
+  local out
+  if ! out="$(render "$@")"; then
+    fail "$label: expected a successful render, got: $(head -3 <<<"$out" | tr '\n' ' ')"
+    return
+  fi
+  if grep -qF "$want" <<<"$out"; then
+    pass "$label -> $want"
+  else
+    fail "$label: rendered, but '$want' is not in the output"
+  fi
+}
+
+# expect_reject <label> <error substring> <helm args...>
+expect_reject() {
+  local label="$1" want="$2"; shift 2
+  local out
+  if out="$(render "$@")"; then
+    fail "$label: expected a rejection, but the chart rendered"
+    return
+  fi
+  if grep -qF "$want" <<<"$out"; then
+    pass "$label (rejected: $want)"
+  else
+    fail "$label: rejected, but not for the expected reason. Got: $(head -3 <<<"$out" | tr '\n' ' ')"
+  fi
+}
+
+SCHEMA_ERR="values don't meet the specifications of the schema"
+
+echo "== env.CLIENT_ENV: the six accepted spellings plus empty all resolve =="
+# The accept side is the control for every reject case below: it proves the
+# command line, values file and chart path are good, so a rejection downstream
+# is attributable to the value under test and nothing else.
+expect_render "CLIENT_ENV unset"        "tracebloc/jobs-manager:prod"
+expect_render "CLIENT_ENV=''"           "tracebloc/jobs-manager:prod" --set env.CLIENT_ENV=""
+expect_render "CLIENT_ENV=dev"          "tracebloc/jobs-manager:dev"  --set env.CLIENT_ENV=dev
+expect_render "CLIENT_ENV=stg"          "tracebloc/jobs-manager:stg"  --set env.CLIENT_ENV=stg
+expect_render "CLIENT_ENV=prod"         "tracebloc/jobs-manager:prod" --set env.CLIENT_ENV=prod
+expect_render "CLIENT_ENV=development"  "tracebloc/jobs-manager:dev"  --set env.CLIENT_ENV=development
+expect_render "CLIENT_ENV=staging"      "tracebloc/jobs-manager:stg"  --set env.CLIENT_ENV=staging
+expect_render "CLIENT_ENV=production"   "tracebloc/jobs-manager:prod" --set env.CLIENT_ENV=production
+
+echo "== env.CLIENT_ENV: everything else is refused at install time =="
+# `prd`, `Prod` and `develop` are the realistic ones — an abbreviation, a
+# capitalisation, and an alias that is one letter off `development`. Each used
+# to render `tracebloc/*:<the raw value>`, miss channelTags AND
+# serviceDbAccountsByEnv, and drop the prod digest pin.
+for bad in prd qa Prod PROD produktion develop stage test ""$'\t'; do
+  [[ -n "${bad// /}" ]] || continue
+  expect_reject "CLIENT_ENV=$bad" "$SCHEMA_ERR" --set env.CLIENT_ENV="$bad"
+done
+
+echo "== the template fail is a real backstop, not decoration =="
+# The enum is only enforced where the packaged schema is read. Prove the helper
+# refuses independently, by rendering with schema validation switched off.
+# Gated on flag support: CI pins helm v3.15.4 and the flag landed in 3.16.
+if helm template --help 2>&1 | grep -q -- '--skip-schema-validation'; then
+  expect_reject "CLIENT_ENV=prd with the schema skipped" \
+    "is not a recognized environment" \
+    --set env.CLIENT_ENV=prd --skip-schema-validation
+  # Control: with the same flag, a valid value must still render. Without this,
+  # the assertion above would also pass if --skip-schema-validation had broken
+  # rendering outright.
+  expect_render "CLIENT_ENV=staging with the schema skipped" \
+    "tracebloc/jobs-manager:stg" \
+    --set env.CLIENT_ENV=staging --skip-schema-validation
+else
+  echo "  skip  --skip-schema-validation unsupported by $(helm version --short) — helper backstop not exercised"
+fi
+
+echo "== images.ingestor.channelTags: keys are closed =="
+# The lookup is on the RESOLVED env, so only dev/stg/prod can ever match. An
+# alias key validated fine and was then silently ignored: channelTags.staging
+# on a staging edge rendered `stg` (from channelTags.stg), not the value written.
+expect_render "channelTags.dev"     'value: "9.9"' --set env.CLIENT_ENV=dev  --set images.ingestor.channelTags.dev=9.9
+expect_render "channelTags.stg"     'value: "9.9"' --set env.CLIENT_ENV=stg  --set images.ingestor.channelTags.stg=9.9
+expect_render "channelTags.prod"    'value: "9.9"' --set env.CLIENT_ENV=prod --set images.ingestor.prodPin=false --set images.ingestor.channelTags.prod=9.9
+for bad in staging development production dev-1 PROD totallyBogus; do
+  expect_reject "channelTags.$bad" "$SCHEMA_ERR" --set "images.ingestor.channelTags.$bad=9.9"
+done
+
+echo
+if (( fails )); then
+  echo "chart-env-vocabulary: $fails of $checks checks FAILED"
+  exit 1
+fi
+echo "chart-env-vocabulary: all $checks checks passed"

--- a/scripts/tests/chart-env-vocabulary.sh
+++ b/scripts/tests/chart-env-vocabulary.sh
@@ -110,7 +110,8 @@ echo "== the template fail is a real backstop, not decoration =="
 # The enum is only enforced where the packaged schema is read. Prove the helper
 # refuses independently, by rendering with schema validation switched off.
 # Gated on flag support: CI pins helm v3.15.4 and the flag landed in 3.16.
-if helm template --help 2>&1 | grep -q -- '--skip-schema-validation'; then
+_helm_help="$(helm template --help 2>&1 || true)"
+if grep -q -- '--skip-schema-validation' <<<"$_helm_help"; then
   expect_reject "CLIENT_ENV=prd with the schema skipped" \
     "is not a recognized environment" \
     --set env.CLIENT_ENV=prd --skip-schema-validation


### PR DESCRIPTION
> **⚠️ NEEDS A CALL FROM @LukasWodka BEFORE MERGE — see "Blast radius" below.**
> Finding 1 turns an open vocabulary into a closed one. That is breaking for any
> edge currently deploying an out-of-vocabulary `CLIENT_ENV`. I believe failing
> closed is right and consistent with the chart's own conventions, but it is a
> policy call, not a correctness one, and I am not making it unilaterally.
> Findings 2 and 3 are unambiguous and could ship alone if you'd rather split.

## Summary

Three findings from a mutable-tags sweep, all the same shape: the chart
**documented a vocabulary it never enforced**, and in one case **documented a
fallback it does not have**. Follow-up to backend#1723, which fixed the
*resolution* and left the *validation* open.

Every claim below was verified by rendering the real chart, each with a control
proving the opposite input behaves differently. Helm `v4.1.1`, values
`client/ci/bm-values.yaml`, base `origin/develop` @ `ead58c6`.

---

### 1. `env.CLIENT_ENV` had no `enum` — the important one

`tracebloc.clientEnv` normalized three aliases and passed **anything else
through raw**. Measured on `develop`:

```
CLIENT_ENV=prod  -> jobs-manager:prod  pods-monitor:prod  resource-monitor:prod   INGESTOR_IMAGE_DIGEST="sha256:05e1249…"
CLIENT_ENV=prd   -> jobs-manager:prd   pods-monitor:prd   resource-monitor:prd    INGESTOR_IMAGE_DIGEST=""      <-- pin GONE
CLIENT_ENV=qa    -> jobs-manager:qa    pods-monitor:qa    resource-monitor:qa     INGESTOR_IMAGE_DIGEST=""
CLIENT_ENV=Prod  -> jobs-manager:Prod  pods-monitor:Prod  resource-monitor:Prod   INGESTOR_IMAGE_DIGEST=""
```

Published tags, checked against Docker Hub 2026-08-12 — no `prd`, no `qa`, no `Prod`:

```
tracebloc/jobs-manager      ['arm-canary', 'dev', 'prod', 'staging', 'stg']
tracebloc/pods-monitor      ['arm-canary', 'dev', 'latest', 'prod', 'staging', 'stg']
tracebloc/resource-monitor  ['arm-canary', 'dev', 'prod', 'staging', 'stg']
```

**The clearest demonstration is a one-letter typo.** `development` is an alias;
`develop` is not:

```
CLIENT_ENV=development -> tag: dev       INGESTOR_IMAGE_TAG="dev"   SERVICE_DB_ACCOUNTS="1"
CLIENT_ENV=develop     -> tag: develop   INGESTOR_IMAGE_TAG="0.8"   SERVICE_DB_ACCOUNTS=(absent)
```

Four things break at once, none of them loudly: a control-plane tag that does
not exist, `images.ingestor.channelTags` missed, `serviceDbAccountsByEnv`
missed so **no service DB account is provisioned**, and the prod digest pin
dropped (it applies only where the env resolves to exactly `prod`). That last
pair is backend#1752 reconstructed from a typo — and it matters more now that
the `0.8` float has moved past the `edgeuser` ceiling (**backend#1853**).

The only validator that existed was `client-runtime` `jobs_manager.py`'s
`sys.exit(1)` on "Unknown CLIENT_ENV" — which lives **inside the container that
cannot start**, so it cannot help.

**Fix:** an `enum` in `values.schema.json` (primary gate) plus a `fail` in
`tracebloc.clientEnv` (backstop — the enum is only checked where the packaged
schema is read, and `--skip-schema-validation` skips it). Failing closed matches
the chart's own conventions: it already `fail`s on placeholder `clientId`, empty
training CIDRs, non-alphanumeric service passwords, `perDatasetPvcs` without
`clusterScope`, and a missing metrics API.

**Accepted vocabulary — the complete list:**

| value | resolves to |
|---|---|
| `dev` | `dev` |
| `stg` | `stg` |
| `prod` | `prod` |
| `development` | `dev` |
| `staging` | `stg` |
| `production` | `prod` |
| `""` / unset | `prod` |

Everything else is refused.

### 2. `channelTags` accepted arbitrary keys

Proven with the control, on `develop`:

```
CLIENT_ENV=staging  channelTags.staging=0.7  ->  INGESTOR_IMAGE_TAG "stg"   <-- the key is IGNORED
CLIENT_ENV=staging  channelTags.stg=0.7      ->  INGESTOR_IMAGE_TAG "0.7"   <-- takes effect
channelTags.totallyBogusKey=9.9              ->  validates fine, silently inert
```

The lookup is on the **resolved** env, so only `dev`/`stg`/`prod` can ever
match. The same word "staging" is normalized in one place and meaningless one
key over — a customer writing the alias gets silence.
**Fix:** `additionalProperties: false`.

### 3. A schema description that was false

`values.schema.json` said the mysql-client tag *"Empty falls back to
env.CLIENT_ENV"*. The template is `.Values.images.mysqlClient.tag | default
"prod"`:

```
CLIENT_ENV=dev  -> mysql-client:prod
CLIENT_ENV=stg  -> mysql-client:prod
CLIENT_ENV=prod -> mysql-client:prod
```

Published tags (Docker Hub, 2026-08-12) — **no `dev`, no `stg`**:

```
['8.0', '8.4', '8.4-528d7cee…', '8.4-5af5e835…', '8.4-87a7b276…', '8.4-b9c6b7a8…', 'latest', 'prod']
```

So the doc was not merely imprecise, it was an instruction to break the edge.
And it costs more than a failed pull — an env-derived tag is unrecognized by
`tracebloc.mysqlEngineMajor`, so the **mysql-format-guard silently stands
down**:

```
mysqlClient.tag=prod -> TB_EXPECTED_ENGINE="5.7"       <-- armed
mysqlClient.tag=dev  -> TB_EXPECTED_ENGINE="unknown"   <-- disarmed
mysqlClient.tag=stg  -> TB_EXPECTED_ENGINE="unknown"
mysqlClient.tag=8.4  -> TB_EXPECTED_ENGINE="8.4"
```

Worth noting: **`values.yaml` already said this correctly** ("mysql-client is
only published under the `prod` tag — it has no dev/staging variants, so we
decouple it from `env.CLIENT_ENV`"). The two files contradicted each other and
the schema — the copy Helm shows customers — held the false half. Description
corrected; **the template is right and is left alone.**

---

## Blast radius — the part that needs your call

Closing an open vocabulary is **breaking for any edge currently deploying an
out-of-vocabulary value**. Such an edge is *already* broken — it is pulling
control-plane tags that do not exist, running with no service DB account, and
has no prod digest pin — but the failure moves:

| | before | after |
|---|---|---|
| where it fails | pod start (`ImagePullBackOff`, or `sys.exit(1)` inside the container) | `helm upgrade` / `helm install`, with a message naming the accepted values |
| the fleet auto-upgrade | proceeds, edge stays broken | **the upgrade fails and the edge stays on its current release** |

That second row is the real risk and the reason I am not merging this myself:
the auto-upgrade CronJob runs `helm upgrade --reset-then-reuse-values`, so a
misconfigured edge's next auto-upgrade would start failing. It would fail
*visibly*, which is the point — but it is a behaviour change on live edges.

**I could not find such an edge from inside this repo:** every `CLIENT_ENV`
value anywhere in the tree is one of the six accepted spellings (the only
exceptions were two test fixtures deliberately exercising the pass-through, both
handled here). `arm-canary` is a published image tag but is referenced nowhere
in the repo as a `CLIENT_ENV`. **Confirming no live edge is out of vocabulary is
outside what I can check** — that needs a look at the actual installed values,
and it is the thing I would want checked before this merges.

If you'd rather not take that on now: findings **2 and 3 are non-breaking** and
can ship on their own.

## Tests

**The gates cannot be asserted from helm-unittest** — verified, not assumed: it
validates values against the packaged schema and reports a violation as a
plugin-level **error** rather than a template failure, so `failedTemplate`
cannot catch it, and it exposes no flag to skip validation and reach the
helper's `fail`. So they are exercised from
`scripts/tests/chart-env-vocabulary.sh`, wired into `make check` and the
`helm-ci` lint job. Every rejection is paired with an **accept control on the
same command line**, and matched against the specific error text rather than
merely a non-zero exit.

```
== env.CLIENT_ENV: the six accepted spellings plus empty all resolve ==
  ok    CLIENT_ENV unset -> tracebloc/jobs-manager:prod
  ok    CLIENT_ENV='' -> tracebloc/jobs-manager:prod
  ok    CLIENT_ENV=dev -> tracebloc/jobs-manager:dev
  ok    CLIENT_ENV=stg -> tracebloc/jobs-manager:stg
  ok    CLIENT_ENV=prod -> tracebloc/jobs-manager:prod
  ok    CLIENT_ENV=development -> tracebloc/jobs-manager:dev
  ok    CLIENT_ENV=staging -> tracebloc/jobs-manager:stg
  ok    CLIENT_ENV=production -> tracebloc/jobs-manager:prod
== env.CLIENT_ENV: everything else is refused at install time ==
  ok    CLIENT_ENV=prd (rejected: values don't meet the specifications of the schema)
  ok    CLIENT_ENV=qa (rejected: ...)
  ok    CLIENT_ENV=Prod (rejected: ...)
  ok    CLIENT_ENV=PROD (rejected: ...)
  ok    CLIENT_ENV=produktion (rejected: ...)
  ok    CLIENT_ENV=develop (rejected: ...)
  ok    CLIENT_ENV=stage (rejected: ...)
  ok    CLIENT_ENV=test (rejected: ...)
  ok    CLIENT_ENV=<tab> (rejected: ...)
== the template fail is a real backstop, not decoration ==
  ok    CLIENT_ENV=prd with the schema skipped (rejected: is not a recognized environment)
  ok    CLIENT_ENV=staging with the schema skipped -> tracebloc/jobs-manager:stg
== images.ingestor.channelTags: keys are closed ==
  ok    channelTags.dev -> value: "9.9"
  ok    channelTags.stg -> value: "9.9"
  ok    channelTags.prod -> value: "9.9"
  ok    channelTags.staging (rejected: ...)
  ok    channelTags.development (rejected: ...)
  ok    channelTags.production (rejected: ...)
  ok    channelTags.dev-1 (rejected: ...)
  ok    channelTags.PROD (rejected: ...)
  ok    channelTags.totallyBogus (rejected: ...)

chart-env-vocabulary: all 28 checks passed
```

**Mutation-checked** — each guard is independently load-bearing:

```
MUT A: drop the enum (keep the helper fail)          -> 9 of 28 checks FAILED   (= the 9 CLIENT_ENV rejects)
MUT B: drop additionalProperties on channelTags      -> 6 of 28 checks FAILED   (= the 6 bad keys)
MUT C: drop the helper fail (keep the enum)          -> 1 of 28 checks FAILED   (= the skip-schema backstop)
restored                                             -> all 28 checks passed
```

MUT C is the one that matters: it shows the backstop case is not just
re-testing the enum.

`make check` (shell parse + shellcheck + 3 drift guards + helm lint, 5 value files):

```
check-facts: all installer facts match scripts/spec/facts.env.
== tracebloc style guard ==
  ok: style + terminology clean
1 chart(s) linted, 0 chart(s) failed        (x5)
chart-env-vocabulary: all 28 checks passed
==> check: green
```

`make helm-unittest` — 5 new cases pin the mysql-client behaviour the corrected
description now describes:

```
Charts:      1 passed, 1 total
Test Suites: 30 passed, 30 total
Tests:       389 passed, 389 total
```

Mutation-checked too — someone "fixing" the template to match the old false doc
gets caught, and the prod control correctly stays green because prod is
indistinguishable either way:

```
MUT D: make the mysql tag env-derived, as the old doc claimed
  Tests: 2 failed, 387 passed, 389 total
    - an empty tag renders :prod on a dev edge, not :dev
    - an empty tag renders :prod on a stg edge, not :stg
```

`make helm-template` — all four platforms render; `shellcheck -S warning -x` on
the new script is clean.

**Manifest:** `scripts/gen-manifest.sh --check` passes and needs no
regeneration — the manifest is the installer bootstrap's integrity surface
(`scripts/install.sh`'s fetch list), and a CI-only test script is correctly not
in it. Confirmed by reading the `FILES` array rather than assuming.

## Type

- [x] Bug fix
- [x] **Breaking change** (finding 1 only)
- [x] Documentation

## Notes for the reviewer

- Chart version bumped 1.9.34 → 1.9.36 (`values.schema.json` is chart content
  per `scripts/chart-version-guard.sh`; I read the guard to confirm).
- **1.9.35 is taken by #694**, the sibling PR that makes the ingestor tag
  fallback per-environment. The two are independent; whichever lands second
  will want a trivial `Chart.yaml` rebase.
- One existing test case (`CLIENT_ENV: produktion`, asserting the pass-through)
  is replaced rather than re-pointed, because the *input* is now illegal. Its
  replacement deliberately asserts on **prod**, whose fallback is the same on
  this branch and on #694, so it does not depend on merge order.
- After both land, the `| default "0.8"` tail in #694's fallback becomes
  unreachable-by-construction. Left in as a belt-and-braces guard rather than
  coupling the two PRs; say the word if you'd rather it go.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Closing `CLIENT_ENV` is a breaking change: fleet auto-upgrade on edges with out-of-vocabulary values will fail at `helm upgrade` instead of proceeding with a broken cluster.
> 
> **Overview**
> **Closes undocumented open vocabularies** on the client Helm chart so bad `env.CLIENT_ENV` and `images.ingestor.channelTags` keys fail at install/upgrade instead of silently becoming wrong image tags, missed lookups, and dropped prod digest pins.
> 
> `values.schema.json` adds a **`CLIENT_ENV` enum** (six spellings + empty) and **`channelTags` with `additionalProperties: false`**. `tracebloc.clientEnv` adds a **`fail` backstop** when schema validation is skipped. The mysql-client **`tag` description** is corrected to match the template: empty tag always falls back to **`prod`**, not `CLIENT_ENV`.
> 
> **`scripts/tests/chart-env-vocabulary.sh`** exercises both gates via `helm template` (paired accept/reject controls); wired into **`make check`** / **`helm-ci`** and shellcheck. Helm unittest cases are updated (illegal `produktion` removed; mysql empty-tag → `:prod` pinned). Chart version **1.9.34 → 1.9.36**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c3354630e764d369053c1802c5f792a0ca561bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->