### PR TITLE
fix(chart): give jobs-manager the readiness probe that would have caught the crash-loop (backend#1779)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.37
-appVersion: "1.9.37"
+version: 1.9.38
+appVersion: "1.9.38"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -209,37 +209,44 @@ spec:
         # non-empty value as "disabled", and a non-empty string is likewise
         # truthy to Helm. Without this gate, an operator setting that env var
         # would get a pod that never becomes Ready.
-        startupProbe:
-          tcpSocket:
-            port: 8080
-          # 30 x 5s = 150s of headroom. More generous than requests-proxy's
-          # 60s (#1143) on purpose: this container retries backend auth and
-          # then runs a MySQL migration before it ever listens.
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          timeoutSeconds: 3
-          failureThreshold: 30
         readinessProbe:
           tcpSocket:
             port: 8080
-          # The one that fixes the false-green: the jobs-manager Service must
+          # The probe that fixes the false-green: the jobs-manager Service must
           # not route POST /internal/submit-ingestion-run at a pod whose server
           # is not listening ("connection refused to that pod's 8080, x16
-          # tasks" in the 2026-08-11 run).
+          # tasks" in the 2026-08-11 run), and `kubectl rollout status` must not
+          # call the Deployment available until it is.
+          #
+          # initialDelaySeconds covers the slow start without any consequence
+          # if it is not enough: this container retries backend auth and then
+          # runs a MySQL migration before it listens, and while readiness fails
+          # the pod is merely NotReady. Nothing kills it. That is the whole
+          # point — see the note below.
+          initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 3
           failureThreshold: 3
-        # NO livenessProbe, deliberately — recording the decision rather than
-        # leaving it an omission (backend#1779 asks for exactly that).
-        # A liveness probe on 8080 would RESTART the pod whenever the ingestion
-        # server is down, and jobs_manager.py catches a failed
-        # run_server_in_thread on purpose: "Startup failure here is fatal for
-        # the ingestion flow but must not take down the rest of jobs-manager —
-        # SB polling can still operate independently and training submissions
-        # keep working." Adding liveness here would silently reverse that
-        # decision from the chart. Readiness already removes the pod from the
-        # Service, which is the part that needs to happen. Restarting a process
-        # that is still training models is not.
+        # READINESS ONLY — no livenessProbe AND no startupProbe, deliberately.
+        # backend#1779 asks for this to be a recorded decision, so here it is.
+        #
+        # Both of those probe types KILL the container when they fail: liveness
+        # on every failure threshold, and a startupProbe likewise ("if the
+        # startup probe fails, the kubelet kills the container"). jobs_manager.py
+        # catches a failed run_server_in_thread on purpose: "Startup failure
+        # here is fatal for the ingestion flow but must not take down the rest
+        # of jobs-manager — SB polling can still operate independently and
+        # training submissions keep working."
+        #
+        # So either probe would reverse that decision from the chart, and turn a
+        # degraded-but-useful pod into a CrashLoopBackOff that also stops the
+        # Service Bus polling and the training it was still doing. Readiness
+        # removes the pod from the Service, which is the part that needs to
+        # happen. Restarting a process that is still training models is not.
+        #
+        # (An earlier revision of this PR did add a startupProbe with a 150s
+        # budget, which had exactly that bug — it was caught in review. Do not
+        # reintroduce one without also changing jobs_manager.py's decision.)
         {{- end }}
         volumeMounts:
           - name: shared-volume

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -188,6 +188,59 @@ spec:
           - name: http
             containerPort: 8080
             protocol: TCP
+        {{- if not (default dict .Values.env).INGESTION_HTTP_DISABLED }}
+        # backend#1779. jobs-manager had no probes at all, so the kubelet
+        # reported the container Ready the moment it was *running* — and
+        # `kubectl rollout status` printed "successfully rolled out" while the
+        # pod was crash-looping (4 restarts in 72s, 2026-08-11 / backend#1723).
+        #
+        # Why a PORT probe is the right signal here, and not GET /healthz:
+        # jobs-manager opens 8080 only at the END of a successful start — it
+        # authenticates against the backend first and exits(1) on failure
+        # (jobs_manager.py: auth at main() then run_server_in_thread ~140 lines
+        # later), and create_app() runs the ingestion_runs migration against
+        # MySQL on the way up. So "8080 accepts a connection" already implies
+        # backend auth succeeded and MySQL was reachable. `/healthz` is an
+        # unconditional `200 {"status":"ok"}` and would add no information over
+        # the TCP connect — the evidence is in reaching the port at all.
+        #
+        # Gated on INGESTION_HTTP_DISABLED because the runtime gates the server
+        # on it, with the same truthiness: `not os.getenv(...)` treats ANY
+        # non-empty value as "disabled", and a non-empty string is likewise
+        # truthy to Helm. Without this gate, an operator setting that env var
+        # would get a pod that never becomes Ready.
+        startupProbe:
+          tcpSocket:
+            port: 8080
+          # 30 x 5s = 150s of headroom. More generous than requests-proxy's
+          # 60s (#1143) on purpose: this container retries backend auth and
+          # then runs a MySQL migration before it ever listens.
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 30
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          # The one that fixes the false-green: the jobs-manager Service must
+          # not route POST /internal/submit-ingestion-run at a pod whose server
+          # is not listening ("connection refused to that pod's 8080, x16
+          # tasks" in the 2026-08-11 run).
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+        # NO livenessProbe, deliberately — recording the decision rather than
+        # leaving it an omission (backend#1779 asks for exactly that).
+        # A liveness probe on 8080 would RESTART the pod whenever the ingestion
+        # server is down, and jobs_manager.py catches a failed
+        # run_server_in_thread on purpose: "Startup failure here is fatal for
+        # the ingestion flow but must not take down the rest of jobs-manager —
+        # SB polling can still operate independently and training submissions
+        # keep working." Adding liveness here would silently reverse that
+        # decision from the chart. Readiness already removes the pod from the
+        # Service, which is the part that needs to happen. Restarting a process
+        # that is still training models is not.
+        {{- end }}
         volumeMounts:
           - name: shared-volume
             mountPath: "/data/shared"

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -615,3 +615,92 @@ tests:
               secretKeyRef:
                 name: RELEASE-NAME-secrets
                 key: TB_INGEST_PASSWORD
+
+  # -------------------------------------------------------------------------
+  # Readiness / startup probes — backend#1779
+  #
+  # Before this, jobs-manager had no probes, so the kubelet called the
+  # container Ready as soon as it was running and `kubectl rollout status`
+  # reported success over a crash-loop (backend#1723, 2026-08-11).
+  # -------------------------------------------------------------------------
+
+  - it: should give the api container a readiness probe on the ingestion port
+    template: templates/jobs-manager-deployment.yaml
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].readinessProbe
+      # The port is the assertion that matters: a probe pointed anywhere else
+      # would pass `isNotEmpty` while proving nothing about the server that
+      # serves POST /internal/submit-ingestion-run.
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+
+  - it: should give the api container a startup probe with room for auth + migration
+    template: templates/jobs-manager-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: 8080
+      # 30 x 5s = 150s. jobs-manager retries backend auth and runs a MySQL
+      # migration before it listens, so it needs more headroom than
+      # requests-proxy's 60s. Pinned so a later "tidy-up" cannot quietly
+      # shrink it back and start killing slow-but-healthy starts.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 5
+
+  - it: should NOT give the api container a liveness probe (deliberate)
+    template: templates/jobs-manager-deployment.yaml
+    asserts:
+      # jobs_manager.py catches a failed ingestion-server start on purpose so
+      # that Service Bus polling and training submissions keep working. A
+      # liveness probe on 8080 would restart the pod in exactly that case and
+      # reverse the decision from the chart. Readiness (remove from Service)
+      # is the correct response; restarting a process that is still training
+      # models is not.
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should drop the port probes when the ingestion server is disabled
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      # The runtime treats ANY non-empty value as "disabled"
+      # (`not os.getenv("INGESTION_HTTP_DISABLED")`), so the chart must too —
+      # otherwise the probe would wait forever on a port nothing opens and the
+      # pod would never become Ready.
+      env.INGESTION_HTTP_DISABLED: "1"
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: should still probe when INGESTION_HTTP_DISABLED is present but empty
+    template: templates/jobs-manager-deployment.yaml
+    set:
+      # Empty string is falsey to both Python's os.getenv guard and Helm, so
+      # ingestion IS enabled and the probes must stay.
+      env.INGESTION_HTTP_DISABLED: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: 8080
+
+  - it: should not probe the pods-monitor sidecar (no HTTP surface)
+    template: templates/jobs-manager-deployment.yaml
+    asserts:
+      # Recorded, not overlooked: pods-monitor listens on nothing, so there is
+      # no port to probe. backend#1779 leaves it open; giving it a probe needs
+      # a health surface first, which is a separate change.
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: pods-monitor-container
+      - notExists:
+          path: spec.template.spec.containers[1].readinessProbe

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -617,11 +617,16 @@ tests:
                 key: TB_INGEST_PASSWORD
 
   # -------------------------------------------------------------------------
-  # Readiness / startup probes — backend#1779
+  # Readiness probe — backend#1779
   #
   # Before this, jobs-manager had no probes, so the kubelet called the
   # container Ready as soon as it was running and `kubectl rollout status`
   # reported success over a crash-loop (backend#1723, 2026-08-11).
+  #
+  # READINESS ONLY, on purpose. Both livenessProbe and startupProbe kill the
+  # container when they fail, and jobs_manager.py deliberately survives a
+  # failed ingestion-server start so Service Bus polling and training keep
+  # working. The two "must not exist" tests below are the guard on that.
   # -------------------------------------------------------------------------
 
   - it: should give the api container a readiness probe on the ingestion port
@@ -639,36 +644,40 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.failureThreshold
           value: 3
 
-  - it: should give the api container a startup probe with room for auth + migration
+  - it: should give the readiness probe room for a slow auth + migration start
     template: templates/jobs-manager-deployment.yaml
     asserts:
+      # jobs-manager retries backend auth and runs a MySQL migration before it
+      # listens. Failing readiness during that costs nothing (the pod is just
+      # NotReady, nothing kills it), but the delay keeps the event log honest.
       - equal:
-          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
-          value: 8080
-      # 30 x 5s = 150s. jobs-manager retries backend auth and runs a MySQL
-      # migration before it listens, so it needs more headroom than
-      # requests-proxy's 60s. Pinned so a later "tidy-up" cannot quietly
-      # shrink it back and start killing slow-but-healthy starts.
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 10
       - equal:
-          path: spec.template.spec.containers[0].startupProbe.failureThreshold
-          value: 30
-      - equal:
-          path: spec.template.spec.containers[0].startupProbe.periodSeconds
-          value: 5
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 10
 
-  - it: should NOT give the api container a liveness probe (deliberate)
+  - it: should NOT give the api container any probe that restarts it (deliberate)
     template: templates/jobs-manager-deployment.yaml
     asserts:
-      # jobs_manager.py catches a failed ingestion-server start on purpose so
-      # that Service Bus polling and training submissions keep working. A
-      # liveness probe on 8080 would restart the pod in exactly that case and
-      # reverse the decision from the chart. Readiness (remove from Service)
-      # is the correct response; restarting a process that is still training
-      # models is not.
+      # BOTH of these kill the container on failure — liveness on every
+      # threshold breach, and a startupProbe likewise ("if the startup probe
+      # fails, the kubelet kills the container"). jobs_manager.py catches a
+      # failed run_server_in_thread on purpose so that Service Bus polling and
+      # training submissions keep working, so either probe would reverse that
+      # decision from the chart and turn a degraded-but-useful pod into a
+      # CrashLoopBackOff. Readiness (remove from Service) is the correct
+      # response; restarting a process that is still training models is not.
+      #
+      # An earlier revision of this PR shipped a startupProbe with a 150s
+      # budget and had exactly that bug. This test is why it cannot come back
+      # silently.
       - notExists:
           path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
 
-  - it: should drop the port probes when the ingestion server is disabled
+  - it: should drop the port probe when the ingestion server is disabled
     template: templates/jobs-manager-deployment.yaml
     set:
       # The runtime treats ANY non-empty value as "disabled"
@@ -679,8 +688,6 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].readinessProbe
-      - notExists:
-          path: spec.template.spec.containers[0].startupProbe
 
   - it: should still probe when INGESTION_HTTP_DISABLED is present but empty
     template: templates/jobs-manager-deployment.yaml


### PR DESCRIPTION
Part of tracebloc/backend#1779.

## The finding that changes the ticket

**#1779 says the chart half must not ship first.** Its argument:

> the obvious fix — "add a readiness probe on `/healthz`" — would have been green
> throughout the incident … Doing (2) before (1) is the trap and should be called
> out in review if it shows up as a standalone PR.

I checked that, and **for the incident it describes, it does not hold.** Startup
order in `jobs_manager.py::main()` on `origin/develop`:

| line | what happens |
|---|---|
| 3392 | `auth = authenticate_user(backend_address, username, password)` |
| 3414 / 3425 | auth failed → `logger.error(...)`; **`sys.exit(1)`** |
| … | ~100 further lines, incl. another `sys.exit(1)` at 3511 |
| **3531** | `run_server_in_thread(port=INGESTION_HTTP_PORT default 8080)` — **the port opens here** |

The 2026-08-11 outage was a **bad backend auth**. The process therefore exited at
3414, **~140 lines before anything listened on 8080**. Nothing was bound to the
port, so a probe against it — `tcpSocket` *or* `GET /healthz` — would have got
connection-refused and been **red**, not green. The ticket's own evidence says so:

```
14:26:03  ingest: connection refused to that pod's 8080, x16 tasks
```

Connection refused *is* a failing probe. So the false-green came entirely from
finding #1 (**no probe at all** — a container with no readiness probe is Ready as
soon as it is running), not from finding #2.

**What remains true from #1779, and what I am demoting:**

- ✅ **Finding #1 is real and is what this PR fixes.** Verified: `jobs-manager-deployment.yaml` contains zero probe keys, while `mysql-deployment.yaml` and `requests-proxy-deployment.yaml` each have all three. `egress-proxy` and `resource-monitor-daemonset` also have none.
- ✅ **`/healthz` really is an unconditional 200** (`submit_ingestion_run.py:1697-1699` on `origin/develop` — the ticket cites `:1681`, the file has drifted 16 lines, the code is exactly as quoted).
- ⚠️ **Demoted: "probing `/healthz` would create a *new* false-green."** Not for this incident class. It is true for a *narrower* class — process listening, but MySQL / Service Bus / the backend token has since died — where `/healthz` would answer 200 regardless. Worth fixing, but it is not a prerequisite for this PR, and it is not what made the rollout lie.
- ⚠️ **Demoted: the strict work ordering.** (2) before (1) is not a trap here; (2) alone fixes the observed failure. I would keep (1) open as its own ticket for the narrower class.

Also worth noting: the precedent the ticket points at, #1143's requests-proxy probes, are `tcpSocket` — **not** HTTP `/healthz`. So "copy #1143's shape" and "probe `/healthz`" were never the same instruction.

## Why a port probe is the right signal, not `GET /healthz`

Because of that same ordering, **reaching port 8080 is itself the evidence**:
jobs-manager only listens after backend auth has succeeded *and* `create_app()`
has run the `ingestion_runs` migration against MySQL. A TCP connect therefore
already implies "authenticated + MySQL reachable". An unconditional
`200 {"status":"ok"}` adds nothing on top of that.

## What this PR does

- A **`readinessProbe`** only, `tcpSocket: 8080`, on the `api` container, with `initialDelaySeconds: 10` to cover the auth-retry + MySQL-migration start.
- **Gated on `INGESTION_HTTP_DISABLED`**, matching the runtime's truthiness exactly. The runtime uses `ingestion_enabled = not os.getenv("INGESTION_HTTP_DISABLED")`, so **any non-empty value** disables the server — and a non-empty string is likewise truthy to Helm, so the two agree on `"1"`, on `"false"`, and on `""`. Without this gate an operator who disabled ingestion would get a pod that never becomes Ready. (The chart itself never sets the var; `.Values.env` is a free-form passthrough, so a user can.)
- **No `livenessProbe` and no `startupProbe`, deliberately, with the reason in the template.** Both kill the container when they fail. `jobs_manager.py:3535-3542` catches a failed `run_server_in_thread` on purpose: *"Startup failure here is fatal for the ingestion flow but must not take down the rest of jobs-manager — SB polling can still operate independently and training submissions keep working."* A liveness probe on 8080 would restart the pod in exactly that case, reversing that decision from the chart. Readiness pulls the pod out of the Service, which is the part that needs to happen; restarting a process that is still training models is not. #1779 asks for this to be "a recorded decision rather than an omission" — it now is, in the template and in a test.

  **This is where Bugbot caught me** (Medium, and correct — see the thread). The first revision of this PR *did* add a `startupProbe` with a 150s budget, having reasoned only about `livenessProbe`. But a failing startup probe also makes the kubelet kill the container, so it reintroduced the exact restart the PR argued against, via a different key — and since the retry fails identically it would CrashLoopBackOff a pod that was still training. Fixed in 9984e87 by removing it; readiness alone never restarts anything, and is all the false-green fix needs.
- Chart `version`/`appVersion` 1.9.37 → 1.9.38 (`chart-version-guard` requires a bump for any `client/**` content change).

Out of scope, recorded in a test rather than silently skipped: `pods-monitor` listens on nothing, so it has no port to probe — giving it one needs a health surface first.

## Tests — real output

`make check` (lint + drift + helm-lint + helm-vocab):

```
chart-env-vocabulary: all 28 checks passed
==> check: green (bats + helm unit tests are in 'make check-all')
```

`scripts/gen-manifest.sh --check` stays clean:

```
scripts/manifest.sha256 is up to date.
```

Full `helm-unittest` (all 30 suites, not just the one I touched):

```
Charts:      1 passed, 1 total
Test Suites: 30 passed, 30 total
Tests:       396 passed, 396 total
```

`make bats` — exit 0, 970 tests (last line `ok 970 print_summary image_pull_ca: ...`).

`make helm-template` — all four platforms render (aks, bm, eks, oc).

The `jobs_manager_test.yaml` suite went 35 → 41 tests.

## Proof the tests are not inert

Six deliberate mutations of the template, each reverted after measuring. Each
one reddens a different assertion, and these were re-run **after** the Bugbot fix:

| # | Mutation | Result |
|---|---|---|
| 1 | Reintroduce a `startupProbe` (the exact bug Bugbot found) | **1 failed** — `should NOT give the api container any probe that restarts it` |
| 2 | Add a `livenessProbe` on 8080 | **1 failed** — same test |
| 3 | Delete the `readinessProbe` block | **3 failed** — incl. `should give the api container a readiness probe on the ingestion port` |
| 4 | Point the readiness probe at port `9999` | **2 failed** — proves the **port** is pinned, not merely the probe's presence |
| 5 | Remove the `INGESTION_HTTP_DISABLED` gate | **1 failed** — `should drop the port probe when the ingestion server is disabled` |
| 6 | `initialDelaySeconds` 10 → 0 | **1 failed** — `should give the readiness probe room for a slow auth + migration start` |

Mutations 1 and 2 are the regression guard for the Bugbot finding: neither
restarting probe can come back silently. Mutation 4 is why the port and
thresholds are asserted by value — `isNotEmpty` alone would have survived it.

I could not prove the probe goes red *against a live kubelet* from here — that
needs a cluster. What is proven is that the probe exists, targets the port the
ingestion server actually binds, disappears exactly when that server is disabled,
and that every one of those properties fails if the template regresses.

## Docs

No CLAUDE.md / BUGBOT.md / runbook statement is made false by this change.
Deliberately untouched (open PRs elsewhere): `client/values.yaml`,
`docs/SECURITY.md`, `.github/workflows/build-k3s-cuda.yaml`,
`scripts/check-digest-drift.sh`.
