### PR TITLE
fix(ci): watch every mutable label that points at a pinned digest (backend#1853)

### DIFF
--- a/.github/workflows/digest-drift.yml
+++ b/.github/workflows/digest-drift.yml
@@ -1,0 +1,42 @@
+# Watch every mutable label that points at a pinned digest (backend#1853).
+#
+# On 2026-08-12 the ingestor's `channelTags.prod: "0.8"` float moved to 0.8.8 and
+# crossed a compatibility boundary. Nothing noticed; a manual sweep found it.
+# The pre-existing guard (`resolve-ingestor-digest.sh --write`) enforces a ceiling
+# against the HUMAN advancing the pin -- but the thing that moves is the
+# REGISTRY, on someone else's schedule, so that guard cannot fire on this event.
+#
+# Deliberately property-agnostic. It does not assert anything about a build's
+# contents (no DB_USER check): the alarm is "the float no longer resolves to the
+# digest we trust", so it fires on whatever moves next rather than on the one
+# thing that moved first.
+#
+# No event payload is read anywhere here (schedule + dispatch only), so there is
+# no untrusted input to interpolate into a run: block.
+name: Digest drift watch
+
+on:
+  schedule:
+    # Daily. A float can move any day, and the cost of asking is two registry
+    # lookups; a weekly cadence would leave up to six days of unnoticed drift.
+    - cron: "30 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: digest-drift
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v5.0.0
+
+      # Public read of a public index needs no credential. Left unauthenticated
+      # on purpose: a watcher that requires a secret is a watcher that silently
+      # stops when the secret rotates.
+      - name: Check for digest drift
+        run: scripts/check-digest-drift.sh

--- a/.github/workflows/digest-drift.yml
+++ b/.github/workflows/digest-drift.yml
@@ -33,7 +33,7 @@ jobs:
   watch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v5.0.0
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # Public read of a public index needs no credential. Left unauthenticated
       # on purpose: a watcher that requires a secret is a watcher that silently

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,18 @@ drift:
 	scripts/check-facts.sh --check
 	bash scripts/check-style.sh
 
+# digest-drift: the watcher on every mutable label that points at a pinned
+# digest (backend#1853). NOT in `check`: it needs the network and a docker
+# daemon, and it is knowingly RED today -- the ingestor's 0.8 float has moved
+# off the pinned v0.8.2 digest, which is the whole finding. A red target in the
+# pre-push tier trains people to skip the tier.
+#
+# It runs on the schedule in .github/workflows/digest-drift.yml. Its bats suite
+# IS in `make bats`, because that part needs no network.
+.PHONY: digest-drift
+digest-drift:
+	scripts/check-digest-drift.sh
+
 # bats: standard-checks.yml `Unit tests` / installer-tests.yaml
 # `unit-bash`. ~2 min serially.
 .PHONY: bats

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.34
+version: 1.9.35
 appVersion: "1.9.34"
 keywords:
   - tracebloc

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -3,7 +3,7 @@ name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
 version: 1.9.35
-appVersion: "1.9.34"
+appVersion: "1.9.35"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -434,9 +434,17 @@ images:
       dev: "dev"
       stg: "stg"
       # 0.8 line: carries the ds_<hex> per-ingestion write path (D16,
-      # data-ingestors#408, first released as v0.8.0 on 2026-07-30; line at
-      # v0.8.4 as of 2026-08-12, but `prodDigest` below deliberately pins v0.8.2
-      # — see the ordering constraint noted there). A prod edge left on 0.7
+      # data-ingestors#408, first released as v0.8.0 on 2026-07-30). THIS FLOAT
+      # MOVES WITHOUT US: it was at v0.8.4 on 2026-08-12 and is at **v0.8.8**
+      # (sha256:4beb85da…) later the same day. `prodDigest` below deliberately
+      # pins v0.8.2 — see the ordering constraint noted there.
+      #
+      # Do not restate the float's current version here. Any version written
+      # into this comment is stale the moment the next release ships, and a
+      # stale one reads as reassurance ("only two patches behind") for a gap
+      # that may be much larger. scripts/check-digest-drift.sh is what tracks
+      # it; it compares the float against the pin on a schedule and says so
+      # when they part company (backend#1853). A prod edge left on 0.7
       # spawns a pre-D16 ingestor
       # and silently falls back to the legacy tables even with
       # `perIngestionTables` on (found on staging). Verified multi-arch against
@@ -469,8 +477,10 @@ images:
     # index; matches the v0.8.2 GitHub Release digest). The `VERIFIED` note is
     # the audit trail: re-resolve it, do not trust a previous note's date.
     #
-    # DELIBERATELY BEHIND the `channelTags.prod: "0.8"` float, which now resolves
-    # to v0.8.4 (sha256:02da1ebd…). Do not "refresh" this to the float without
+    # DELIBERATELY BEHIND the `channelTags.prod: "0.8"` float. The float has
+    # since moved to v0.8.8 (sha256:4beb85da…), which REMOVED the edgeuser
+    # fallback — i.e. it crossed the boundary described below, and the gap is no
+    # longer "two patches". Do not "refresh" this to the float without
     # reading the ordering constraint in docs/SECURITY.md §4.1.1: prod's
     # `serviceDbAccountsByEnv.prod` is still `false`, and the boundary is not a
     # version number — it is whether the release you move to was cut before

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -137,9 +137,20 @@ The dedicated accounts are minted by jobs-manager at startup via runtime DDL (mi
 >
 > **The requirement attaches to a BUILD, not to a version number.** #468 merged **2026-08-11**, one day *after* **v0.8.4** was cut on 08-10, so **no tagged `0.8.x` release carries it** — verified 2026-08-12 by reading `tracebloc_ingestor/config.py` at both v0.8.2 and v0.8.4, which still read `os.environ.get("DB_USER", "edgeuser")`. An earlier revision of this note said the requirement began "from version 0.8.0"; that was wrong, and taken literally it made the client#490 repin to v0.8.2 look like a prod-breaker while also contradicting the `0.8.2` ceiling stated in the next paragraph.
 >
-> So, as of 2026-08-12: `v0.8.0`–`v0.8.4` are all **safe** with the flag off; the **first `0.8.x` release cut after 2026-08-11** is the one that is not. Do not re-derive that boundary from a version number in this file — check whether the release you are moving to predates #468.
+> **The ceiling, and the fact that it has already been crossed.** This is a bounded range, not an open one:
 >
-> **Therefore: turn this flag on for a fleet BEFORE its ingestor moves to a build containing #468, never after.** For prod that means before `images.ingestor.prodDigest` moves to such a build. client#490 pins **v0.8.2**, which is deliberately conservative rather than the boundary — the newest safe release today is v0.8.4. The invariant is checked in CI by `client-runtime/tests/test_ingestor_env_contract.py` against the contract `data-ingestors` publishes as `runtime_env.v1.json` (backend#1754).
+> | release | `DB_USER` resolution (read from `tracebloc_ingestor/config.py` at the tag) | safe with the flag OFF |
+> |---|---|---|
+> | `v0.8.0` – `v0.8.4` | `os.environ.get("DB_USER", "edgeuser")` | **yes** — `v0.8.4` is the ceiling |
+> | `v0.8.8` and later | `self._require_env("DB_USER")` — raises | **NO** |
+>
+> **`v0.8.8` exists and is past the ceiling** (released 2026-08-12 16:13 UTC, `sha256:4beb85da…`), and the `channelTags.prod: "0.8"` **float now resolves to it** — verified live against ghcr, not inferred. So this is no longer a hypothetical future release: the unsafe build is what the float points at today. Prod is unaffected only because `prodDigest` pins `v0.8.2` and `prodPin` defaults to `true` (backend#1853).
+>
+> Read the ceiling as "safe **up to** v0.8.4", never as "recent releases are fine". And do not re-derive the boundary from a version number in this file — check whether the release you are moving to predates #468, and do not assume the newest tag is inside the range.
+>
+> **This table is not the watcher.** A hand-maintained version list goes stale silently and then reads as reassurance. `scripts/check-digest-drift.sh` runs on a schedule and reports whenever the float stops resolving to the pinned digest — deliberately without asserting anything about `DB_USER`, because the next thing to move will not be `DB_USER` (backend#1853).
+>
+> **Therefore: turn this flag on for a fleet BEFORE its ingestor moves to a build containing #468, never after.** For prod that means before `images.ingestor.prodDigest` moves to such a build. client#490 pins **v0.8.2**, which is deliberately conservative rather than the boundary: the newest safe release is **v0.8.4**, and the newest release *of any kind* is v0.8.8, which is **not** safe. The invariant is checked in CI by `client-runtime/tests/test_ingestor_env_contract.py` against the contract `data-ingestors` publishes as `runtime_env.v1.json` (backend#1754).
 
 **Staged retirement (backend#1528, RFC-0003 D10 close-out):** **S1** mint `tb_meta` + `tb_ingest` (done) → **S2** switch jobs-manager, requests-proxy, and spawned ingestion Jobs off the hardcoded `edgeuser` constants onto the injected identities, and re-parent the `tb_credmgr` bootstrap → **S3** `REVOKE` `edgeuser` to nothing and `DROP USER`, fleet-staged. `edgeuser` must retain `CREATE USER` + `GRANT OPTION` until the bootstrap is re-parented, so the revoke is deliberately last.
 

--- a/scripts/check-digest-drift.sh
+++ b/scripts/check-digest-drift.sh
@@ -137,12 +137,29 @@ discover_pins() {
     /^    tag:[[:space:]]*/        { if (blk_tag  == "") { v = $0; sub(/^    tag:[[:space:]]*/, "", v);        blk_tag  = trim(v) } }
     /^      prod:[[:space:]]*/     { if (ch_prod  == "") { v = $0; sub(/^      prod:[[:space:]]*/, "", v);     ch_prod  = trim(v) } }
     # A pin. prodDigest pairs with channelTags.prod; digest pairs with tag.
-    /^    (digest|prodDigest):[[:space:]]*"sha256:/ {
-      kind = $0; sub(/^    /, "", kind); sub(/:.*$/, "", kind)
-      v = $0; sub(/^    (digest|prodDigest):[[:space:]]*/, "", v); pin = trim(v)
-      flt = (kind == "prodDigest") ? ch_prod : blk_tag
-      name = (mid == "") ? top : top "." mid
-      printf "%s%s%s%s%s%s%s\n", name, SEP, blk_repo, SEP, flt, SEP, pin
+    #
+    # Quote- and indent-agnostic on purpose (Bugbot, client#697). The old pattern
+    # demanded a DOUBLE quote at EXACTLY four-space indent, so a single-quoted or
+    # more-deeply-nested pin was dropped in total silence -- and the PINS==0 guard
+    # below cannot catch that while any one conforming pin remains, so a `no drift`
+    # pass would print with a pin unwatched. Detect the pin however it is written.
+    # A canonical four-space pin pairs with the block repo/float as before; a pin
+    # at any other depth is emitted with no repo/float, so the loop REPORTS it
+    # UNWATCHABLE rather than skipping it -- watched or reported, never skipped.
+    # (No apostrophes in these comments: the awk program is single-quoted.)
+    /^[[:space:]]*(digest|prodDigest):[[:space:]]*["\047]?sha256:[a-f0-9]/ {
+      kind = $0; sub(/^[[:space:]]*/, "", kind); sub(/:.*$/, "", kind)
+      v = $0; sub(/^[[:space:]]*(digest|prodDigest):[[:space:]]*/, "", v); pin = trim(v)
+      if ($0 ~ /^    (digest|prodDigest):/) {
+        flt = (kind == "prodDigest") ? ch_prod : blk_tag
+        name = (mid == "") ? top : top "." mid
+        printf "%s%s%s%s%s%s%s\n", name, SEP, blk_repo, SEP, flt, SEP, pin
+      } else {
+        # Off the canonical structure: name it as best we can, emit empty
+        # repo+float so the main loop reports UNWATCHABLE instead of dropping.
+        name = (mid != "") ? top "." mid : (top != "" ? top : "?")
+        printf "%s%s%s%s%s%s%s\n", name, SEP, "", SEP, "", SEP, pin
+      }
     }
   ' "$1"
 }

--- a/scripts/check-digest-drift.sh
+++ b/scripts/check-digest-drift.sh
@@ -68,6 +68,17 @@ fi
 # (ok / DRIFT / UNRESOLVED / UNWATCHABLE) without a network, and the parsing is
 # where this script's two real bugs were. A stubbed run prints STUBBED on every
 # line and in the summary, so a log cannot look like evidence it is not.
+# _tmout <seconds> <cmd...> — bound a registry/daemon call so a wedged docker or
+# stuck registry fails closed (non-zero exit -> UNRESOLVED) rather than hanging the
+# daily job (Bugbot). timeout on Linux, gtimeout on macOS; unbounded only if
+# neither exists (the CI runner where the daily job runs has timeout).
+_tmout() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then gtimeout "$secs" "$@"
+  else "$@"; fi
+}
+
 resolve_index_digest() {
   local ref="$1" out="" d=""
   if [[ -n "${DRIFT_RESOLVE_STUB:-}" ]]; then
@@ -77,12 +88,12 @@ resolve_index_digest() {
     printf '%s\n' "$d"
     return 0
   fi
-  if docker buildx imagetools inspect "$ref" >/dev/null 2>&1; then
-    out="$(docker buildx imagetools inspect "$ref" 2>/dev/null || true)"
+  if _tmout 30 docker buildx imagetools inspect "$ref" >/dev/null 2>&1; then
+    out="$(_tmout 30 docker buildx imagetools inspect "$ref" 2>/dev/null || true)"
     d="$(awk '/^Digest:/ {print $2; exit}' <<<"$out")"
   fi
   if [[ -z "$d" ]]; then
-    out="$(docker manifest inspect --verbose "$ref" 2>/dev/null || true)"
+    out="$(_tmout 30 docker manifest inspect --verbose "$ref" 2>/dev/null || true)"
     d="$(grep -m1 '"Ref"' <<<"$out" | sed -E 's/.*@(sha256:[a-f0-9]{64}).*/\1/')"
   fi
   [[ "$d" =~ ^sha256:[a-f0-9]{64}$ ]] || return 1

--- a/scripts/check-digest-drift.sh
+++ b/scripts/check-digest-drift.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# check-digest-drift.sh — watch every mutable label that points at a pinned digest.
+#
+# WHY THIS EXISTS (backend#1853)
+# -----------------------------
+# On 2026-08-12 the ingestor's `channelTags.prod: "0.8"` float moved from 0.8.4
+# to 0.8.8, and 0.8.8 dropped the legacy `edgeuser` DB_USER fallback. Default
+# prod edges were protected only because `prodDigest` pins 0.8.2. Nothing
+# noticed the move; it was found by a manual sweep.
+#
+# THE DIAGNOSIS THAT SHAPED THIS SCRIPT (Saqlain, on backend#1853):
+#
+#   "The disease is a moving label pointing at an immutable trust decision, with
+#    no watcher on the label. Anything about the build could have been the thing
+#    that changed -- the fallback just got there first."
+#
+# So this script deliberately makes NO assertion about the contents of a build.
+# It does not know or care what `DB_USER` is. It asks one property-agnostic
+# question, for every pinned image in the chart:
+#
+#     does the float still resolve to the digest we decided to trust?
+#
+# If it does not, that is the alarm, and a human re-verifies. A check that
+# instead asserted "the fallback is still present" would go green the next time
+# something ELSE moves -- which is the failure this script exists to prevent, not
+# a variant of it.
+#
+# WHERE THE TRUSTED VERSIONS ARE REGISTERED: in the chart, as the `digest:` /
+# `prodDigest:` fields of client/values.yaml. There is no second list to keep in
+# sync -- the pin IS the registration. Adding a pin automatically enrols it here.
+#
+# READ-ONLY. Never writes, never publishes. To advance a pin, use
+# scripts/resolve-ingestor-digest.sh --write, which carries its own ceiling
+# guard (backend#1528).
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+chart_values="${CHART_VALUES:-$here/../client/values.yaml}"
+
+FINDINGS=0
+CHECKED=0
+PINS=0
+
+if [[ ! -r "$chart_values" ]]; then
+  echo "ERROR: cannot read $chart_values" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Readers. Same scoping discipline as resolve-ingestor-digest.sh: a leaf is only
+# matched inside its own `images: -> <key>:` block, so a sibling image's `tag:`
+# or `digest:` can never be picked up by mistake. Pure awk, bash-3.2/macOS-safe.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Registry resolution. Same two-step as resolve-ingestor-digest.sh: buildx
+# imagetools prints the manifest-list/index digest directly; docker manifest
+# inspect is the fallback.
+#
+# The capture-then-slice via here-string is NOT stylistic. `inspect | awk ...
+# exit` closes the pipe early, and under `set -o pipefail` a SIGPIPE'd producer
+# makes the substitution 141, which killed a script before its own diagnostic
+# could run (backend#1778). Capture first, slice after.
+# ---------------------------------------------------------------------------
+# DRIFT_RESOLVE_STUB is a TEST SEAM, and the banner below exists so it can never
+# be mistaken for a real audit. It points at a file of `ref<0x1f>digest` lines and
+# replaces the registry entirely -- the suite needs to assert classification
+# (ok / DRIFT / UNRESOLVED / UNWATCHABLE) without a network, and the parsing is
+# where this script's two real bugs were. A stubbed run prints STUBBED on every
+# line and in the summary, so a log cannot look like evidence it is not.
+resolve_index_digest() {
+  local ref="$1" out="" d=""
+  if [[ -n "${DRIFT_RESOLVE_STUB:-}" ]]; then
+    [[ -r "$DRIFT_RESOLVE_STUB" ]] || { echo "ERROR: DRIFT_RESOLVE_STUB is set but unreadable: $DRIFT_RESOLVE_STUB" >&2; exit 2; }
+    d="$(awk -F"$(printf '\037')" -v want="$ref" '$1 == want { print $2; exit }' "$DRIFT_RESOLVE_STUB")"
+    [[ "$d" =~ ^sha256:[a-f0-9]{64}$ ]] || return 1
+    printf '%s\n' "$d"
+    return 0
+  fi
+  if docker buildx imagetools inspect "$ref" >/dev/null 2>&1; then
+    out="$(docker buildx imagetools inspect "$ref" 2>/dev/null || true)"
+    d="$(awk '/^Digest:/ {print $2; exit}' <<<"$out")"
+  fi
+  if [[ -z "$d" ]]; then
+    out="$(docker manifest inspect --verbose "$ref" 2>/dev/null || true)"
+    d="$(grep -m1 '"Ref"' <<<"$out" | sed -E 's/.*@(sha256:[a-f0-9]{64}).*/\1/')"
+  fi
+  [[ "$d" =~ ^sha256:[a-f0-9]{64}$ ]] || return 1
+  printf '%s\n' "$d"
+}
+
+# discover_pins <file>
+#
+# PIN-DRIVEN, and deliberately not scoped to `images:`. My first version walked
+# `images:` and read each key's tag/digest, which silently watched 1 of the 3
+# pins in this file: squid's pin lives OUTSIDE images:, and mysqlClient has no
+# `repository:` leaf at all, so an "empty means skip" rule dropped it without a
+# word. A watcher that quietly covers a third of its subject is the failure this
+# script exists to catch.
+#
+# So: find every non-empty digest pin ANYWHERE, then resolve its block's
+# repository and float. Enrolment is automatic and cannot be missed -- a pin is
+# either watched or REPORTED, never skipped.
+#
+# Emits one TSV record per pin: path <TAB> repository <TAB> float <TAB> pin
+# with an empty field where the file does not say.
+discover_pins() {
+  awk -v SEP="$(printf '\037')" '
+    function trim(v) {
+      sub(/[[:space:]]+#.*$/, "", v)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+      gsub(/^"|"$/, "", v); gsub(/^\047|\047$/, "", v)
+      return v
+    }
+    # Track the innermost 0-space and 2-space keys so a pin can be named.
+    /^[A-Za-z_][A-Za-z0-9_]*:/ {
+      top = $0; sub(/:.*$/, "", top); mid = ""; blk_repo = ""; blk_tag = ""
+    }
+    /^  [A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$/ {
+      mid = $0; sub(/^  /, "", mid); sub(/:[[:space:]]*$/, "", mid)
+      blk_repo = ""; blk_tag = ""; ch_prod = ""
+    }
+    # Leaves of the current block. Only the FIRST of each kind, so a commented
+    # example further down cannot overwrite the live value.
+    /^    repository:[[:space:]]*/ { if (blk_repo == "") { v = $0; sub(/^    repository:[[:space:]]*/, "", v); blk_repo = trim(v) } }
+    /^    tag:[[:space:]]*/        { if (blk_tag  == "") { v = $0; sub(/^    tag:[[:space:]]*/, "", v);        blk_tag  = trim(v) } }
+    /^      prod:[[:space:]]*/     { if (ch_prod  == "") { v = $0; sub(/^      prod:[[:space:]]*/, "", v);     ch_prod  = trim(v) } }
+    # A pin. prodDigest pairs with channelTags.prod; digest pairs with tag.
+    /^    (digest|prodDigest):[[:space:]]*"sha256:/ {
+      kind = $0; sub(/^    /, "", kind); sub(/:.*$/, "", kind)
+      v = $0; sub(/^    (digest|prodDigest):[[:space:]]*/, "", v); pin = trim(v)
+      flt = (kind == "prodDigest") ? ch_prod : blk_tag
+      name = (mid == "") ? top : top "." mid
+      printf "%s%s%s%s%s%s%s\n", name, SEP, blk_repo, SEP, flt, SEP, pin
+    }
+  ' "$1"
+}
+
+report_drift() {  # <path> <ref> <pinned> <resolved>
+  FINDINGS=$((FINDINGS + 1))
+  cat <<EOF
+
+DRIFT: $1
+  the label          $2
+  now resolves to    $4
+  but the pin says   $3
+
+  The trusted build and the build the label points at are no longer the same.
+  Nothing here says the new build is bad -- only that nobody has looked at it.
+  A human must re-verify before the pin moves.
+
+  Deliberately property-agnostic (backend#1853). The last time this happened the
+  thing that moved was a DB_USER fallback; asserting THAT specifically would go
+  green the next time something else moves, which is the failure this watches
+  for rather than a variant of it.
+EOF
+}
+
+report_unwatchable() {  # <path> <pin> <why>
+  FINDINGS=$((FINDINGS + 1))
+  cat <<EOF
+
+UNWATCHABLE: $1 is pinned to $2
+  but $3
+
+  A pin records a trust decision. If the label it is meant to track cannot be
+  determined from the chart, nothing can tell you when that decision goes stale
+  -- which is the same blind spot as having no watcher at all, just quieter.
+
+  Fix by declaring the repository/tag in values.yaml next to the pin, or by
+  recording there why this pin needs no watcher.
+EOF
+}
+
+if [[ -n "${DRIFT_RESOLVE_STUB:-}" ]]; then
+  echo "*** STUBBED RUN — registry replaced by $DRIFT_RESOLVE_STUB. NOT a real audit. ***"
+fi
+echo "Watching every mutable label that points at a pinned digest."
+echo "Registry of trusted versions: ${chart_values#"$here"/../}"
+echo
+
+while IFS="$(printf '\037')" read -r path repo flt pin; do
+  [[ -n "${pin:-}" ]] || continue
+  PINS=$((PINS + 1))
+
+  if [[ -z "${repo:-}" ]]; then
+    report_unwatchable "$path" "$pin" "the block declares no \`repository:\`, so there is no image to resolve."
+    continue
+  fi
+  if [[ -z "${flt:-}" ]]; then
+    report_unwatchable "$path" "$pin" "the block declares no tag (or channel) to resolve against."
+    continue
+  fi
+
+  CHECKED=$((CHECKED + 1))
+  ref="${repo}:${flt}"
+  if ! resolved="$(resolve_index_digest "$ref")"; then
+    # Fail CLOSED. An unresolvable label is not evidence of agreement, and
+    # "green because it could not look" is the class this repo keeps
+    # rediscovering (backend#1729).
+    FINDINGS=$((FINDINGS + 1))
+    printf '\nUNRESOLVED: %s could not be resolved (registry auth, rate limit, network?).\n' "$ref"
+    printf '  Reporting rather than passing: not being able to look is not the same as\n'
+    printf '  looking and finding agreement.\n'
+    continue
+  fi
+
+  if [[ "$resolved" == "$pin" ]]; then
+    printf 'ok    %-46s %s\n' "$ref" "${pin:0:19}…"
+  else
+    report_drift "$path" "$ref" "$pin" "$resolved"
+  fi
+done <<EOF
+$(discover_pins "$chart_values")
+EOF
+
+printf '\n%s\n' "-----"
+# Guard on PINS DISCOVERED, not on pins checked. Counting only what got as far
+# as a registry call would let a reader that stopped matching the file report
+# "no drift" -- an audit that examined nothing must never look like a pass.
+if [[ "$PINS" -eq 0 ]]; then
+  echo "ERROR: found no digest pins at all in ${chart_values#"$here"/../}."
+  echo "       This chart pins images by digest as a matter of policy, so zero pins"
+  echo "       means the reader stopped matching the file, not that there is nothing"
+  echo "       to watch. Refusing to report success on an audit that examined nothing."
+  exit 2
+fi
+if [[ "$FINDINGS" -eq 0 ]]; then
+  echo "no drift: $CHECKED of $PINS pinned label(s) checked, all still resolve to their trusted digest."
+  if [[ -n "${DRIFT_RESOLVE_STUB:-}" ]]; then
+    echo "  (STUBBED — proves nothing about the real registry.)"
+  fi
+  exit 0
+fi
+echo "$FINDINGS finding(s): $PINS pin(s) found, $CHECKED resolvable and compared."
+echo
+echo "To advance a pin deliberately, use scripts/resolve-ingestor-digest.sh --write"
+echo "(it carries the ordering ceiling from backend#1528) and bump client/Chart.yaml"
+echo "-- the chart only publishes on a version change, so an unbumped refresh"
+echo "reaches no edge."
+exit 1

--- a/scripts/tests/check-digest-drift.bats
+++ b/scripts/tests/check-digest-drift.bats
@@ -115,6 +115,64 @@ EOF
   [[ "$output" == *"2 of 2"* ]] || return 1
 }
 
+# --- discovery: bug 3 (quote/indent narrowness, client#697) ----------------
+
+@test "a SINGLE-quoted pin is discovered and classified, not skipped" {
+  cat > "$TMP/values.yaml" <<EOF
+images:
+  widget:
+    repository: example/widget
+    tag: "1.0"
+    digest: '$D_TRUST'
+EOF
+  stub "example/widget:1.0" "$D_MOVED"
+  run_check
+  # Old discovery required a double quote, so this pin was invisible -> PINS==0
+  # -> ERROR (exit 2). It must instead be watched and its drift reported.
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"DRIFT"* ]] || return 1
+}
+
+@test "a conforming pin does not mask a single-quoted one that drifts" {
+  cat > "$TMP/values.yaml" <<EOF
+images:
+  good:
+    repository: example/good
+    tag: "1.0"
+    digest: "$D_TRUST"
+  sneaky:
+    repository: example/sneaky
+    tag: "2.0"
+    digest: '$D_TRUST'
+EOF
+  printf 'example/good:1.0%s%s\nexample/sneaky:2.0%s%s\n' \
+    "$SEP" "$D_TRUST" "$SEP" "$D_MOVED" > "$TMP/stub"
+  run_check
+  # Asad's repro: one conforming (double-quoted) pin agrees, so the old reader
+  # printed `no drift` and exited 0 while the single-quoted one drifted unseen.
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"DRIFT"* ]] || return 1
+  [[ "$output" == *"sneaky"* ]] || return 1
+  [[ "$output" == *"2 pin(s) found"* ]] || return 1
+}
+
+@test "a pin nested off the canonical 4-space structure is UNWATCHABLE, not skipped" {
+  cat > "$TMP/values.yaml" <<EOF
+images:
+  widget:
+    variants:
+      extra:
+        digest: "$D_TRUST"
+    repository: example/widget
+    tag: "1.0"
+EOF
+  : > "$TMP/stub"
+  run_check
+  # The pin sits two levels deeper than the reader can pair a repo/float to. It
+  # is reported, not dropped -- the contract is watched-or-reported-never-skipped.
+  [[ "$output" == *"UNWATCHABLE"* ]] || return 1
+}
+
 @test "an UNPINNED image is not a finding — it made no trust decision" {
   cat > "$TMP/values.yaml" <<EOF
 images:

--- a/scripts/tests/check-digest-drift.bats
+++ b/scripts/tests/check-digest-drift.bats
@@ -1,0 +1,238 @@
+#!/usr/bin/env bats
+# check-digest-drift.sh — the watcher on every mutable label that points at a
+# pinned digest (backend#1853).
+#
+# The registry is stubbed via DRIFT_RESOLVE_STUB so classification can be
+# asserted without a network. The two bugs this script actually shipped were
+# both in DISCOVERY, not in resolution, so most of these cases are about which
+# pins are found and what happens to the ones that cannot be watched:
+#
+#   1. images:-scoped discovery watched 1 of 3 pins -- squid's pin lives outside
+#      images:, and an "empty field means skip" rule dropped mysqlClient in
+#      silence.
+#   2. IFS=$'\t' collapses runs of tabs (tab is IFS whitespace), so a record with
+#      an empty repository AND tag slid the pin into the wrong variable, leaving
+#      $pin empty and the row skipped without a word. 0x1f is not whitespace.
+#
+# Both were found by RUNNING it against the real chart, not by reading it, which
+# is why "watched N of M" is asserted explicitly rather than just "exit 0".
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../check-digest-drift.sh"
+  TMP="$(mktemp -d)"
+  SEP="$(printf '\037')"
+}
+teardown() { rm -rf "$TMP"; }
+
+# A values.yaml with one plain image: repository + tag + digest.
+plain_values() {  # <tag> <digest>
+  cat > "$TMP/values.yaml" <<EOF
+images:
+  widget:
+    repository: example/widget
+    tag: "$1"
+    digest: "$2"
+EOF
+}
+stub() { printf '%s%s%s\n' "$1" "$SEP" "$2" > "$TMP/stub"; }
+run_check() {
+  CHART_VALUES="$TMP/values.yaml" DRIFT_RESOLVE_STUB="$TMP/stub" run "$SCRIPT"
+}
+
+D_TRUST="sha256:1111111111111111111111111111111111111111111111111111111111111111"
+D_MOVED="sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+@test "agreement between float and pin is clean" {
+  plain_values "1.0" "$D_TRUST"
+  stub "example/widget:1.0" "$D_TRUST"
+  run_check
+  [ "$status" -eq 0 ] || return 1
+  [[ "$output" == *"ok "* ]] || return 1
+}
+
+@test "the float resolving elsewhere is DRIFT" {
+  plain_values "1.0" "$D_TRUST"
+  stub "example/widget:1.0" "$D_MOVED"
+  run_check
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"DRIFT"* ]] || return 1
+}
+
+@test "DRIFT names both digests, so the reader need not go looking" {
+  plain_values "1.0" "$D_TRUST"
+  stub "example/widget:1.0" "$D_MOVED"
+  run_check
+  [[ "$output" == *"$D_TRUST"* ]] || return 1
+  [[ "$output" == *"$D_MOVED"* ]] || return 1
+}
+
+@test "DRIFT does not claim the new build is bad, only unreviewed" {
+  plain_values "1.0" "$D_TRUST"
+  stub "example/widget:1.0" "$D_MOVED"
+  run_check
+  [[ "$output" == *"only that nobody has looked at it"* ]] || return 1
+}
+
+@test "an unresolvable label is reported, never treated as agreement" {
+  plain_values "1.0" "$D_TRUST"
+  : > "$TMP/stub"                     # resolves nothing
+  run_check
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"UNRESOLVED"* ]] || return 1
+}
+
+# --- discovery: bug 1 ------------------------------------------------------
+
+@test "a pin OUTSIDE the images: block is still discovered" {
+  cat > "$TMP/values.yaml" <<EOF
+egress:
+  proxy:
+    repository: ubuntu/squid
+    tag: "6.6"
+    digest: "$D_TRUST"
+EOF
+  stub "ubuntu/squid:6.6" "$D_TRUST"
+  run_check
+  [ "$status" -eq 0 ] || return 1
+  [[ "$output" == *"1 of 1"* ]] || return 1
+}
+
+@test "every pin is discovered, not just the first" {
+  cat > "$TMP/values.yaml" <<EOF
+images:
+  a:
+    repository: example/a
+    tag: "1"
+    digest: "$D_TRUST"
+  b:
+    repository: example/b
+    tag: "2"
+    digest: "$D_TRUST"
+EOF
+  printf 'example/a:1%s%s\nexample/b:2%s%s\n' "$SEP" "$D_TRUST" "$SEP" "$D_TRUST" > "$TMP/stub"
+  run_check
+  [ "$status" -eq 0 ] || return 1
+  [[ "$output" == *"2 of 2"* ]] || return 1
+}
+
+@test "an UNPINNED image is not a finding — it made no trust decision" {
+  cat > "$TMP/values.yaml" <<EOF
+images:
+  pinned:
+    repository: example/a
+    tag: "1"
+    digest: "$D_TRUST"
+  floats:
+    repository: example/b
+    tag: "2"
+    digest: ""
+EOF
+  stub "example/a:1" "$D_TRUST"
+  run_check
+  [ "$status" -eq 0 ] || return 1
+  [[ "$output" != *"example/b"* ]] || return 1
+}
+
+# --- discovery: bug 2 (the tab-collapse) -----------------------------------
+
+@test "a pin with NO repository is reported UNWATCHABLE, not skipped" {
+  cat > "$TMP/values.yaml" <<EOF
+images:
+  mysteryClient:
+    tag: ""
+    digest: "$D_TRUST"
+EOF
+  : > "$TMP/stub"
+  run_check
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"UNWATCHABLE"* ]] || return 1
+  [[ "$output" == *"mysteryClient"* ]] || return 1
+}
+
+@test "a pin with a repository but no tag is reported UNWATCHABLE" {
+  cat > "$TMP/values.yaml" <<EOF
+images:
+  noTag:
+    repository: example/x
+    tag: ""
+    digest: "$D_TRUST"
+EOF
+  : > "$TMP/stub"
+  run_check
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"UNWATCHABLE"* ]] || return 1
+}
+
+@test "the empty-field record keeps its pin (the tab-collapse regression)" {
+  # With IFS=tab this row collapsed, $pin came out empty, and the row was
+  # skipped in total silence. The pin must appear in the output.
+  cat > "$TMP/values.yaml" <<EOF
+images:
+  bothEmpty:
+    tag: ""
+    digest: "$D_TRUST"
+EOF
+  : > "$TMP/stub"
+  run_check
+  [[ "$output" == *"$D_TRUST"* ]] || return 1
+}
+
+# --- fail-closed -----------------------------------------------------------
+
+@test "finding zero pins is an ERROR, not 'no drift'" {
+  printf 'images:\n  none:\n    repository: example/x\n    tag: "1"\n    digest: ""\n' > "$TMP/values.yaml"
+  : > "$TMP/stub"
+  run_check
+  [ "$status" -eq 2 ] || return 1
+  [[ "$output" == *"examined nothing"* ]] || return 1
+}
+
+@test "an unreadable values.yaml is a hard error" {
+  CHART_VALUES="$TMP/nope.yaml" run "$SCRIPT"
+  [ "$status" -eq 2 ] || return 1
+}
+
+@test "a stubbed run says so, loudly, in the banner and the summary" {
+  plain_values "1.0" "$D_TRUST"
+  stub "example/widget:1.0" "$D_TRUST"
+  run_check
+  [[ "$output" == *"STUBBED RUN"* ]] || return 1
+  [[ "$output" == *"proves nothing about the real registry"* ]] || return 1
+}
+
+# --- the ingestor's own shape ---------------------------------------------
+
+@test "prodDigest is paired with channelTags.prod, not with tag:" {
+  cat > "$TMP/values.yaml" <<EOF
+images:
+  ingestor:
+    repository: "ghcr.io/tracebloc/ingestor"
+    tag: ""
+    channelTags:
+      dev: "dev"
+      stg: "stg"
+      prod: "0.8"
+    prodDigest: "$D_TRUST"
+EOF
+  stub "ghcr.io/tracebloc/ingestor:0.8" "$D_MOVED"
+  run_check
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"DRIFT"* ]] || return 1
+  [[ "$output" == *"ingestor:0.8"* ]] || return 1
+}
+
+@test "the ingestor's empty tag: does not make it UNWATCHABLE" {
+  cat > "$TMP/values.yaml" <<EOF
+images:
+  ingestor:
+    repository: "ghcr.io/tracebloc/ingestor"
+    tag: ""
+    channelTags:
+      prod: "0.8"
+    prodDigest: "$D_TRUST"
+EOF
+  stub "ghcr.io/tracebloc/ingestor:0.8" "$D_TRUST"
+  run_check
+  [ "$status" -eq 0 ] || return 1
+  [[ "$output" != *"UNWATCHABLE"* ]] || return 1
+}


### PR DESCRIPTION
Fixes tracebloc/backend#1853. Built to @saadqbal's diagnosis rather than to the symptom.

## The design, and why the DB_USER check is deliberately absent

> *"The disease is a moving label pointing at an immutable trust decision, with no watcher on the label. Anything about the build could have been the thing that changed — the fallback just got there first."*

So this script asserts **nothing** about a build's contents. There is no `DB_USER` check, on purpose: an assertion about the fallback would go green the next time something *else* moves, which is the failure being watched for rather than a variant of it. It asks one property-agnostic question per pin:

> does the float still resolve to the digest we decided to trust?

**Where the trusted versions are registered: exactly where they already were** — the `digest:` / `prodDigest:` fields of `client/values.yaml`. There is no second list to keep in sync, and adding a pin enrols it automatically.

## Against the real chart

```
ok    ubuntu/squid:6.6-24.04_beta                    sha256:6a097f68bae7…
DRIFT: images.ingestor
UNWATCHABLE: images.mysqlClient is pinned to sha256:f546e47fb339…
2 finding(s): 3 pin(s) found, 2 resolvable and compared.
```

The `UNWATCHABLE` row is a real finding, not noise: `mysqlClient` carries a pin but declares **no `repository:`**, so nothing can tell you when its trust decision goes stale. That is a modelling gap worth surfacing — reported rather than skipped.

## Two bugs of my own, both found by running it rather than reading it

1. **`images:`-scoped discovery watched 1 of the 3 pins.** squid's pin lives *outside* `images:`, and an "empty field means skip" rule dropped `mysqlClient` without a word. A watcher silently covering a third of its subject is precisely the failure this exists to catch. Rewritten **pin-driven** over the whole file: a pin is either watched or **reported**, never skipped.

2. **`IFS=$'\t'` collapses runs of tabs**, because tab is IFS whitespace. A record with an empty repository *and* an empty tag slid the pin into the wrong variable, left `$pin` empty, and the row was skipped in total silence. This is the same defect release-train's own `parse-repos` suite pins by name — *"0x1f, not tab: bash collapses runs of IFS whitespace, so one empty field lets the next value slide into its place."* I re-made a mistake my own test suite documents.

## The two review items

**`client/values.yaml` no longer states the float's version.** It said *"line at v0.8.4 as of 2026-08-12"* while the float was already at v0.8.8. Beyond being stale, any version written there is stale on the next release — and a stale one reads as reassurance ("only two patches behind") for a gap that may be much larger. The comment now says the float moves without us and points at this watcher.

**`docs/SECURITY.md` §4.1.1 is reframed as an explicit ceiling**, with the evidence read from `config.py` at each tag:

| release | `DB_USER` resolution | safe with the flag OFF |
|---|---|---|
| `v0.8.0` – `v0.8.4` | `os.environ.get("DB_USER", "edgeuser")` | **yes** — v0.8.4 is the ceiling |
| `v0.8.8` and later | `self._require_env("DB_USER")` — raises | **NO** |

It previously implied the unsafe release was a hypothetical *"first 0.8.x release cut after 2026-08-11"*. It exists, and it is what the float points at today.

## Tests

**16 bats cases.** The registry is stubbed through a documented seam that prints `STUBBED RUN` in the banner **and** the summary, so a stubbed log can never pass as a real audit.

**The repo's own `bats-hygiene` guard caught a real defect in my tests:** 31 assertions were bare `[ ... ]` on non-final lines, which bats treats as advisory — they could not fail their test. All are now `|| return 1`. That guard earned its keep on this PR.

Mutation-verified *after* that fix:

| mutation | result |
|---|---|
| comparison always true | **4 tests fail** |
| discovery restricted to the `images:` block | **test 6 fails** |
| a pin with no repository silently skipped | **tests 9 + 11 fail** |

One honest note on that third row: my first attempt at it was a `sed` whose pattern contained backticks and never matched, so it reported **0 failures**. That was an inert mutation, not evidence of coverage — I re-did it with an asserted anchor. Worth recording, since "the mutation ran and nothing failed" and "the mutation never applied" look identical in a log.

```
bats scripts/tests/check-digest-drift.bats   16 passed
bats scripts/tests/bats-hygiene.bats          4 passed
shellcheck: clean    actionlint: clean    manifest.sha256: up to date
```

## Not in `make check`

It needs the network and a docker daemon, and it is **knowingly red today** — the ingestor drift *is* the finding. A red target in the pre-push tier trains people to skip the tier. It runs daily via `digest-drift.yml` (unauthenticated: a watcher that needs a secret is a watcher that stops silently when the secret rotates). The bats suite *is* in `make bats`, which needs neither.

## What this does not do

It does not advance any pin. Advancing is still `scripts/resolve-ingestor-digest.sh --write`, which carries the ordering ceiling from backend#1528. This watcher's only job is to make sure nobody finds out about drift from a manual sweep again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds scheduled CI that depends on public registry/Docker availability and will report red on known ingestor float vs pin drift until pins are advanced deliberately; behavior is read-only and does not change deployed images.
> 
> **Overview**
> Adds **digest drift detection** so registry float tags moving away from chart-pinned digests are caught without a manual sweep (backend#1853).
> 
> **`scripts/check-digest-drift.sh`** scans `client/values.yaml` for every `digest` / `prodDigest`, resolves the paired mutable label (e.g. `channelTags.prod` for ingestor `prodDigest`), and compares registry index digests via Docker. Outcomes are **ok**, **DRIFT**, **UNRESOLVED** (fail closed), or **UNWATCHABLE** (pin without resolvable repo/tag). Discovery is pin-driven across the whole values file—not only `images:`—with a `DRIFT_RESOLVE_STUB` seam for offline tests.
> 
> **`.github/workflows/digest-drift.yml`** runs the script daily (and on `workflow_dispatch`) with read-only permissions and no registry secrets.
> 
> **`make digest-drift`** is added but **excluded from `make check`** because it needs network/Docker and is expected to fail until someone deliberately advances pins.
> 
> **Docs and chart comments** stop embedding the ingestor float’s current semver (stale reassurance); **`docs/SECURITY.md` §4.1.1** documents the v0.8.4 safe ceiling vs v0.8.8+ and points operators at the watcher instead of hand-maintained version lists.
> 
> **`scripts/tests/check-digest-drift.bats`** (16 cases) covers discovery edge cases and classification. Chart version bumps to **1.9.39**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5deec84d88660bc07eec92913a24605729d7dbed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->