### PR TITLE
sec(ci): actor-gate the k3s-cuda publish dispatch (backend#1857)

### DIFF
--- a/.github/workflows/build-k3s-cuda.yaml
+++ b/.github/workflows/build-k3s-cuda.yaml
@@ -28,6 +28,43 @@ jobs:
     # instead of spinning to the 6h default (parity with helm-ci / installer-tests).
     timeout-minutes: 60
     steps:
+      # No un-gated workflow_dispatch may publish (backend#1422, decided
+      # 2026-08-05; enforced by release-train's publish-inventory-check.sh,
+      # backend#1857). This workflow is dispatch-ONLY and pushes to
+      # ghcr.io/tracebloc/k3s-cuda, so before this step any writer could
+      # publish it.
+      #
+      # A failing STEP is red and auditable; a skipped job would report green
+      # and hide the denial (the promote.yml lesson, backend#1424).
+      #
+      # BOTH identities must pass: github.actor stays the ORIGINAL dispatcher
+      # on a re-run, while triggering_actor is whoever clicked re-run --
+      # checking only one lets a non-allowlisted user replay an allowlisted
+      # dispatch (Bugbot, backend#1536).
+      #
+      # Gated on `inputs.push` rather than on the event, so build-only
+      # validation stays open to everyone -- the rule is about publishing. THAT
+      # CONDITION MUST STAY IN SYNC with the publish steps below (the GHCR
+      # login and build.sh's PUSH): if anything here ever pushes
+      # unconditionally, this gate stops covering it.
+      - name: Authorize dispatcher (backend#1422)
+        if: ${{ inputs.push }}
+        env:
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          set -euo pipefail
+          for who in "$ACTOR" "$TRIGGERING_ACTOR"; do
+            case "$who" in
+              LukasWodka|saadqbal) ;;
+              *)
+                echo "::error::$who is not permitted to (re-)dispatch this publish workflow (backend#1422)."
+                exit 1
+                ;;
+            esac
+          done
+          echo "Dispatcher $ACTOR (triggering: $TRIGGERING_ACTOR) is on the allowlist."
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Plain docker CLI (no unpinned marketplace actions -> passes action-pins).

--- a/.github/workflows/build-k3s-cuda.yaml
+++ b/.github/workflows/build-k3s-cuda.yaml
@@ -47,11 +47,34 @@ jobs:
       # CONDITION MUST STAY IN SYNC with the publish steps below (the GHCR
       # login and build.sh's PUSH): if anything here ever pushes
       # unconditionally, this gate stops covering it.
-      - name: Authorize dispatcher (backend#1422)
+      # SECOND control, and the one that actually bounds the blast radius: the
+      # ref. `install-k8s.ps1` defaults $K3S_CUDA_IMAGE to
+      # ghcr.io/tracebloc/k3s-cuda:$K8S_VERSION-cuda-$CUDA_BASE_TAG and, in its
+      # own words, "PULLS this image automatically at cluster-create -- the user
+      # never builds or pulls anything by hand". So this tag is fetched by
+      # customers, by tag, and it is mutable. Without a ref check an allowlisted
+      # dispatcher could publish it from ANY branch, putting unreviewed content
+      # behind the tag a GPU install pulls.
+      #
+      # staging AND main, not develop:
+      #   * both are train-owned and protected; develop is the least-reviewed
+      #     integration branch and has no business behind a customer-pulled tag.
+      #   * staging is included deliberately to avoid an ordering trap. The tag
+      #     encodes K8S_VERSION + CUDA_TAG, and check-facts.sh pins those across
+      #     install-k8s.ps1, the Dockerfile, build.sh and this workflow -- so a
+      #     bump arrives everywhere at once. Publishing from staging lets the
+      #     image for a new tag exist BEFORE main's installer starts asking for
+      #     it; main-only would leave a window where prod installs pull a tag
+      #     nobody has pushed yet.
+      #
+      # This is NOT the whole fix. The tag stays mutable and the installer pins
+      # it by tag, not digest -- see backend#1867.
+      - name: Authorize publish — dispatcher and ref (backend#1422, backend#1857)
         if: ${{ inputs.push }}
         env:
           ACTOR: ${{ github.actor }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REF: ${{ github.ref }}
         run: |
           set -euo pipefail
           for who in "$ACTOR" "$TRIGGERING_ACTOR"; do
@@ -63,7 +86,14 @@ jobs:
                 ;;
             esac
           done
-          echo "Dispatcher $ACTOR (triggering: $TRIGGERING_ACTOR) is on the allowlist."
+          case "$REF" in
+            refs/heads/main|refs/heads/staging) ;;
+            *)
+              echo "::error::refusing to publish from $REF. This tag is pulled by customers at cluster-create, so it may only be published from a train-owned branch (staging or main). Re-run with push=false to build-validate from any branch."
+              exit 1
+              ;;
+          esac
+          echo "Publish authorized: $ACTOR (triggering: $TRIGGERING_ACTOR) from $REF."
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 


### PR DESCRIPTION
Part of tracebloc/backend#1857.

## The breach

`build-k3s-cuda.yaml` is **dispatch-only** and pushes `ghcr.io/tracebloc/k3s-cuda`. Nothing authorized the dispatcher. That breaches the rule decided on backend#1422 (Lukas, 2026-08-05) and restated at the top of release-train's `PUBLISH-PATHS.md`:

> *no un-gated `workflow_dispatch` that publishes.*

**Why it was missed:** it was added **one day after** the 2026-08-05 inventory was measured, and the `client` repo had **no rows in `PUBLISH-PATHS.md` at all** — the org's most customer-visible publish path. It was found by release-train's new `publish-inventory-check.sh` (tracebloc/release-train#69), which compares the inventory against every workflow in the fleet instead of trusting that it was kept current.

## The gate

Copied, not reinvented, from the fleet's canonical block — `data-ingestors/release-image.yml`, `backend/docker-build.yml`, `client-runtime/publish-images.yml` all carry it verbatim. Three properties, each load-bearing:

| property | why |
|---|---|
| a failing **step**, not a skipped job | red and auditable; a skipped job reports green and hides the denial (backend#1424) |
| **both** `github.actor` **and** `github.triggering_actor` | `actor` stays the *original* dispatcher on a re-run while `triggering_actor` is whoever clicked it — checking one lets a non-allowlisted user **replay** an allowlisted dispatch (backend#1536) |
| gated on `inputs.push` | build-only validation stays open to everyone. The rule is about publishing, not building |

## Verified, not assumed

Ran every path against the exact shell the step executes:

```
actor=LukasWodka         trigger=LukasWodka         -> ALLOWED
actor=saadqbal           trigger=saadqbal           -> ALLOWED
actor=waqaskhanroghani   trigger=waqaskhanroghani   -> DENIED
actor=LukasWodka         trigger=waqaskhanroghani   -> DENIED   <- the replay case
actor=waqaskhanroghani   trigger=LukasWodka         -> DENIED
actor=<empty>            trigger=<empty>            -> DENIED   <- fail-closed
```

The fourth row is the one that matters: an allowlisted dispatch re-run by anyone else is refused. That is the failure mode a single-identity check silently permits.

```
make check: green      actionlint: clean      scripts/manifest.sha256: up to date
```

## A bigger gap this does NOT close

**This workflow has no ref restriction.** Its only `if:` was `inputs.push`, so a dispatch from **any branch** could publish — with the image tag assembled from two **user-supplied inputs** (`k3s_tag`, `cuda_tag`), and that constructed tag (`v1.29.4-k3s1-cuda-12.4.1-base-ubuntu22.04`) is the one the **GPU installer pins**.

This PR reduces that from *any writer* to *two admins*, which is a real reduction but not a fix. Confining publishes to a reviewed ref — as `client-runtime/build-mysql-client.yml` does with `if: github.ref == 'refs/heads/develop'` — is the natural companion. I have deliberately **not** done it here: choosing *which* ref is a policy decision rather than a copy of an existing pattern, and it would change who can legitimately use this workflow. Happy to add it in this PR if you name the ref.

## Related correction

The sweep that produced backend#1857 named **two** un-gated dispatch publishers. On inspection the second one — `client-runtime/build-mysql-client.yml` — is **already contained by construction**: `if: github.ref == 'refs/heads/develop'` means a dispatch can only republish what `develop` already is, which is precisely the reasoning `PUBLISH-PATHS.md` already accepts as compliant for `data-ingestors/publish-images.yml`. It needs an inventory **row**, not a gate. Correcting that on backend#1857 and in release-train#69 rather than gating a workflow that does not need it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches customer-pulled container publish controls; misconfiguration could block legitimate releases or still leave tag-mutability gaps called out in backend#1867.
> 
> **Overview**
> Adds a **fail-closed publish authorization step** to the manual `build-k3s-cuda` workflow so pushing `ghcr.io/tracebloc/k3s-cuda` is no longer available to any repo writer with dispatch access.
> 
> When `inputs.push` is true, the new step runs **before** checkout/GHCR login and **denies** the job unless **both** `github.actor` and `github.triggering_actor` are on the allowlist (`LukasWodka`, `saadqbal`), blocking replay of an allowlisted run by someone else on re-run. It also **refuses publish** unless the workflow runs on **`staging` or `main`**, since GPU installs pull that mutable tag at cluster-create.
> 
> Build-only dispatches (`push=false`) are unchanged—no actor/ref gate on validation builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e865cdc5a2111ff3bd3eb83fbc9bfa8d98703ea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->