### PR TITLE
fix(chart): re-image control-plane pods by digest instead of relying on Always (#569)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.38
-appVersion: "1.9.38"
+version: 1.9.39
+appVersion: "1.9.39"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -187,6 +187,29 @@ mysql-pvc
 {{- end }}
 
 {{/*
+  Name of the requests-proxy Deployment. ONE definition, because #569 gave it a
+  second consumer: image-refresh reconciles it by name with `kubectl set image`,
+  so a rename that reached only the Deployment would leave the CronJob patching
+  a workload that does not exist — failing the tick, freezing the digest record,
+  and eventually tripping the shared flap lockout for every control-plane image.
+
+  This is the third instance on #569 of one side of a two-sided contract moving
+  without the other (the requests-proxy digest pin and the resource-monitor pin
+  signal were the first two, both found in review). Same remedy: collapse to a
+  single definition rather than keep two literals in sync by hand.
+
+  The jobs-manager Deployment has the same shape — image-refresh's
+  DEPLOYMENT_NAME re-derives `<release>-jobs-manager` with its own printf, and
+  five other call sites spell it out too (NOTES.txt, the PDB,
+  tracebloc.serviceAccountName, ...). Unifying THAT is a mechanical refactor
+  across templates this change does not otherwise touch, so it is deliberately
+  left for its own PR; a contract test pins the two sides here in the meantime.
+*/}}
+{{- define "tracebloc.requestsProxyName" -}}
+{{ .Release.Name }}-requests-proxy
+{{- end }}
+
+{{/*
   Whether the image-refresh CronJob has anything to do. When ALL THREE
   managed images (jobs-manager, pods-monitor, resource-monitor) are
   digest-pinned, the operator has explicitly opted into reproducible

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -165,16 +165,18 @@ mysql-pvc
 
 {{/*
   Whether the image-refresh CronJob has anything to do. When ALL THREE
-  managed images (jobs-manager, pods-monitor, ingestor) are
+  managed images (jobs-manager, pods-monitor, resource-monitor) are
   digest-pinned, the operator has explicitly opted into reproducible
   pinning for every image this CronJob would refresh, so we render
   nothing — no CronJob, no RBAC, no ConfigMap. When at least one is
   unpinned, the CronJob is rendered and the script skips the pinned
   images at runtime via env flags.
 
-  Three pins because #158 added ingestor refresh on top of #154's
-  jobs-manager + pods-monitor. Keep this list in sync if more images
-  come under auto-refresh in future.
+  The three have changed over time: #154 started with jobs-manager +
+  pods-monitor, #158 added the ingestor, the floating-tag migration
+  retired the ingestor pass, and #569 brought resource-monitor under
+  refresh (it had no deliberate update path before). Keep this list in
+  sync if more images come under auto-refresh in future.
 
   Nil-guarded with `default dict` on every dereference: these are
   newer top-level keys, and a customer who runs
@@ -203,8 +205,18 @@ mysql-pvc
 */}}
 {{- $jmPinned := $jm.digest -}}
 {{- $pmPinned := $pm.digest -}}
+{{/*
+  #569: resource-monitor came under refresh too, so it joins the "nothing left
+  to do" test. requests-proxy deliberately does NOT: it runs the SAME
+  tracebloc/jobs-manager image and follows the jobs-manager digest, so
+  `$jmPinned` already covers it. (`images.requestsProxy.digest` remains an
+  operator override that pins requests-proxy alone; it is checked at runtime,
+  not here, because pinning only requests-proxy still leaves jobs-manager
+  itself to refresh.)
+*/}}
+{{- $rmPinned := (default dict $imgs.resourceMonitor).digest -}}
 {{- if not $ir.enabled -}}
-{{- else if and $jmPinned $pmPinned -}}
+{{- else if and $jmPinned $pmPinned $rmPinned -}}
 {{- else -}}
 true
 {{- end -}}

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -213,6 +213,14 @@ mysql-pvc
   operator override that pins requests-proxy alone; it is checked at runtime,
   not here, because pinning only requests-proxy still leaves jobs-manager
   itself to refresh.)
+
+  "Follows the jobs-manager digest" is only true because
+  requests-proxy-deployment.yaml FALLS BACK to `images.jobsManager.digest` when
+  its own key is empty. Without that fallback this test is a silent trap
+  (Bugbot): retiring the CronJob here on a jobs-manager pin would leave the
+  proxy rendering the floating tag with nothing left to reconcile it, running a
+  different build of the same image forever. If that fallback is ever removed,
+  requests-proxy must get its own entry in this test.
 */}}
 {{- $rmPinned := (default dict $imgs.resourceMonitor).digest -}}
 {{- if not $ir.enabled -}}

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -231,6 +231,62 @@ true
 {{- end }}
 
 {{/*
+  tracebloc.controlPlanePullPolicy — the pull policy for the four always-running
+  control-plane images (jobs-manager, pods-monitor, requests-proxy,
+  resource-monitor). ONE definition so the four call sites cannot disagree.
+
+  #569 set out to make these pods survive an offline Docker/WSL restart:
+  `Always` forces a registry round-trip on every (re)start, so a restart without
+  the registry lands in ImagePullBackOff even with the image cached in
+  containerd. The fix is IfNotPresent.
+
+  But `Always` is not just fragility — on a floating tag it IS an update path:
+  restart the pod and the kubelet re-resolves the tag. The first cut of #569
+  made IfNotPresent UNCONDITIONAL, which silently removed that path from every
+  edge where the replacement (image-refresh's `kubectl set image repo@digest`)
+  cannot run — those edges would have frozen on their cached image forever, with
+  a green CronJob and no signal (Bugbot, High). So the policy tracks whether an
+  update path actually exists:
+
+    1. An explicit `digest` pin -> IfNotPresent. The reference is immutable, so
+       re-checking the registry can only ever return the same image. Updates
+       come from changing the pin.
+    2. Otherwise, if the image-refresh reconcile can actually drive updates on
+       this edge -> IfNotPresent, because `set image` changes the REFERENCE and
+       the kubelet pulls a digest it has never seen. Two conditions:
+         * the CronJob renders at all (`imageRefresh.enabled`, and not every
+           refreshed image already pinned), and
+         * images come from docker.io. Under a `global.imageRegistry` mirror the
+           script goes inert by design — it resolves digests from docker.io, and
+           pinning one onto a mirrored reference could pin an image the mirror
+           does not hold.
+    3. Otherwise -> Always. No reconcile, no pin, so a floating tag plus a
+       restart is the ONLY way that edge can ever move. This is exactly the
+       pre-#569 behaviour, kept for exactly the edges that still depend on it:
+       mirror installs (sync the mirror, restart) and `imageRefresh.enabled:
+       false` (restart manually), which is what values.schema.json has always
+       promised those operators.
+
+  The trade is deliberate and worth stating plainly: offline-restart safety is
+  delivered precisely where the digest reconcile can deliver updates. An edge
+  that opts out of the mechanism keeps the old semantics rather than silently
+  freezing — a frozen control plane with no signal is worse than a restart that
+  needs the network.
+
+  Usage: {{ include "tracebloc.controlPlanePullPolicy" (dict "digest" $d "root" $) }}
+*/}}
+{{- define "tracebloc.controlPlanePullPolicy" -}}
+{{- $mirror := (dig "imageRegistry" "docker.io" (.root.Values.global | default dict)) | default "docker.io" -}}
+{{- if .digest -}}
+IfNotPresent
+{{- else if and (include "tracebloc.imageRefreshEnabled" .root) (eq $mirror "docker.io") -}}
+IfNotPresent
+{{- else -}}
+Always
+{{- end -}}
+{{- end }}
+
+{{/*
   StorageClass name: when storageClass.create is true, use a release-unique name
   so each release gets its own StorageClass (avoids Helm ownership conflicts).
   When create is false, use the user-provided storageClass.name for an existing class.

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -188,6 +188,36 @@ mysql-pvc
   ever absent. Belt-and-suspenders — see the "nil-guard every new
   top-level value key" rule in CLAUDE.md.
 */}}
+{{/*
+  tracebloc.resourceMonitorRefreshPinned — whether image-refresh has nothing to
+  do for resource-monitor. Renders "true" when so, nothing when not.
+
+  ONE definition, because there are TWO consumers that must agree:
+  `tracebloc.imageRefreshEnabled` (does the CronJob render at all?) and the
+  CronJob's own RESOURCE_MONITOR_PINNED env (does the script skip this image?).
+  The first cut of #569 wrote the rule twice and they disagreed: the helper
+  checked only the digest while the env also treated `resourceMonitor: false` as
+  pinned. With the DaemonSet disabled and both class-1 images pinned, the CronJob
+  therefore kept rendering a job that skipped every image and exited green every
+  tick, forever — where before #569 that combination retired it (Bugbot).
+
+  Two ways to have nothing to do:
+    * an explicit `images.resourceMonitor.digest` pin, same signal as the other
+      images, or
+    * `resourceMonitor: false` — there is no DaemonSet at all, so there is
+      nothing to reconcile and a cross-namespace `set image` would just fail.
+
+  Nil-safe: `.Values.resourceMonitor` absent reads as enabled, matching the
+  `ne .Values.resourceMonitor false` gate on the DaemonSet itself.
+*/}}
+{{- define "tracebloc.resourceMonitorRefreshPinned" -}}
+{{- if eq .Values.resourceMonitor false -}}
+true
+{{- else if (default dict (default dict .Values.images).resourceMonitor).digest -}}
+true
+{{- end -}}
+{{- end }}
+
 {{- define "tracebloc.imageRefreshEnabled" -}}
 {{- $ir := default dict .Values.imageRefresh -}}
 {{- $imgs := default dict .Values.images -}}
@@ -222,7 +252,7 @@ mysql-pvc
   different build of the same image forever. If that fallback is ever removed,
   requests-proxy must get its own entry in this test.
 */}}
-{{- $rmPinned := (default dict $imgs.resourceMonitor).digest -}}
+{{- $rmPinned := include "tracebloc.resourceMonitorRefreshPinned" . -}}
 {{- if not $ir.enabled -}}
 {{- else if and $jmPinned $pmPinned $rmPinned -}}
 {{- else -}}

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -164,6 +164,29 @@ mysql-pvc
 {{- end }}
 
 {{/*
+  Name for the image-refresh Role + RoleBinding in the NODE-AGENTS namespace
+  (#569). DISTINCT from tracebloc.imageRefreshName on purpose.
+
+  `nodeAgents.namespace.name` pointing back at the release namespace is a
+  supported layout — node-agents-namespace.yaml documents it and explicitly
+  skips creating the Namespace in that case. Reusing the release-namespace name
+  here collided with it: two Roles and two RoleBindings with the SAME name in
+  the SAME namespace. Helm either refuses the release or the later
+  DaemonSet-only Role overwrites the deployments Role, at which point
+  image-refresh silently loses patch on jobs-manager and requests-proxy — and
+  since those pods now render IfNotPresent, they would have no update path left
+  at all (Bugbot, High).
+
+  A separate name is correct in BOTH layouts: split namespaces get one Role
+  each, and the collapsed layout gets two complementary Roles (deployments,
+  daemonsets) bound to the same ServiceAccount, which is exactly the intended
+  grant.
+*/}}
+{{- define "tracebloc.imageRefreshNodeAgentsName" -}}
+{{ .Release.Name }}-image-refresh-node-agents
+{{- end }}
+
+{{/*
   Whether the image-refresh CronJob has anything to do. When ALL THREE
   managed images (jobs-manager, pods-monitor, resource-monitor) are
   digest-pinned, the operator has explicitly opted into reproducible

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -635,8 +635,11 @@ spec:
                 # OR when `resourceMonitor: false` disables the DaemonSet
                 # entirely — with no workload to reconcile, attempting a
                 # cross-namespace `set image` would just fail the tick.
+                # Shares ONE definition with tracebloc.imageRefreshEnabled --
+                # see tracebloc.resourceMonitorRefreshPinned. Writing the rule
+                # twice is what let the render-time and runtime views disagree.
                 - name: RESOURCE_MONITOR_PINNED
-                  value: {{ ternary "1" "0" (or (eq .Values.resourceMonitor false) (not (empty (default dict (default dict .Values.images).resourceMonitor).digest))) | quote }}
+                  value: {{ ternary "1" "0" (not (empty (include "tracebloc.resourceMonitorRefreshPinned" .))) | quote }}
                 # requests-proxy follows the jobs-manager digest by default;
                 # this flag is the per-workload override that opts it out.
                 - name: REQUESTS_PROXY_PINNED

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -11,15 +11,72 @@ metadata:
 data:
   image-refresh.sh: |
     #!/bin/sh
-    # Polls the registry for a new manifest digest and reconciles it onto
-    # the long-lived jobs-manager Deployment (the jobs-manager + pods-monitor
-    # containers, on docker.io under the floating CLIENT_ENV tag, #154).
-    # Action on change: `kubectl rollout restart` the deployment.
-    # Source of truth: an annotation on the deployment metadata
+    # Polls the registry for a new manifest digest and reconciles it onto the
+    # long-lived control-plane workloads, on docker.io under the floating
+    # CLIENT_ENV tag (#154, extended by #569).
+    #
+    # Action on change: `kubectl set image <workload> <container>=repo@digest`.
+    # It used to be `kubectl rollout restart`. #569 changed the mechanism so
+    # the always-running pods can drop `imagePullPolicy: Always`: `Always`
+    # forced a registry round-trip on every (re)start, so an offline Docker
+    # Desktop / WSL2 restart landed in ImagePullBackOff even with the image
+    # already cached in containerd. `restart` only works as an update path
+    # BECAUSE of `Always` — the two are mutually exclusive unless the image
+    # REFERENCE itself changes, which is exactly what `set image` does. The
+    # pods now render `IfNotPresent` and the kubelet pulls because it has
+    # never seen that digest, not because a policy told it to re-check a tag.
+    #
+    # Workloads reconciled (all in RELEASE_NAMESPACE unless noted):
+    #   deployment/<release>-jobs-manager      api                       (tracebloc/jobs-manager)
+    #                                          pods-monitor-container    (tracebloc/pods-monitor)
+    #   deployment/<release>-requests-proxy    proxy                     (tracebloc/jobs-manager)
+    #   daemonset/<release>-resource-monitor   tracebloc-resource-monitor
+    #                                          in NODE_AGENTS_NAMESPACE  (tracebloc/resource-monitor)
+    #
+    # requests-proxy runs the SAME tracebloc/jobs-manager image, so it follows
+    # the jobs-manager digest resolved in this tick — no second registry HEAD.
+    # Before #569 it was not reconciled at all: it stayed on its old build
+    # until some unrelated restart, then jumped to whatever the floating tag
+    # pointed at, so the two pods routinely ran different builds of one image.
+    # resource-monitor was likewise untouched (and a chart release does not
+    # change its image ref either), so it only ever moved by accident.
+    #
+    # TWO KNOWN, BOUNDED LIMITATIONS of keeping the annotation (rather than the
+    # live pod spec) as the source of truth. Both are self-healing at the next
+    # upstream image change, which at the control plane's release cadence is
+    # days, and neither can break a running edge — the pods stay offline-safe
+    # throughout because IfNotPresent does not depend on any of this.
+    #
+    #   1. HELM RE-RENDER. `helm upgrade --reset-then-reuse-values` (the fleet
+    #      auto-upgrade path) re-renders the templates, which write `repo:tag`
+    #      and so revert an earlier `set image` pin. This tick will NOT re-pin:
+    #      the annotation still records that digest, so `recorded == latest`
+    #      and the loop no-ops. The edge floats on the tag until the next
+    #      upstream release re-pins it. Note this only happens on a chart
+    #      VERSION bump — auto-upgrade compares versions and skips otherwise —
+    #      so it is not an hourly revert.
+    #
+    #   2. PRE-EXISTING SKEW. requests-proxy and jobs-manager may already be
+    #      running different builds of the same image on an edge upgrading INTO
+    #      this version, because nothing reconciled requests-proxy before now.
+    #      This script converges them on the next digest change (both are set
+    #      in the same tick); it does not detect and repair skew that predates
+    #      it, because it compares registry-vs-annotation, never pod-vs-pod.
+    #
+    # Fixing either properly means reconciling against each workload's LIVE
+    # container image instead of a shared annotation — a declarative reconcile,
+    # which `set image` makes possible for the first time (`rollout restart`
+    # was a blind action, which is why the annotation existed at all). That is
+    # a deliberate follow-up, not an oversight.
+    #
+    # Source of truth: annotations on the JOBS-MANAGER deployment metadata
     # (`tracebloc.io/last-refreshed-<image>-digest`) — comparing the registry
     # digest to an annotation we wrote ourselves sidesteps imageID format
     # variation across container runtimes (kubernetes/kubernetes#108689 +
     # #115199) and multi-arch manifest-list vs platform-manifest divergence.
+    # All records live on that one Deployment even for resource-monitor: they
+    # are this script's private bookkeeping, not a property of the workload,
+    # and keeping them in one object keeps get_annotation a single read.
     #
     # The ingestor image is intentionally NOT handled here. jobs-manager
     # spawns each ingestion Job by the floating tag `images.ingestor.tag`
@@ -33,8 +90,15 @@ data:
     # regression a customer hit). Spawning by floating tag is revert-proof.
     #
     # First-tick contract: annotation missing → record the current registry
-    # digest WITHOUT restarting (no evidence of drift, no reason to churn
-    # pods).
+    # digest WITHOUT touching the workload (no evidence of drift, no reason to
+    # churn pods). #569 keeps this deliberately. Pinning on the first tick
+    # would rewrite `repo:tag` to `repo@digest` on every fresh install — a spec
+    # change, therefore a rollout, for byte-identical content, and for the
+    # resource-monitor DaemonSet that is a rollout across every node. The cost
+    # is that a freshly installed edge runs `repo:tag` until the first real
+    # digest change: still restart-safe offline (IfNotPresent), just not yet
+    # reproducible. Offline-safety is what #569 is fixing; reproducibility
+    # follows on the next upstream release.
     #
     # Parsing: awk/sed/grep + jq. jq used only where JSON-with-dotted-keys
     # or container/env-array filtering motivates it; the rest stays in pure
@@ -59,7 +123,31 @@ data:
     FLAP_KEY="tracebloc.io/refresh-flap-detected"
 
     log "release=$RELEASE_NAME namespace=$RELEASE_NAMESPACE deployment=$DEPLOYMENT_NAME"
-    log "  client images: tracebloc/{jobs-manager,pods-monitor} on docker.io under tag=$IMAGE_TAG"
+    log "  client images: tracebloc/{jobs-manager,pods-monitor,resource-monitor} on docker.io under tag=$IMAGE_TAG"
+    log "  also reconciling: deployment/${REQUESTS_PROXY_DEPLOYMENT} (jobs-manager image), daemonset/${RESOURCE_MONITOR_DAEMONSET} in ${NODE_AGENTS_NAMESPACE}"
+
+    # #569: a private-mirror install (global.imageRegistry) renders every pod
+    # image as <mirror>/tracebloc/... , but the digests resolved below come from
+    # docker.io. Writing a docker.io digest onto a mirror reference is not just
+    # wrong, it is BREAKING: the mirror may not hold that digest at all, so
+    # `set image` would pin the control plane to an unpullable ref. Under the
+    # old `rollout restart` this mismatch was merely useless (it restarted pods
+    # to re-pull the mirror's own tag); with `set image` it must fail closed.
+    #
+    # Exit 0, not 1: a mirror install has deliberately taken over image
+    # distribution, so "nothing to reconcile" is the correct steady state, not
+    # an error to page on. It is logged loudly rather than silently skipped —
+    # a green-forever CronJob that never does its job is the #571 failure mode.
+    # The CronJob is still RENDERED under a mirror (the alpine/k8s runner image
+    # is re-homed onto it, per global_image_registry_test.yaml); only the
+    # reconcile is inert.
+    if [ "$IMAGE_REGISTRY" != "docker.io" ]; then
+      log "NOTE: images are served from private mirror '${IMAGE_REGISTRY}' (global.imageRegistry), but this script resolves digests from docker.io."
+      log "      Pinning a docker.io digest onto a mirrored reference could pin an image the mirror does not hold, so auto-refresh is INERT on this edge."
+      log "      Update the control-plane images by syncing your mirror and restarting the workloads, or pin images.<image>.digest explicitly."
+      log "tick complete"
+      exit 0
+    fi
 
     # kubectl in the alpine/k8s image does NOT reliably auto-detect in-cluster
     # config in this Job's pod: with no kubeconfig on disk it falls back to
@@ -201,18 +289,26 @@ data:
     fi
 
     # =================================================================
-    # Pass 1 — class-1 images: jobs-manager + pods-monitor.
-    # docker.io, floating CLIENT_ENV tag, annotation-based source of
-    # truth, action = kubectl rollout restart.
+    # Pass 1 — the control-plane images: jobs-manager, pods-monitor,
+    # resource-monitor. docker.io, floating CLIENT_ENV tag,
+    # annotation-based source of truth, action = kubectl set image.
     # =================================================================
 
     restart_needed=0
     annotate_args=""
+    # `kubectl set image` argument lists, accumulated per WORKLOAD (a single
+    # `set image` call can carry several container=ref pairs, so the
+    # two-container jobs-manager Deployment is re-imaged in one patch and
+    # therefore one rollout, not two).
+    jm_set_args=""
+    rp_set_args=""
+    rm_set_args=""
 
     # Each entry: "<docker-hub-repo>|<annotation-key>|<pin-flag>".
     set -- \
       "tracebloc/jobs-manager|tracebloc.io/last-refreshed-jobs-manager-digest|${JOBS_MANAGER_PINNED}" \
-      "tracebloc/pods-monitor|tracebloc.io/last-refreshed-pods-monitor-digest|${PODS_MONITOR_PINNED}"
+      "tracebloc/pods-monitor|tracebloc.io/last-refreshed-pods-monitor-digest|${PODS_MONITOR_PINNED}" \
+      "tracebloc/resource-monitor|tracebloc.io/last-refreshed-resource-monitor-digest|${RESOURCE_MONITOR_PINNED}"
 
     for entry in "$@"; do
       repo="${entry%%|*}"
@@ -239,18 +335,52 @@ data:
       log "  recorded=${recorded:-<unset>}"
 
       if [ -z "$recorded" ]; then
-        # First-observation path: record without restarting. No evidence
-        # the running pod is on an older digest; a spurious restart on
-        # install would surprise operators.
-        log "  first observation; recording without restart"
+        # First-observation path: record without re-imaging. No evidence
+        # the running pod is on an older digest, and rewriting repo:tag to
+        # repo@digest for identical content would roll every pod on install
+        # (see the first-tick contract in the header).
+        log "  first observation; recording without re-imaging"
         annotate_args="$annotate_args ${key}=${latest}"
-      elif [ "$recorded" = "$latest" ]; then
-        log "  digest unchanged since last refresh; no-op"
-      else
-        log "  digest changed (${recorded} -> ${latest}); restart needed"
-        annotate_args="$annotate_args ${key}=${latest}"
-        restart_needed=1
+        continue
       fi
+
+      if [ "$recorded" = "$latest" ]; then
+        log "  digest unchanged since last refresh; no-op"
+        continue
+      fi
+
+      log "  digest changed (${recorded} -> ${latest}); re-image needed"
+      annotate_args="$annotate_args ${key}=${latest}"
+      restart_needed=1
+
+      # The reference we pin. IMAGE_REGISTRY is docker.io here — a mirror
+      # exits the tick far above — but render it from the variable so this
+      # stays honest if that guard is ever relaxed.
+      ref="${IMAGE_REGISTRY}/${repo}@${latest}"
+
+      # Map the image onto the workload+container(s) that run it. Container
+      # names are contractual with the templates; keep them in sync with
+      # jobs-manager-deployment.yaml, requests-proxy-deployment.yaml and
+      # resource-monitor-daemonset.yaml.
+      case "$repo" in
+        tracebloc/jobs-manager)
+          jm_set_args="$jm_set_args api=${ref}"
+          # requests-proxy runs this SAME image. It follows the jobs-manager
+          # digest unless the operator pinned it separately via
+          # images.requestsProxy.digest, which is a per-workload override.
+          if [ "$REQUESTS_PROXY_PINNED" = "1" ]; then
+            log "  requests-proxy is pinned by images.requestsProxy.digest; not following this digest"
+          else
+            rp_set_args="$rp_set_args proxy=${ref}"
+          fi
+          ;;
+        tracebloc/pods-monitor)
+          jm_set_args="$jm_set_args pods-monitor-container=${ref}"
+          ;;
+        tracebloc/resource-monitor)
+          rm_set_args="$rm_set_args tracebloc-resource-monitor=${ref}"
+          ;;
+      esac
     done
 
     # Order matters: rollout FIRST, annotate AFTER `rollout status`
@@ -277,7 +407,7 @@ data:
       # absent, so we can tell the two apart. On a read error we cannot confirm
       # we are clear to restart, so take the SAFE branch: skip this tick.
       if ! attempt="$(get_annotation "$ATTEMPT_KEY")"; then
-        log "  WARN: could not read ${ATTEMPT_KEY} annotation (kubectl/jq error); cannot confirm the rollout attempt count -- skipping the restart this tick rather than risk churning a flapping deployment. Will retry next tick."
+        log "  WARN: could not read ${ATTEMPT_KEY} annotation (kubectl/jq error); cannot confirm the rollout attempt count -- skipping the re-image this tick rather than risk churning a flapping workload. Will retry next tick."
         log "tick complete"
         exit 0
       fi
@@ -294,7 +424,7 @@ data:
         # monitoring via FLAP_KEY (value = the failure count) and leave the count
         # in place; refresh re-arms once someone clears the ${ATTEMPT_KEY}
         # annotation (or fixes the image so the next rollout settles).
-        log "  WARN: rollout for the current image digest(s) failed ${attempt} time(s) in a row (>= MAX_REFRESH_ATTEMPTS=${MAX_REFRESH_ATTEMPTS}) -- FLAP DETECTED. NOT restarting deployment/${DEPLOYMENT_NAME} (it becomes Ready then crashes; further restarts only churn ReplicaSets). MANUAL ATTENTION NEEDED: investigate the deployment, then clear its ${ATTEMPT_KEY} annotation to re-arm refresh."
+        log "  WARN: rollout for the current image digest(s) failed ${attempt} time(s) in a row (>= MAX_REFRESH_ATTEMPTS=${MAX_REFRESH_ATTEMPTS}) -- FLAP DETECTED. NOT re-imaging the control-plane workloads (a workload becomes Ready then crashes; retrying only churns ReplicaSets). MANUAL ATTENTION NEEDED: investigate deployment/${DEPLOYMENT_NAME}, deployment/${REQUESTS_PROXY_DEPLOYMENT} and daemonset/${RESOURCE_MONITOR_DAEMONSET}, then clear the ${ATTEMPT_KEY} annotation on deployment/${DEPLOYMENT_NAME} to re-arm refresh."
         kubectl annotate deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" \
           "${FLAP_KEY}=${attempt}" --overwrite --request-timeout=15s
         log "tick complete"
@@ -308,12 +438,51 @@ data:
       kubectl annotate deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" \
         "${ATTEMPT_KEY}=${new_count}" --overwrite --request-timeout=15s
 
-      log "rolling restart of deployment/${DEPLOYMENT_NAME} (attempt ${new_count}/${MAX_REFRESH_ATTEMPTS})"
-      kubectl rollout restart -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" \
-        --request-timeout=15s
-      kubectl rollout status  -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" \
-        --timeout="$ROLLOUT_TIMEOUT"
-      log "rollout complete"
+      log "re-imaging control-plane workloads (attempt ${new_count}/${MAX_REFRESH_ATTEMPTS})"
+
+      # `kubectl set image` per workload, each followed by its own
+      # `rollout status`. Under `set -e` a rollout that does not settle exits
+      # the tick here, leaving the incremented counter above in place — the
+      # #563 flap semantics are unchanged by the mechanism swap.
+      #
+      # `set image` is IDEMPOTENT in a way `rollout restart` never was: it
+      # writes a desired reference, so re-running it with the same digest is a
+      # no-op patch that triggers no rollout. A tick that dies partway (say
+      # resource-monitor fails after jobs-manager succeeded) can therefore be
+      # retried wholesale on the next tick without re-rolling the workloads
+      # that already landed.
+      #
+      # shellcheck disable=SC2086  # word-splitting the arg lists is intentional
+      if [ -n "$jm_set_args" ]; then
+        log "  set image deployment/${DEPLOYMENT_NAME}:${jm_set_args}"
+        kubectl set image -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" \
+          $jm_set_args --request-timeout=15s
+        kubectl rollout status -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" \
+          --timeout="$ROLLOUT_TIMEOUT"
+        log "  deployment/${DEPLOYMENT_NAME} rollout complete"
+      fi
+
+      if [ -n "$rp_set_args" ]; then
+        log "  set image deployment/${REQUESTS_PROXY_DEPLOYMENT}:${rp_set_args}"
+        kubectl set image -n "$RELEASE_NAMESPACE" "deployment/${REQUESTS_PROXY_DEPLOYMENT}" \
+          $rp_set_args --request-timeout=15s
+        kubectl rollout status -n "$RELEASE_NAMESPACE" "deployment/${REQUESTS_PROXY_DEPLOYMENT}" \
+          --timeout="$ROLLOUT_TIMEOUT"
+        log "  deployment/${REQUESTS_PROXY_DEPLOYMENT} rollout complete"
+      fi
+
+      if [ -n "$rm_set_args" ]; then
+        # Cross-namespace: the DaemonSet lives in the node-agents namespace,
+        # reachable via the second, narrower Role (see image-refresh-rbac.yaml).
+        log "  set image daemonset/${RESOURCE_MONITOR_DAEMONSET} in ${NODE_AGENTS_NAMESPACE}:${rm_set_args}"
+        kubectl set image -n "$NODE_AGENTS_NAMESPACE" "daemonset/${RESOURCE_MONITOR_DAEMONSET}" \
+          $rm_set_args --request-timeout=15s
+        kubectl rollout status -n "$NODE_AGENTS_NAMESPACE" "daemonset/${RESOURCE_MONITOR_DAEMONSET}" \
+          --timeout="$ROLLOUT_TIMEOUT"
+        log "  daemonset/${RESOURCE_MONITOR_DAEMONSET} rollout complete"
+      fi
+
+      log "re-image complete"
       # Success (settled rollout): reset the failure counter and clear any flap
       # marker so a future change starts fresh. #626 (CID 3729110045): do this in
       # its OWN bounded annotate BEFORE the digest record below -- do NOT batch it
@@ -352,8 +521,8 @@ spec:
   schedule: {{ .Values.imageRefresh.schedule | quote }}
   suspend: {{ .Values.imageRefresh.suspend }}
   # Forbid: never run two checks at once. A long rollout that crosses the
-  # next scheduled tick must not stack a second `rollout restart` on top
-  # of itself — that would orphan the in-flight rollout's new ReplicaSet.
+  # next scheduled tick must not stack a second re-image on top of itself —
+  # that would orphan the in-flight rollout's new ReplicaSet.
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: {{ .Values.imageRefresh.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.imageRefresh.failedJobsHistoryLimit }}
@@ -362,9 +531,10 @@ spec:
     spec:
       backoffLimit: 2
       # MUST exceed imageRefresh.rolloutTimeout (default 10m): a legitimate tick does
-      # `rollout restart` and then waits on `rollout status` for up to that long, so a
-      # deadline below it would kill the wait mid-flight and the post-success digest
-      # annotation would never land, causing later ticks to re-restart forever (#572).
+      # `set image` and then waits on `rollout status` for up to that long — and since
+      # #569 it may do so for up to THREE workloads in sequence — so a deadline below
+      # it would kill the wait mid-flight and the post-success digest annotation would
+      # never land, causing later ticks to re-issue the same re-image forever (#572).
       # This is only a backstop -- every API call is already --request-timeout-bounded;
       # it just caps the total wall-clock well above any sane rollout wait.
       activeDeadlineSeconds: 1800
@@ -407,6 +577,28 @@ spec:
                   value: {{ .Release.Namespace | quote }}
                 - name: DEPLOYMENT_NAME
                   value: {{ printf "%s-jobs-manager" .Release.Name | quote }}
+                # #569: the two additional workloads reconciled by `set image`.
+                - name: REQUESTS_PROXY_DEPLOYMENT
+                  value: {{ printf "%s-requests-proxy" .Release.Name | quote }}
+                - name: RESOURCE_MONITOR_DAEMONSET
+                  value: {{ include "tracebloc.resourceMonitorName" . | quote }}
+                - name: NODE_AGENTS_NAMESPACE
+                  value: {{ .Values.nodeAgents.namespace.name | quote }}
+                # The registry the chart renders into every pod image. The
+                # script resolves digests from docker.io only, so it goes inert
+                # when this is a private mirror rather than pinning a digest the
+                # mirror may not hold (see the guard at the top of the script).
+                #
+                # `| default "docker.io"` is NOT redundant with dig's default:
+                # values.yaml ships `global.imageRegistry: ""`, so the key EXISTS
+                # and dig returns the empty string rather than its fallback.
+                # Without the trailing default this renders "", the mirror guard
+                # below sees "" != "docker.io" and goes inert on every DEFAULT
+                # install — silently disabling refresh fleet-wide. The
+                # `tracebloc.image` helper handles the same trap with its own
+                # `| default "docker.io"`.
+                - name: IMAGE_REGISTRY
+                  value: {{ dig "imageRegistry" "docker.io" (.Values.global | default dict) | default "docker.io" | quote }}
                 - name: IMAGE_TAG
                   # RESOLVED, not raw. This is the tag the refresh pulls, so a
                   # documented alias here freezes the edge on a tag the publish
@@ -427,6 +619,17 @@ spec:
                   value: {{ ternary "1" "0" (not (empty (default dict (default dict .Values.images).jobsManager).digest)) | quote }}
                 - name: PODS_MONITOR_PINNED
                   value: {{ ternary "1" "0" (not (empty (default dict (default dict .Values.images).podsMonitor).digest)) | quote }}
+                # #569: resource-monitor is refreshed too. It counts as "pinned"
+                # (i.e. skip it) either when an operator set an explicit digest
+                # OR when `resourceMonitor: false` disables the DaemonSet
+                # entirely — with no workload to reconcile, attempting a
+                # cross-namespace `set image` would just fail the tick.
+                - name: RESOURCE_MONITOR_PINNED
+                  value: {{ ternary "1" "0" (or (eq .Values.resourceMonitor false) (not (empty (default dict (default dict .Values.images).resourceMonitor).digest))) | quote }}
+                # requests-proxy follows the jobs-manager digest by default;
+                # this flag is the per-workload override that opts it out.
+                - name: REQUESTS_PROXY_PINNED
+                  value: {{ ternary "1" "0" (not (empty (default dict (default dict .Values.images).requestsProxy).digest)) | quote }}
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -590,7 +590,7 @@ spec:
                   value: {{ printf "%s-jobs-manager" .Release.Name | quote }}
                 # #569: the two additional workloads reconciled by `set image`.
                 - name: REQUESTS_PROXY_DEPLOYMENT
-                  value: {{ printf "%s-requests-proxy" .Release.Name | quote }}
+                  value: {{ include "tracebloc.requestsProxyName" . | quote }}
                 - name: RESOURCE_MONITOR_DAEMONSET
                   value: {{ include "tracebloc.resourceMonitorName" . | quote }}
                 - name: NODE_AGENTS_NAMESPACE

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -145,6 +145,7 @@ data:
       log "NOTE: images are served from private mirror '${IMAGE_REGISTRY}' (global.imageRegistry), but this script resolves digests from docker.io."
       log "      Pinning a docker.io digest onto a mirrored reference could pin an image the mirror does not hold, so auto-refresh is INERT on this edge."
       log "      Update the control-plane images by syncing your mirror and restarting the workloads, or pin images.<image>.digest explicitly."
+      log "      (That restart DOES re-pull: because this reconcile is inert here, the chart renders imagePullPolicy=Always on the unpinned control-plane images rather than IfNotPresent -- see the tracebloc.controlPlanePullPolicy helper. Offline-restart safety is traded away on this edge precisely so it is not left with no update path at all.)"
       log "tick complete"
       exit 0
     fi

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -530,14 +530,24 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
-      # MUST exceed imageRefresh.rolloutTimeout (default 10m): a legitimate tick does
-      # `set image` and then waits on `rollout status` for up to that long — and since
-      # #569 it may do so for up to THREE workloads in sequence — so a deadline below
-      # it would kill the wait mid-flight and the post-success digest annotation would
-      # never land, causing later ticks to re-issue the same re-image forever (#572).
-      # This is only a backstop -- every API call is already --request-timeout-bounded;
-      # it just caps the total wall-clock well above any sane rollout wait.
-      activeDeadlineSeconds: 1800
+      # MUST exceed (number of reconciled workloads) x imageRefresh.rolloutTimeout.
+      # A legitimate tick does `set image` and then waits on `rollout status` for up
+      # to rolloutTimeout — and since #569 it may do so for up to THREE workloads IN
+      # SEQUENCE (jobs-manager, requests-proxy, resource-monitor).
+      #
+      # This was a hardcoded 1800 (30m), which with the default 10m rolloutTimeout is
+      # EXACTLY 3 x 10m — zero headroom (Bugbot). Blowing the deadline is not a benign
+      # timeout: the Job is killed mid-wait, so under `set -e` the post-success
+      # annotate never runs, the digest record never advances, and the
+      # `refresh-attempt` counter stays incremented. Three such ticks trip the #563
+      # flap lockout on the SHARED counter, which stops refresh for ALL control-plane
+      # images at once — while the CronJob looks healthy from outside.
+      #
+      # Now a value, defaulting to 3600 (60m) = 3 x the default rolloutTimeout plus
+      # 100% slack. An operator who raises rolloutTimeout must raise this too; the
+      # schema and values.yaml say so. Still only a backstop — every API call is
+      # already --request-timeout-bounded.
+      activeDeadlineSeconds: {{ .Values.imageRefresh.activeDeadlineSeconds | default 3600 }}
       template:
         metadata:
           labels:

--- a/client/templates/image-refresh-rbac.yaml
+++ b/client/templates/image-refresh-rbac.yaml
@@ -82,7 +82,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "tracebloc.imageRefreshName" . }}
+  name: {{ include "tracebloc.imageRefreshNodeAgentsName" . }}
   namespace: {{ .Values.nodeAgents.namespace.name }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
@@ -101,18 +101,22 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "tracebloc.imageRefreshName" . }}
+  name: {{ include "tracebloc.imageRefreshNodeAgentsName" . }}
   namespace: {{ .Values.nodeAgents.namespace.name }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
     app.kubernetes.io/component: image-refresh
 subjects:
+  # The SUBJECT keeps tracebloc.imageRefreshName: there is only ONE
+  # ServiceAccount, and it lives in the release namespace. Only the Role and
+  # RoleBinding are renamed, to avoid colliding with the release-namespace pair
+  # when nodeAgents.namespace.name points back at the release namespace.
   - kind: ServiceAccount
     name: {{ include "tracebloc.imageRefreshName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ include "tracebloc.imageRefreshName" . }}
+  name: {{ include "tracebloc.imageRefreshNodeAgentsName" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}

--- a/client/templates/image-refresh-rbac.yaml
+++ b/client/templates/image-refresh-rbac.yaml
@@ -11,11 +11,15 @@ metadata:
 ---
 {{/*
   Namespace-scoped Role — narrower than autoUpgrade's cluster-admin
-  binding on purpose. This CronJob only touches the jobs-manager
-  Deployment in {{ .Release.Namespace }}: read it to compare the recorded
-  refresh digest, and patch it for `rollout restart` + annotation
-  update. No pods, no other resources, no cluster scope. A compromise
-  of this Pod is bounded to kicking and annotating one Deployment.
+  binding on purpose. This CronJob only touches Deployments in
+  {{ .Release.Namespace }}: read the jobs-manager Deployment to compare the
+  recorded refresh digest, and patch the jobs-manager + requests-proxy
+  Deployments for `kubectl set image` + annotation update. No pods, no other
+  resources, no cluster scope. A compromise of this Pod is bounded to
+  re-imaging and annotating those two Deployments.
+
+  #569 added requests-proxy as a patch target. No rule change was needed: it
+  is a Deployment in the SAME namespace, already covered below.
 */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -26,12 +30,12 @@ metadata:
     {{- include "tracebloc.labels" . | nindent 4 }}
     app.kubernetes.io/component: image-refresh
 rules:
-  # `kubectl rollout restart` + `kubectl annotate` are both patches on
-  # the deployment. `rollout status` uses a ListWatch on the deployment
+  # `kubectl set image` + `kubectl annotate` are both patches on the
+  # deployment. `rollout status` uses a ListWatch on the deployment
   # to wait for completion; a ListWatch reflector needs BOTH `list`
   # (initial sync) and `watch` (incremental updates). Missing either
   # one drops the call into a 403 retry loop until --timeout fires
-  # (kubectl#580), marking every successful restart as a failed Job.
+  # (kubectl#580), marking every successful refresh as a failed Job.
   # Both caught in PR #155 review.
   - apiGroups: ["apps"]
     resources: ["deployments"]
@@ -53,4 +57,62 @@ roleRef:
   kind: Role
   name: {{ include "tracebloc.imageRefreshName" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- if ne .Values.resourceMonitor false }}
+---
+{{/*
+  #569: the resource-monitor DaemonSet lives in the node-agents namespace, not
+  the release namespace, so reconciling its image needs a SECOND, separate Role
+  over there. This is the one genuinely new piece of trust surface in #569 —
+  everything else reuses the deployments rule above — so keep it as narrow as
+  the RBAC model allows:
+
+    * `get` + `patch` are resourceNames-scoped to the single DaemonSet this
+      chart owns. The CronJob cannot read or modify any OTHER DaemonSet in the
+      node-agents namespace, which matters because that namespace runs under
+      the `privileged` PSA profile (see nodeAgents in values.yaml).
+    * `list` + `watch` CANNOT be resourceNames-scoped — the RBAC authorizer
+      ignores resourceNames for collection verbs — and `kubectl rollout status`
+      needs both for its ListWatch reflector (same #155 reasoning as above).
+      So those two stay namespace-wide and read-only. That is the residual
+      widening: this SA can enumerate DaemonSets in tracebloc-node-agents.
+
+  Rendered only when resourceMonitor is enabled: with no DaemonSet to
+  reconcile, the grant would be pure unused surface.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  namespace: {{ .Values.nodeAgents.namespace.name }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-refresh
+rules:
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    resourceNames: [{{ include "tracebloc.resourceMonitorName" . | quote }}]
+    verbs: ["get", "patch"]
+  # Collection verbs: resourceNames is not honoured for list/watch, so these
+  # are namespace-scoped and read-only. Required by `rollout status`.
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  namespace: {{ .Values.nodeAgents.namespace.name }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-refresh
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "tracebloc.imageRefreshName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "tracebloc.imageRefreshName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -151,7 +151,15 @@ spec:
       containers:
       - name: api
         image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" (include "tracebloc.clientEnv" .) "digest" .Values.images.jobsManager.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
-        imagePullPolicy: {{ if .Values.images.jobsManager.digest }}IfNotPresent{{ else }}Always{{ end }}
+        # #569: unconditionally IfNotPresent. `Always` forced a registry
+        # round-trip on every (re)start, so an offline Docker Desktop / WSL2
+        # restart landed in ImagePullBackOff even though containerd already had
+        # the image cached. Updates no longer depend on the pull policy: the
+        # image-refresh CronJob pins each new digest onto this container with
+        # `kubectl set image` (see image-refresh-cronjob.yaml), so the image
+        # REFERENCE changes and the kubelet pulls because it has never seen that
+        # digest -- not because the policy told it to re-pull an unchanged tag.
+        imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -449,7 +457,9 @@ spec:
         {{- end }}
       - name: pods-monitor-container
         image: {{ include "tracebloc.image" (dict "repository" "tracebloc/pods-monitor" "tag" (include "tracebloc.clientEnv" .) "digest" .Values.images.podsMonitor.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
-        imagePullPolicy: {{ if .Values.images.podsMonitor.digest }}IfNotPresent{{ else }}Always{{ end }}
+        # #569: unconditionally IfNotPresent -- same reasoning as the api
+        # container above; image-refresh pins the digest with `kubectl set image`.
+        imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -151,15 +151,15 @@ spec:
       containers:
       - name: api
         image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" (include "tracebloc.clientEnv" .) "digest" .Values.images.jobsManager.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
-        # #569: unconditionally IfNotPresent. `Always` forced a registry
-        # round-trip on every (re)start, so an offline Docker Desktop / WSL2
-        # restart landed in ImagePullBackOff even though containerd already had
-        # the image cached. Updates no longer depend on the pull policy: the
-        # image-refresh CronJob pins each new digest onto this container with
-        # `kubectl set image` (see image-refresh-cronjob.yaml), so the image
-        # REFERENCE changes and the kubelet pulls because it has never seen that
-        # digest -- not because the policy told it to re-pull an unchanged tag.
-        imagePullPolicy: IfNotPresent
+        # #569: IfNotPresent wherever an update path exists without `Always` --
+        # a pinned digest, or the image-refresh reconcile. `Always` forced a
+        # registry round-trip on every (re)start, so an offline Docker Desktop /
+        # WSL2 restart landed in ImagePullBackOff even though containerd already
+        # had the image cached. See tracebloc.controlPlanePullPolicy for why this
+        # is NOT unconditional: on an edge the reconcile cannot reach (private
+        # mirror, or imageRefresh disabled) a floating tag plus a restart is the
+        # only update path there is, so it stays Always.
+        imagePullPolicy: {{ include "tracebloc.controlPlanePullPolicy" (dict "digest" .Values.images.jobsManager.digest "root" $) }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -457,9 +457,9 @@ spec:
         {{- end }}
       - name: pods-monitor-container
         image: {{ include "tracebloc.image" (dict "repository" "tracebloc/pods-monitor" "tag" (include "tracebloc.clientEnv" .) "digest" .Values.images.podsMonitor.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
-        # #569: unconditionally IfNotPresent -- same reasoning as the api
-        # container above; image-refresh pins the digest with `kubectl set image`.
-        imagePullPolicy: IfNotPresent
+        # #569: same policy as the api container above -- see
+        # tracebloc.controlPlanePullPolicy.
+        imagePullPolicy: {{ include "tracebloc.controlPlanePullPolicy" (dict "digest" .Values.images.podsMonitor.digest "root" $) }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-requests-proxy
+  name: {{ include "tracebloc.requestsProxyName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -24,10 +24,19 @@ spec:
         - name: proxy
           {{- $rpDigest := (dig "requestsProxy" "digest" "" .Values.images) }}
           image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" (include "tracebloc.clientEnv" .) "digest" $rpDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
-          # digest set -> repo@digest + IfNotPresent (restart-safe offline); empty ->
-          # repo:tag + Always. Was hardcoded Always, which ignored a pinned digest and
-          # re-pulled on every restart even when the image was already cached (#552).
-          imagePullPolicy: {{ if $rpDigest }}IfNotPresent{{ else }}Always{{ end }}
+          # #569: unconditionally IfNotPresent (was `Always` when no digest was
+          # pinned, and hardcoded `Always` before #552). `Always` re-pulled on every
+          # restart even when the image was already cached, so an offline
+          # Docker/WSL restart landed in ImagePullBackOff. Updates come from
+          # image-refresh pinning the digest with `kubectl set image`.
+          #
+          # This Deployment runs the SAME docker.io/tracebloc/jobs-manager image as
+          # the jobs-manager Deployment, and image-refresh now reconciles both to
+          # the same digest in one tick. Before #569 it reconciled only
+          # `<release>-jobs-manager`, so requests-proxy silently skewed: it stayed
+          # on the old build until some unrelated restart, then jumped to whatever
+          # the floating tag pointed at.
+          imagePullPolicy: IfNotPresent
           workingDir: /app
           command: ["python", "-m", "gunicorn"]
           args:

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -22,7 +22,25 @@ spec:
           type: RuntimeDefault
       containers:
         - name: proxy
-          {{- $rpDigest := (dig "requestsProxy" "digest" "" .Values.images) }}
+          {{- $rpImages := (.Values.images | default dict) }}
+          {{- /*
+            #569 (Bugbot): requests-proxy runs the jobs-manager IMAGE, so it must
+            follow the jobs-manager pin. `images.requestsProxy.digest` stays an
+            explicit per-workload override; when it is empty we fall back to
+            `images.jobsManager.digest`.
+
+            Without this fallback, pinning jobs-manager ALONE was a silent trap:
+            this Deployment kept rendering the floating `repo:tag` while
+            jobs-manager ran the pinned digest, AND image-refresh skips pinned
+            images — so it never wrote a `set image` for the proxy either. The
+            proxy froze on the tag indefinitely, running a different build of the
+            same image than jobs-manager. That is precisely the skew this change
+            set out to close, re-introduced through the pinning path.
+
+            Nil-guarded on `.Values.images` for --reuse-values replays predating
+            these keys.
+          */}}
+          {{- $rpDigest := (dig "requestsProxy" "digest" "" $rpImages) | default (dig "jobsManager" "digest" "" $rpImages) }}
           image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" (include "tracebloc.clientEnv" .) "digest" $rpDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
           # #569: unconditionally IfNotPresent (was `Always` when no digest was
           # pinned, and hardcoded `Always` before #552). `Always` re-pulled on every

--- a/client/templates/requests-proxy-deployment.yaml
+++ b/client/templates/requests-proxy-deployment.yaml
@@ -42,11 +42,12 @@ spec:
           */}}
           {{- $rpDigest := (dig "requestsProxy" "digest" "" $rpImages) | default (dig "jobsManager" "digest" "" $rpImages) }}
           image: {{ include "tracebloc.image" (dict "repository" "tracebloc/jobs-manager" "tag" (include "tracebloc.clientEnv" .) "digest" $rpDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
-          # #569: unconditionally IfNotPresent (was `Always` when no digest was
-          # pinned, and hardcoded `Always` before #552). `Always` re-pulled on every
-          # restart even when the image was already cached, so an offline
-          # Docker/WSL restart landed in ImagePullBackOff. Updates come from
-          # image-refresh pinning the digest with `kubectl set image`.
+          # #569: IfNotPresent wherever an update path exists without `Always` --
+          # a pinned digest, or the image-refresh reconcile (see
+          # tracebloc.controlPlanePullPolicy; it stays Always on an edge the
+          # reconcile cannot reach, or that edge could never update at all).
+          # `Always` re-pulled on every restart even when the image was already
+          # cached, so an offline Docker/WSL restart landed in ImagePullBackOff.
           #
           # This Deployment runs the SAME docker.io/tracebloc/jobs-manager image as
           # the jobs-manager Deployment, and image-refresh now reconciles both to
@@ -54,7 +55,7 @@ spec:
           # `<release>-jobs-manager`, so requests-proxy silently skewed: it stayed
           # on the old build until some unrelated restart, then jumped to whatever
           # the floating tag pointed at.
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ include "tracebloc.controlPlanePullPolicy" (dict "digest" $rpDigest "root" $) }}
           workingDir: /app
           command: ["python", "-m", "gunicorn"]
           args:

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -28,6 +28,25 @@ spec:
   selector:
     matchLabels:
       app: {{ include "tracebloc.resourceMonitorName" . }}
+  # #569 (Bugbot): #569 made this DaemonSet a `kubectl set image` target, and the
+  # refresh tick then BLOCKS on `rollout status` for up to imageRefresh.rolloutTimeout
+  # (10m). The Kubernetes default is maxUnavailable: 1 — strictly one node at a time —
+  # so on a multi-node cluster a single digest change takes (nodes x pull+start time)
+  # to converge and blows that wait long before the image is bad. The tick then fails,
+  # the digest annotation never advances, and three of those trip the #563 flap lockout
+  # for every control-plane image, not just this one.
+  #
+  # 10% widens the wave enough that rollout time scales with the cluster instead of
+  # with node COUNT, while never taking out more than a tenth of the fleet's metrics
+  # collection at once. Safe here specifically because resource-monitor is a read-only
+  # node metrics reader: a node without it briefly reports no utilisation, which
+  # degrades scheduling telemetry and nothing else — no training pod, ingestion Job, or
+  # control-plane request depends on it being present. Kubernetes rounds 10% DOWN and
+  # floors it at 1, so small clusters keep exactly today's one-at-a-time behaviour.
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
   template:
     metadata:
       labels:

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -70,15 +70,17 @@ spec:
           */}}
           {{- $rmDigest := (default (dict) (default (dict) .Values.images).resourceMonitor).digest | default "" }}
           image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" (include "tracebloc.clientEnv" .) "digest" $rmDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
-          # #569: unconditionally IfNotPresent. `Always` made every node's pod
+          # #569: IfNotPresent wherever an update path exists without `Always` --
+          # see tracebloc.controlPlanePullPolicy. `Always` made every node's pod
           # re-pull on restart, so an offline restart wedged the DaemonSet in
           # ImagePullBackOff fleet-wide. This DaemonSet previously had NO
           # deliberate update path at all (image-refresh did not touch it, and a
           # chart release does not change its image ref) -- it only moved when a
           # pod happened to restart. image-refresh now reconciles it explicitly
-          # with `kubectl set image`, so IfNotPresent costs nothing and the
-          # update path is intentional for the first time.
-          imagePullPolicy: IfNotPresent
+          # with `kubectl set image`, so the update path is intentional for the
+          # first time -- but only where that reconcile can run, which is exactly
+          # what the helper gates on.
+          imagePullPolicy: {{ include "tracebloc.controlPlanePullPolicy" (dict "digest" $rmDigest "root" $) }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/client/templates/resource-monitor-daemonset.yaml
+++ b/client/templates/resource-monitor-daemonset.yaml
@@ -51,7 +51,15 @@ spec:
           */}}
           {{- $rmDigest := (default (dict) (default (dict) .Values.images).resourceMonitor).digest | default "" }}
           image: {{ include "tracebloc.image" (dict "repository" "tracebloc/resource-monitor" "tag" (include "tracebloc.clientEnv" .) "digest" $rmDigest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
-          imagePullPolicy: {{ if $rmDigest }}IfNotPresent{{ else }}Always{{ end }}
+          # #569: unconditionally IfNotPresent. `Always` made every node's pod
+          # re-pull on restart, so an offline restart wedged the DaemonSet in
+          # ImagePullBackOff fleet-wide. This DaemonSet previously had NO
+          # deliberate update path at all (image-refresh did not touch it, and a
+          # chart release does not change its image ref) -- it only moved when a
+          # pod happened to restart. image-refresh now reconciles it explicitly
+          # with `kubectl set image`, so IfNotPresent costs nothing and the
+          # update path is intentional for the first time.
+          imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -800,3 +800,60 @@ tests:
           path: metadata.name
           value: stg-image-refresh-node-agents
         documentIndex: 4
+
+  # =====================================================================
+  # Two-sided-contract guards. Three of #569's review findings were one
+  # side of a contract moving without the other. These pin the sides that
+  # are still spelled out in two places.
+  # =====================================================================
+
+  - it: reconcile targets match the workload names the chart actually renders
+    # DEPLOYMENT_NAME re-derives `<release>-jobs-manager` with its own printf,
+    # and five other call sites spell it out too (NOTES.txt, the PDB,
+    # tracebloc.serviceAccountName, ...). Unifying that is a mechanical refactor
+    # across templates this change does not touch, so it is left for its own PR
+    # — this test is the interim binding. A `set image` against a name that no
+    # longer exists fails the tick, freezes the digest record, and eventually
+    # trips the shared flap lockout for every control-plane image.
+    # requests-proxy IS unified now (tracebloc.requestsProxyName); resource-monitor
+    # already was (tracebloc.resourceMonitorName). Cross-check these literals
+    # against jobs_manager_test / requests_proxy_test / resource_monitor_test,
+    # which pin the same strings from the workload side.
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: DEPLOYMENT_NAME
+            value: "stg-jobs-manager"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: REQUESTS_PROXY_DEPLOYMENT
+            value: "stg-requests-proxy"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_MONITOR_DAEMONSET
+            value: "stg-resource-monitor"
+
+  - it: set-image container names match the containers the chart renders
+    # `kubectl set image <workload> <container>=<ref>` fails outright if the
+    # container name is wrong, so these four strings are a hard contract with
+    # the workload templates. Pinned from the workload side too.
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'jm_set_args api='
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'jm_set_args pods-monitor-container='
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'rp_set_args proxy='
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'rm_set_args tracebloc-resource-monitor='

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -527,6 +527,13 @@ tests:
     asserts:
       - isKind:
           of: Role
+      # DISTINCT name from the release-namespace Role. Reusing it collided when
+      # nodeAgents.namespace.name points back at the release namespace — a
+      # supported layout — and the loser was the deployments Role, silently
+      # costing image-refresh its patch on jobs-manager and requests-proxy.
+      - equal:
+          path: metadata.name
+          value: stg-image-refresh-node-agents
       - equal:
           path: metadata.namespace
           value: tracebloc-node-agents
@@ -557,11 +564,20 @@ tests:
           path: subjects[0].namespace
           value: tracebloc
       - equal:
+          path: metadata.name
+          value: stg-image-refresh-node-agents
+      # The SUBJECT keeps the un-suffixed name: there is only ONE
+      # ServiceAccount and it lives in the release namespace. Only the Role and
+      # RoleBinding are renamed.
+      - equal:
           path: subjects[0].name
           value: stg-image-refresh
       - equal:
           path: roleRef.kind
           value: Role
+      - equal:
+          path: roleRef.name
+          value: stg-image-refresh-node-agents
 
   - it: cronjob wires the workload names the set-image reconcile targets
     template: templates/image-refresh-cronjob.yaml
@@ -743,3 +759,44 @@ tests:
           content:
             name: RESOURCE_MONITOR_PINNED
             value: "1"
+
+  - it: RBAC names do not collide when node-agents shares the release namespace (#569, Bugbot High)
+    # `nodeAgents.namespace.name` pointing back at the release namespace is a
+    # supported layout — node-agents-namespace.yaml documents it and skips
+    # creating the Namespace in that case. Both Role/RoleBinding pairs then land
+    # in ONE namespace, so they must have distinct names or Helm refuses the
+    # release (or the DaemonSet-only Role overwrites the deployments Role, which
+    # silently strips image-refresh's patch on jobs-manager and requests-proxy —
+    # and with IfNotPresent those pods would have no update path left).
+    template: templates/image-refresh-rbac.yaml
+    set:
+      nodeAgents:
+        namespace:
+          name: tracebloc
+    asserts:
+      - hasDocuments:
+          count: 5
+      - equal:
+          path: metadata.name
+          value: stg-image-refresh
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: tracebloc
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: stg-image-refresh-node-agents
+        documentIndex: 3
+      - equal:
+          path: metadata.namespace
+          value: tracebloc
+        documentIndex: 3
+      - equal:
+          path: metadata.name
+          value: stg-image-refresh
+        documentIndex: 2
+      - equal:
+          path: metadata.name
+          value: stg-image-refresh-node-agents
+        documentIndex: 4

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -696,3 +696,50 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.activeDeadlineSeconds
           value: 5400
+
+  - it: retires the CronJob when the DaemonSet is disabled and both class-1 images are pinned (#569, Bugbot)
+    # The helper-vs-runtime disagreement: `imageRefreshEnabled` checked only
+    # `images.resourceMonitor.digest`, while RESOURCE_MONITOR_PINNED also treated
+    # `resourceMonitor: false` as pinned. So this combination kept rendering a
+    # CronJob that skipped every image and exited green every tick forever —
+    # where before #569 it retired cleanly. Both now read one helper.
+    template: templates/image-refresh-cronjob.yaml
+    set:
+      resourceMonitor: false
+      images:
+        jobsManager:
+          digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        podsMonitor:
+          digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rbac renders nothing for that same combination
+    template: templates/image-refresh-rbac.yaml
+    set:
+      resourceMonitor: false
+      images:
+        jobsManager:
+          digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        podsMonitor:
+          digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: still renders when the DaemonSet is disabled but a class-1 image can drift
+    # Guard the other direction: disabling resource-monitor must NOT retire the
+    # CronJob while jobs-manager or pods-monitor is still floating.
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    set:
+      resourceMonitor: false
+    asserts:
+      - isKind:
+          of: CronJob
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_MONITOR_PINNED
+            value: "1"

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -670,3 +670,29 @@ tests:
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: "pods-monitor-container="
+
+  - it: the Job budget covers three sequential rollouts (#569, Bugbot)
+    # activeDeadlineSeconds MUST exceed 3 x rolloutTimeout: a tick re-images
+    # jobs-manager, requests-proxy and the resource-monitor DaemonSet in sequence
+    # and blocks on each. It was a hardcoded 1800, which with the default 10m
+    # rolloutTimeout is EXACTLY 3 x 10m — no headroom. Blowing it kills the Job
+    # mid-wait, so the annotate never lands, the recorded digest never advances,
+    # and three such ticks trip the shared flap lockout for every control-plane
+    # image at once while the CronJob still looks healthy.
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.activeDeadlineSeconds
+          value: 3600
+
+  - it: activeDeadlineSeconds is operator-overridable
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    set:
+      imageRefresh:
+        activeDeadlineSeconds: 5400
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.activeDeadlineSeconds
+          value: 5400

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -15,8 +15,21 @@ tests:
       - hasDocuments:
           count: 2
 
-  - it: rbac template renders ServiceAccount + Role + RoleBinding by default
+  # #569 added a SECOND Role + RoleBinding, in the node-agents namespace, so the
+  # CronJob can `kubectl set image` the resource-monitor DaemonSet that lives
+  # there. 3 documents -> 5.
+  - it: rbac template renders ServiceAccount + both Roles + both RoleBindings by default
     template: templates/image-refresh-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 5
+
+  # The node-agents grant is pure unused surface when there is no DaemonSet to
+  # reconcile, so it is not rendered at all in that case — back to 3 documents.
+  - it: rbac template omits the node-agents Role when resourceMonitor is disabled
+    template: templates/image-refresh-rbac.yaml
+    set:
+      resourceMonitor: false
     asserts:
       - hasDocuments:
           count: 3
@@ -39,13 +52,31 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: cronjob template renders nothing when both class-1 images are pinned
-    # jobs-manager + pods-monitor are the only images this CronJob
-    # refreshes — the ingestor is spawned by jobs-manager from a floating
-    # tag, not refreshed here. When both class-1 images are digest-pinned
+  - it: cronjob template renders nothing when all three refreshed images are pinned
+    # jobs-manager + pods-monitor + resource-monitor are the images this CronJob
+    # refreshes. The ingestor is spawned by jobs-manager from a floating tag, not
+    # refreshed here; requests-proxy runs the jobs-manager IMAGE and follows its
+    # digest, so it needs no entry of its own. When all three are digest-pinned
     # there is nothing left to reconcile, so the CronJob renders nothing.
-    # A pinned image is signalled by a non-empty `digest` — the same
-    # signal the deployment uses to switch imagePullPolicy to IfNotPresent.
+    # A pinned image is signalled by a non-empty `digest`.
+    template: templates/image-refresh-cronjob.yaml
+    set:
+      images:
+        jobsManager:
+          digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        podsMonitor:
+          digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        resourceMonitor:
+          digest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # #569 regression guard: pinning only the two class-1 images is no longer
+  # enough to retire the CronJob, because resource-monitor can still drift.
+  # Before #569 this combination rendered nothing, which would have left the
+  # DaemonSet with no update path at all.
+  - it: cronjob STILL renders when resource-monitor is unpinned but both class-1 images are
     template: templates/image-refresh-cronjob.yaml
     set:
       images:
@@ -55,9 +86,9 @@ tests:
           digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     asserts:
       - hasDocuments:
-          count: 0
+          count: 2
 
-  - it: rbac template renders nothing when both class-1 images are pinned
+  - it: rbac template renders nothing when all three refreshed images are pinned
     template: templates/image-refresh-rbac.yaml
     set:
       images:
@@ -65,6 +96,8 @@ tests:
           digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         podsMonitor:
           digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        resourceMonitor:
+          digest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
     asserts:
       - hasDocuments:
           count: 0
@@ -126,9 +159,20 @@ tests:
       - equal:
           path: metadata.name
           value: stg-image-refresh
+      # #569: the action is `kubectl set image`, NOT `kubectl rollout restart`.
+      # A restart only picks up a new build because of imagePullPolicy=Always,
+      # and Always is exactly what makes an offline restart fail. Changing the
+      # image REFERENCE is what lets the pods run IfNotPresent, so assert the
+      # new verb is present AND the old one is gone — a silent revert to
+      # `rollout restart` would leave the pull policy fix updating nothing.
       - matchRegex:
           path: data["image-refresh.sh"]
-          pattern: "kubectl rollout restart"
+          pattern: "kubectl set image"
+      # Anchored to a COMMAND line (leading whitespace, no `#`) so the header
+      # comments that explain why the mechanism changed don't trip it.
+      - notMatchRegex:
+          path: data["image-refresh.sh"]
+          pattern: '(?m)^\s*kubectl rollout restart'
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: "registry-1.docker.io"
@@ -235,11 +279,14 @@ tests:
           pattern: "kubectl get pod"
       # First-observation contract: when an annotation is absent
       # (recorded is empty), the script must record the current digest
-      # WITHOUT triggering a restart. A spurious first-tick restart
-      # would churn the deployment on every fresh install.
+      # WITHOUT touching the workload. #569 keeps this deliberately —
+      # re-imaging on the first tick would rewrite repo:tag to repo@digest
+      # for byte-identical content on every fresh install, rolling the
+      # jobs-manager Deployment and the resource-monitor DaemonSet across
+      # every node for nothing.
       - matchRegex:
           path: data["image-refresh.sh"]
-          pattern: "first observation; recording without restart"
+          pattern: "first observation; recording without re-imaging"
       # Order-of-operations contract: `rollout restart` + `rollout
       # status` MUST run before `kubectl annotate`. If we annotated
       # first and the rollout then failed, the next tick would see
@@ -361,10 +408,14 @@ tests:
     # Pod to one resource type in one namespace. Lock the rule list
     # with `equal` so a regression that adds back a pods rule (or worse,
     # a cluster role) fails loudly.
+    #
+    # #569 added requests-proxy as a `set image` target WITHOUT touching this
+    # rule list: it is a Deployment in the same namespace, already covered.
+    # The resource-monitor DaemonSet needed a separate Role — asserted below.
     template: templates/image-refresh-rbac.yaml
     asserts:
       - hasDocuments:
-          count: 3
+          count: 5
       - isKind:
           of: ServiceAccount
         documentIndex: 0
@@ -381,6 +432,10 @@ tests:
             - apiGroups: ["apps"]
               resources: ["deployments"]
               verbs: ["get", "list", "patch", "watch"]
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: tracebloc
         documentIndex: 1
       - equal:
           path: roleRef.kind
@@ -451,3 +506,167 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # =====================================================================
+  # #569 — digest-on-update: offline-restart-safe control-plane pods.
+  # =====================================================================
+
+  - it: node-agents Role is scoped to the one resource-monitor DaemonSet
+    # The single genuinely new piece of trust surface in #569. The CronJob's
+    # namespace-scoped Role cannot reach the resource-monitor DaemonSet, which
+    # lives in the node-agents namespace, so a SECOND Role goes there. That
+    # namespace runs under the `privileged` PSA profile, so keep the grant as
+    # narrow as RBAC allows and lock it with `equal`:
+    #   * get + patch are resourceNames-scoped to this chart's own DaemonSet.
+    #   * list + watch CANNOT be resourceNames-scoped (the authorizer ignores
+    #     resourceNames for collection verbs) and `rollout status` needs both,
+    #     so they stay namespace-wide and read-only. That is the residual
+    #     widening and it is deliberate — assert it so it cannot grow silently.
+    template: templates/image-refresh-rbac.yaml
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-node-agents
+      - equal:
+          path: rules
+          value:
+            - apiGroups: ["apps"]
+              resources: ["daemonsets"]
+              resourceNames: ["stg-resource-monitor"]
+              verbs: ["get", "patch"]
+            - apiGroups: ["apps"]
+              resources: ["daemonsets"]
+              verbs: ["list", "watch"]
+
+  - it: node-agents RoleBinding binds the release-namespace ServiceAccount
+    # Cross-namespace binding: the Role and RoleBinding live in the node-agents
+    # namespace, but the subject SA lives in the release namespace. Getting the
+    # subject namespace wrong yields a silent 403 at `set image` time.
+    template: templates/image-refresh-rbac.yaml
+    documentIndex: 4
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-node-agents
+      - equal:
+          path: subjects[0].namespace
+          value: tracebloc
+      - equal:
+          path: subjects[0].name
+          value: stg-image-refresh
+      - equal:
+          path: roleRef.kind
+          value: Role
+
+  - it: cronjob wires the workload names the set-image reconcile targets
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: REQUESTS_PROXY_DEPLOYMENT
+            value: "stg-requests-proxy"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_MONITOR_DAEMONSET
+            value: "stg-resource-monitor"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: NODE_AGENTS_NAMESPACE
+            value: "tracebloc-node-agents"
+
+  - it: IMAGE_REGISTRY defaults to docker.io, not the empty string
+    # Regression guard with teeth. values.yaml ships `global.imageRegistry: ""`,
+    # so `dig "imageRegistry" "docker.io" .Values.global` returns "" — the key
+    # EXISTS, so dig's own default never applies. Rendering "" here would make
+    # the script's mirror guard see "" != "docker.io" and go INERT on every
+    # default install, silently disabling auto-refresh fleet-wide. The template
+    # needs a trailing `| default "docker.io"`; this test is what catches its
+    # removal.
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: IMAGE_REGISTRY
+            value: "docker.io"
+
+  - it: IMAGE_REGISTRY follows a configured private mirror
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    set:
+      global:
+        imageRegistry: "mirror.example.com"
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: IMAGE_REGISTRY
+            value: "mirror.example.com"
+
+  - it: resource-monitor counts as pinned when the DaemonSet is disabled
+    # With `resourceMonitor: false` there is no DaemonSet to reconcile, so the
+    # script must skip it rather than fail the tick on a cross-namespace
+    # `set image` against a workload that does not exist.
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    set:
+      resourceMonitor: false
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_MONITOR_PINNED
+            value: "1"
+
+  - it: requests-proxy follows the jobs-manager digest unless explicitly pinned
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 1
+    set:
+      images:
+        requestsProxy:
+          digest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: REQUESTS_PROXY_PINNED
+            value: "1"
+
+  - it: script reconciles all three workloads and goes inert behind a mirror
+    template: templates/image-refresh-cronjob.yaml
+    documentIndex: 0
+    asserts:
+      # jobs-manager (both containers), requests-proxy, resource-monitor.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: '\$jm_set_args --request-timeout'
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'deployment/\$\{REQUESTS_PROXY_DEPLOYMENT\}"'
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'daemonset/\$\{RESOURCE_MONITOR_DAEMONSET\}"'
+      # The resource-monitor patch must target the node-agents namespace, not
+      # the release namespace.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'kubectl set image -n "\$NODE_AGENTS_NAMESPACE"'
+      # Mirror guard: a docker.io digest must never be pinned onto a mirrored
+      # reference the mirror may not hold.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: 'if \[ "\$IMAGE_REGISTRY" != "docker.io" \]; then'
+      # The pods-monitor container name is contractual with the deployment.
+      - matchRegex:
+          path: data["image-refresh.sh"]
+          pattern: "pods-monitor-container="

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -711,3 +711,72 @@ tests:
           value: pods-monitor-container
       - notExists:
           path: spec.template.spec.containers[1].readinessProbe
+
+  # =====================================================================
+  # #569 pull policy. NOT unconditional — it tracks whether an update path
+  # exists that does not depend on `Always`. See the
+  # tracebloc.controlPlanePullPolicy helper.
+  # =====================================================================
+
+  - it: both containers are IfNotPresent by default (refresh on, docker.io)
+    # The offline-restart fix: `Always` forced a registry round-trip on every
+    # (re)start, so a Docker/WSL restart without the registry landed in
+    # ImagePullBackOff on a cached image. Safe here because image-refresh drives
+    # updates by changing the image REFERENCE (`kubectl set image repo@digest`).
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+      - equal:
+          path: spec.template.spec.containers[1].imagePullPolicy
+          value: IfNotPresent
+
+  - it: falls back to Always behind a private mirror (#569, Bugbot High)
+    # The reconcile resolves digests from docker.io, so it goes inert under a
+    # mirror rather than pinning a digest the mirror may not hold. If the pods
+    # were IfNotPresent anyway, that edge would have NO update path at all:
+    # syncing the mirror and restarting would keep serving the cached tag, and
+    # the CronJob would stay green while the control plane froze. Keep the
+    # pre-#569 semantics exactly where they are still the only thing that works.
+    set:
+      global:
+        imageRegistry: "mirror.example.com"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - equal:
+          path: spec.template.spec.containers[1].imagePullPolicy
+          value: Always
+
+  - it: falls back to Always when imageRefresh is disabled (#569, Bugbot High)
+    # values.schema.json has always told these operators that the images stay
+    # put "until manual restart" — which is only true with Always.
+    set:
+      imageRefresh:
+        enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - equal:
+          path: spec.template.spec.containers[1].imagePullPolicy
+          value: Always
+
+  - it: an explicit digest pin is IfNotPresent even with refresh disabled
+    # A digest is immutable, so re-checking the registry can only return the
+    # same image. Updates come from changing the pin, not from the policy.
+    set:
+      imageRefresh:
+        enabled: false
+      images:
+        jobsManager:
+          digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+      # pods-monitor is NOT pinned and refresh is off -> still Always.
+      - equal:
+          path: spec.template.spec.containers[1].imagePullPolicy
+          value: Always

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -780,3 +780,15 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].imagePullPolicy
           value: Always
+
+  - it: container names are the ones image-refresh set-images by name (#569)
+    # Contract with image-refresh-cronjob.yaml's `set image` args. Renaming a
+    # container here without updating that script breaks every future refresh
+    # tick. Pinned on both sides; see image_refresh_test.yaml.
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: api
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: pods-monitor-container

--- a/client/tests/requests_proxy_test.yaml
+++ b/client/tests/requests_proxy_test.yaml
@@ -237,3 +237,12 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
+
+  - it: falls back to Always where the reconcile cannot run (#569, Bugbot High)
+    set:
+      imageRefresh:
+        enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always

--- a/client/tests/requests_proxy_test.yaml
+++ b/client/tests/requests_proxy_test.yaml
@@ -246,3 +246,10 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
+
+  - it: container name is the one image-refresh set-images by name (#569)
+    # Contract with image-refresh-cronjob.yaml's `set image` args.
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: proxy

--- a/client/tests/requests_proxy_test.yaml
+++ b/client/tests/requests_proxy_test.yaml
@@ -79,14 +79,20 @@ tests:
           path: spec.template.spec.containers[0].image
           pattern: "^docker\\.io/tracebloc/jobs-manager[:@]"
 
-  - it: floats on the tag with imagePullPolicy Always when no digest is pinned (default)
+  # #569: still floats on the tag by default, but the pull policy is now
+  # IfNotPresent REGARDLESS of pinning. `Always` forced a registry round-trip on
+  # every restart, so an offline Docker/WSL restart landed in ImagePullBackOff
+  # with the image already cached. The update path moved to the image-refresh
+  # CronJob, which reconciles this Deployment to `repo@digest` with
+  # `kubectl set image` — a reference change the kubelet pulls on its own.
+  - it: floats on the tag with imagePullPolicy IfNotPresent when no digest is pinned (default)
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: "^docker\\.io/tracebloc/jobs-manager:"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
-          value: Always
+          value: IfNotPresent
 
   - it: pins repo@digest with imagePullPolicy IfNotPresent when a digest is set (#552)
     # Was hardcoded Always — a pinned digest was ignored for the pull policy, so a

--- a/client/tests/requests_proxy_test.yaml
+++ b/client/tests/requests_proxy_test.yaml
@@ -194,3 +194,46 @@ tests:
           content:
             name: TB_INGEST_USER
             value: "tb_ingest"
+
+  # #569 (Bugbot): requests-proxy runs the jobs-manager image, so pinning
+  # jobs-manager must pin the proxy too. Before this fallback, pinning
+  # jobs-manager alone left the proxy on the floating tag AND made image-refresh
+  # skip it (pinned images are skipped), so it froze on the tag forever while
+  # jobs-manager ran the pin — a different build of the same image, which is the
+  # exact skew #569 exists to close.
+  - it: follows images.jobsManager.digest when requestsProxy.digest is unset (#569)
+    set:
+      images:
+        jobsManager:
+          digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/jobs-manager@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: requestsProxy.digest overrides the jobsManager digest (per-workload pin)
+    set:
+      images:
+        jobsManager:
+          digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        requestsProxy:
+          digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/tracebloc/jobs-manager@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+  - it: still renders (no nil-pointer) when the images block is entirely absent
+    # --reuse-values replay from a release predating these keys.
+    set:
+      images: null
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^docker\\.io/tracebloc/jobs-manager:"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent

--- a/client/tests/resource_monitor_test.yaml
+++ b/client/tests/resource_monitor_test.yaml
@@ -137,3 +137,17 @@ tests:
       - equal:
           path: spec.updateStrategy.rollingUpdate.maxUnavailable
           value: "10%"
+
+  - it: falls back to Always behind a private mirror (#569, Bugbot High)
+    # Without this the DaemonSet would freeze on every node's cached image:
+    # the reconcile is inert under a mirror, and IfNotPresent means a restart
+    # never re-pulls. A frozen node agent with a green CronJob is worse than a
+    # restart that needs the network.
+    template: templates/resource-monitor-daemonset.yaml
+    set:
+      global:
+        imageRegistry: "mirror.example.com"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always

--- a/client/tests/resource_monitor_test.yaml
+++ b/client/tests/resource_monitor_test.yaml
@@ -151,3 +151,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
+
+  - it: container name is the one image-refresh set-images by name (#569)
+    # Contract with image-refresh-cronjob.yaml's `set image` args.
+    template: templates/resource-monitor-daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: tracebloc-resource-monitor

--- a/client/tests/resource_monitor_test.yaml
+++ b/client/tests/resource_monitor_test.yaml
@@ -8,6 +8,12 @@ set:
 release:
   name: stg
 tests:
+  # #569: the pull policy is now IfNotPresent UNCONDITIONALLY — it no longer
+  # tracks whether a digest is pinned. `Always` re-pulled on every pod start, so
+  # an offline Docker/WSL restart wedged the DaemonSet in ImagePullBackOff on
+  # every node despite a cached image. Updates arrive as an image REFERENCE
+  # change (`kubectl set image repo@digest` from the image-refresh CronJob), not
+  # from the pull policy re-checking a floating tag.
   - it: should render with tag fallback when no digest is set
     template: templates/resource-monitor-daemonset.yaml
     asserts:
@@ -16,7 +22,7 @@ tests:
           value: "docker.io/tracebloc/resource-monitor:prod"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
-          value: Always
+          value: IfNotPresent
 
   - it: should pin by digest when images.resourceMonitor.digest is set
     template: templates/resource-monitor-daemonset.yaml
@@ -45,7 +51,7 @@ tests:
           value: "docker.io/tracebloc/resource-monitor:prod"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
-          value: Always
+          value: IfNotPresent
 
   # v1.2.0: every shared-namespace resource that used to be literally named
   # `tracebloc-resource-monitor` is now release-scoped to `<release>-resource-monitor`,

--- a/client/tests/resource_monitor_test.yaml
+++ b/client/tests/resource_monitor_test.yaml
@@ -120,3 +120,20 @@ tests:
       - equal:
           path: metadata.name
           value: tenant-d-prod-resource-monitor
+
+  - it: rolls wider than one node at a time so refresh can wait on it (#569, Bugbot)
+    # #569 made this DaemonSet a `set image` target and the refresh tick blocks on
+    # `rollout status` for up to rolloutTimeout (10m). Kubernetes' default
+    # maxUnavailable: 1 converges in (nodes x pull+start), which blows that wait on
+    # a multi-node cluster long before the image is bad — failing the tick, freezing
+    # the digest record, and tripping the shared flap lockout. Safe to widen: this is
+    # a read-only node metrics reader, so a briefly absent pod degrades scheduling
+    # telemetry and nothing else.
+    template: templates/resource-monitor-daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.updateStrategy.rollingUpdate.maxUnavailable
+          value: "10%"

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -1059,6 +1059,12 @@
           "pattern": "^[0-9]+(s|m|h)$",
           "description": "Passed to `kubectl rollout status --timeout`. Allow headroom for bare-metal image pull."
         },
+        "activeDeadlineSeconds": {
+          "type": "integer",
+          "minimum": 60,
+          "default": 3600,
+          "description": "CronJob jobTemplate.spec.activeDeadlineSeconds. MUST exceed 3 x rolloutTimeout: since #569 a tick re-images jobs-manager, requests-proxy and the resource-monitor DaemonSet in sequence, waiting on each. Blowing the deadline kills the Job mid-wait, so the digest annotation never advances and the shared refresh-attempt counter trips the flap lockout for every control-plane image at once."
+        },
         "maxRefreshAttempts": {
           "type": "integer",
           "minimum": 1,

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -583,7 +583,7 @@
             "digest": {
               "type": "string",
               "pattern": "^(sha256:[a-f0-9]{64})?$",
-              "description": "Optional image digest (sha256:...). When set, overrides the tag."
+              "description": "Optional image digest (sha256:...). When set, overrides the tag, opts this image out of image-refresh, and is ALSO inherited by the requests-proxy Deployment, which runs the same image (see images.requestsProxy.digest)."
             }
           }
         },
@@ -592,7 +592,8 @@
           "properties": {
             "digest": {
               "type": "string",
-              "pattern": "^(sha256:[a-f0-9]{64})?$"
+              "pattern": "^(sha256:[a-f0-9]{64})?$",
+              "description": "Optional image digest (sha256:...). When set, overrides the tag and opts this image out of image-refresh."
             }
           }
         },
@@ -601,7 +602,8 @@
           "properties": {
             "digest": {
               "type": "string",
-              "pattern": "^(sha256:[a-f0-9]{64})?$"
+              "pattern": "^(sha256:[a-f0-9]{64})?$",
+              "description": "Optional image digest (sha256:...). When set, overrides the tag and opts the resource-monitor DaemonSet out of image-refresh (#569 brought it under refresh; before that it had no deliberate update path at all)."
             }
           }
         },
@@ -610,7 +612,8 @@
           "properties": {
             "digest": {
               "type": "string",
-              "pattern": "^(sha256:[a-f0-9]{64})?$"
+              "pattern": "^(sha256:[a-f0-9]{64})?$",
+              "description": "Optional image digest (sha256:...) for the requests-proxy Deployment, which runs the tracebloc/jobs-manager image. Leave EMPTY (default) and it follows images.jobsManager.digest, so the two pods cannot run different builds of the same image. Set it only to pin requests-proxy independently of jobs-manager."
             }
           }
         },
@@ -1042,17 +1045,17 @@
     },
     "imageRefresh": {
       "type": "object",
-      "description": "Image-refresh CronJob (issue tracebloc/client#154). Polls Docker Hub for jobs-manager and pods-monitor digests under the floating CLIENT_ENV tag and rolls the deployment when a new image is published. Disable to keep the running image in place until manual restart.",
+      "description": "Image-refresh CronJob (issue tracebloc/client#154; reworked by #569). Polls Docker Hub for the jobs-manager, pods-monitor and resource-monitor digests under the floating CLIENT_ENV tag and, on a change, pins the new digest onto the running workloads with `kubectl set image` (jobs-manager + requests-proxy Deployments and the resource-monitor DaemonSet). It used to `kubectl rollout restart` a single Deployment; the reference change is what lets those pods run imagePullPolicy=IfNotPresent and survive an offline restart. Disable to keep the running image in place until manual restart \u2014 the chart then renders imagePullPolicy=Always on the unpinned control-plane images, because a floating tag plus a restart is the only update path left.",
       "properties": {
         "enabled": {
           "type": "boolean",
           "default": true,
-          "description": "When false, no CronJob, ServiceAccount, Role, or RoleBinding is rendered. The deployment will not auto-refresh on new image pushes."
+          "description": "When false, no CronJob, ServiceAccount, Role, or RoleBinding is rendered. The control-plane workloads will not auto-refresh on new image pushes, and the unpinned ones fall back to imagePullPolicy=Always so a manual restart still picks up a new build (see tracebloc.controlPlanePullPolicy)."
         },
         "schedule": {
           "type": "string",
           "minLength": 1,
-          "description": "Cron expression. Keep the tick rate compatible with Docker Hub's 100/6h anonymous pull-rate limit (each tick HEADs two manifests)."
+          "description": "Cron expression. Keep the tick rate compatible with Docker Hub's 100/6h anonymous pull-rate limit. Since #569 each tick HEADs THREE manifests (jobs-manager, pods-monitor, resource-monitor), not two \u2014 at the default 15m that is 12/hr, i.e. 72 per 6h. Widen the schedule on edges that share an egress IP with other Docker Hub consumers; a digest pin removes that image's HEAD from every tick."
         },
         "rolloutTimeout": {
           "type": "string",
@@ -1068,7 +1071,7 @@
         "maxRefreshAttempts": {
           "type": "integer",
           "minimum": 1,
-          "description": "Consecutive failed rollout attempts (same target digest) after which the refresh backs off instead of re-restarting a flapping deployment every tick (#563)."
+          "description": "Consecutive failed rollout attempts (same target digest) after which the refresh backs off instead of re-imaging a flapping workload every tick (#563). The counter is shared across all reconciled workloads."
         },
         "suspend": {
           "type": "boolean",

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -898,8 +898,20 @@ imageRefresh:
   enabled: true
   # Every 15 minutes at minute :07. The off-hour minute spreads load
   # across Docker Hub's registry-1 origin; 15m balances drift latency
-  # against the 100/6h anonymous pull-rate limit (2 images × 4/hr = 8/hr,
-  # well under the cap even shared with other workloads on the same IP).
+  # against the 100/6h anonymous pull-rate limit.
+  #
+  # #569 raised the per-tick cost from 2 manifest HEADs to 3 (resource-monitor
+  # joined jobs-manager and pods-monitor; requests-proxy adds none, it reuses
+  # the jobs-manager digest). At this schedule that is 3 x 4/hr = 12/hr, so
+  # 72 per 6h against the cap of 100 — up from 48. Still under, but the
+  # headroom for OTHER workloads sharing the egress IP dropped from ~52 to ~28.
+  #
+  # That matters more than the raw number: exhausting this cap behind a shared
+  # corporate NAT is one of the failure modes in the incident #569 exists to fix
+  # (a rate-limited edge cannot pull for up to ~6h). If an edge shares its
+  # egress IP with other Docker Hub consumers, widen this — "7,27,47 * * * *"
+  # (3/hr) puts the cost back to 9/hr, at the price of slower drift pickup.
+  # A digest pin on any image removes its HEAD from every tick entirely.
   schedule: "7,22,37,52 * * * *"
   # `kubectl rollout status --timeout`, applied PER WORKLOAD. Generous;
   # jobs-manager image pulls on bare-metal first-boot can take minutes, and

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -345,20 +345,34 @@ egressProxy:
 # busybox/mysql-client).
 #
 # PULL POLICY (#569). The four always-running control-plane images —
-# jobsManager, podsMonitor, requestsProxy, resourceMonitor — now render
-# `imagePullPolicy: IfNotPresent` UNCONDITIONALLY, pinned or not. `Always`
-# forced a registry round-trip on every (re)start, so an offline Docker
-# Desktop / WSL2 restart landed in ImagePullBackOff even with the image
-# already cached in containerd — the pods came back only once docker.io was
-# reachable again (up to ~6h behind Docker Hub's anonymous pull-rate limit).
+# jobsManager, podsMonitor, requestsProxy, resourceMonitor — render
+# `imagePullPolicy: IfNotPresent` wherever an update path exists that does not
+# depend on `Always`. `Always` forced a registry round-trip on every (re)start,
+# so an offline Docker Desktop / WSL2 restart landed in ImagePullBackOff even
+# with the image already cached in containerd — the pods came back only once
+# docker.io was reachable again (up to ~6h behind Docker Hub's anonymous
+# pull-rate limit).
 #
-# That was safe to change only because the UPDATE path no longer depends on
-# the pull policy. `Always` + a floating tag is an update mechanism: it is
-# what made the image-refresh CronJob's `kubectl rollout restart` pick up a
-# new build. Offline-safety and restart-driven updates are mutually exclusive
-# unless the image REFERENCE itself changes, so image-refresh now pins the
-# resolved digest with `kubectl set image repo@digest` instead. See the
-# imageRefresh block below.
+# That is safe only where the UPDATE path no longer depends on the pull policy.
+# `Always` + a floating tag IS an update mechanism: it is what made the
+# image-refresh CronJob's `kubectl rollout restart` pick up a new build.
+# Offline-safety and restart-driven updates are mutually exclusive unless the
+# image REFERENCE itself changes, so image-refresh now pins the resolved digest
+# with `kubectl set image repo@digest` instead (see the imageRefresh block).
+#
+# So the policy is NOT unconditional — it is resolved per image by the
+# `tracebloc.controlPlanePullPolicy` helper, which is the authoritative
+# description:
+#   * explicit `digest` pin      -> IfNotPresent (immutable reference)
+#   * refresh can reconcile here -> IfNotPresent (`set image` drives updates)
+#   * neither                    -> Always       (floating tag + restart is the
+#                                                 only update path there is)
+#
+# The third case is real, not theoretical: a `global.imageRegistry` mirror makes
+# the reconcile inert (it resolves digests from docker.io, which the mirror may
+# not hold), and `imageRefresh.enabled: false` disables it outright. Those edges
+# keep the pre-#569 behaviour deliberately — a frozen control plane with a green
+# CronJob and no signal is worse than a restart that needs the network.
 #
 # Setting `digest` here is still meaningful: it is an explicit operator pin
 # that also opts the image OUT of auto-refresh.

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -340,9 +340,28 @@ egressProxy:
 # For each image, set `digest` to a sha256 (e.g. "sha256:abc123...") to pin
 # the image by content hash. Digest pinning is strongly preferred: tags are
 # mutable, so registry swaps can silently change what you run. When `digest`
-# is set the tag field is ignored and imagePullPolicy drops to IfNotPresent.
-# Leave `digest` empty to fall back to tag-based pulls (CLIENT_ENV for
-# tracebloc images, `tag` for busybox/mysql-client).
+# is set the tag field is ignored. Leave `digest` empty to fall back to
+# tag-based pulls (CLIENT_ENV for tracebloc images, `tag` for
+# busybox/mysql-client).
+#
+# PULL POLICY (#569). The four always-running control-plane images —
+# jobsManager, podsMonitor, requestsProxy, resourceMonitor — now render
+# `imagePullPolicy: IfNotPresent` UNCONDITIONALLY, pinned or not. `Always`
+# forced a registry round-trip on every (re)start, so an offline Docker
+# Desktop / WSL2 restart landed in ImagePullBackOff even with the image
+# already cached in containerd — the pods came back only once docker.io was
+# reachable again (up to ~6h behind Docker Hub's anonymous pull-rate limit).
+#
+# That was safe to change only because the UPDATE path no longer depends on
+# the pull policy. `Always` + a floating tag is an update mechanism: it is
+# what made the image-refresh CronJob's `kubectl rollout restart` pick up a
+# new build. Offline-safety and restart-driven updates are mutually exclusive
+# unless the image REFERENCE itself changes, so image-refresh now pins the
+# resolved digest with `kubectl set image repo@digest` instead. See the
+# imageRefresh block below.
+#
+# Setting `digest` here is still meaningful: it is an explicit operator pin
+# that also opts the image OUT of auto-refresh.
 images:
   jobsManager:
     digest: ""
@@ -697,9 +716,13 @@ podTokenTtlSeconds: 604800
 #     `sort -V`, so 1.10 > 1.9 — not a string compare).
 #   - --reuse-values is passed, so secrets (clientId, clientPassword,
 #     dockerRegistry creds) and any operator overrides are preserved.
-#   - imagePullPolicy on tracebloc images is `Always` when no digest is
-#     pinned, so the chart upgrade also picks up new image content for the
-#     floating prod/dev tags as pods restart.
+#   - NOTE (#569): a chart upgrade no longer picks up new IMAGE content as a
+#     side effect. That used to work because the control-plane pods ran
+#     `imagePullPolicy: Always`, so any restart re-resolved the floating tag;
+#     they now run IfNotPresent so an offline restart cannot fail. New image
+#     content arrives via the image-refresh CronJob's `kubectl set image`
+#     instead. This CronJob still delivers everything else a chart release
+#     carries — template, RBAC, values-default and schema changes.
 #
 # Trust boundary: the CronJob's ServiceAccount is bound to the built-in
 # `cluster-admin` ClusterRole, so it can apply any resource the chart
@@ -761,51 +784,90 @@ autoUpgrade:
       cpu: "500m"
       memory: "256Mi"
 
-# -- Image-refresh CronJob (closes tracebloc/client#154).
-# Auto-restarts the jobs-manager Deployment when a new image digest is
-# published to Docker Hub under the floating CLIENT_ENV tag. Without
-# this, `imagePullPolicy: Always` only pulls on pod creation — running
-# pods stay on the old image until someone manually
-# `kubectl rollout restart`s them, which is exactly the
-# customer-runs-no-commands UX we want to avoid.
+# -- Image-refresh CronJob (closes tracebloc/client#154; reworked by #569).
+# Re-images the always-running control-plane workloads when a new image
+# digest is published to Docker Hub under the floating CLIENT_ENV tag.
+# Without this, running pods stay on the old image until someone manually
+# restarts them, which is exactly the customer-runs-no-commands UX we want
+# to avoid.
+#
+# #569 changed the ACTION from `kubectl rollout restart` to `kubectl set
+# image repo@digest`, and widened the set of workloads it covers. A restart
+# only picks up a new build when the pods run `imagePullPolicy: Always` —
+# and `Always` is precisely what made an offline Docker/WSL restart fail
+# with ImagePullBackOff on a cached image. The two properties are mutually
+# exclusive unless the image REFERENCE changes on update, so the reference
+# is now what changes; the pods run IfNotPresent (see the images block).
 #
 # How it works:
 #   - A CronJob in this namespace polls Docker Hub for the current
-#     manifest digest of tracebloc/jobs-manager:<CLIENT_ENV> and
-#     tracebloc/pods-monitor:<CLIENT_ENV> (both containers live in one
-#     deployment).
+#     manifest digest of tracebloc/jobs-manager:<CLIENT_ENV>,
+#     tracebloc/pods-monitor:<CLIENT_ENV> and
+#     tracebloc/resource-monitor:<CLIENT_ENV>.
 #   - The script compares each fetched digest to an annotation on the
-#     deployment (`tracebloc.io/last-refreshed-<image>-digest`) that
-#     records the digest the LAST successful refresh restarted to. Not
+#     jobs-manager deployment (`tracebloc.io/last-refreshed-<image>-digest`)
+#     that records the digest the LAST successful refresh moved to. Not
 #     to the running pod's imageID — that value's format varies across
 #     container runtimes (kubernetes/kubernetes#108689 + #115199) and
 #     diverges from the registry's index digest on multi-arch tags.
 #     The annotation makes the comparison entirely server-vs-our-record
 #     with no client-side runtime variation in the loop.
-#   - On a real change: `kubectl rollout restart` + `kubectl rollout
-#     status` to wait for completion, then patch the annotation to the
-#     new digest. (Order matters — annotating first would let a failed
-#     rollout silently freeze the deployment.)
+#   - On a real change: `kubectl set image` + `kubectl rollout status` to
+#     wait for completion, then patch the annotation to the new digest.
+#     (Order matters — annotating first would let a failed rollout
+#     silently freeze the workload.)
+#   - Workloads covered (#569). jobs-manager was always covered; the other
+#     two were NOT, and both were quietly broken as a result:
+#       * deployment/<release>-jobs-manager — containers `api` and
+#         `pods-monitor-container`, re-imaged in ONE patch, one rollout.
+#       * deployment/<release>-requests-proxy — runs the SAME
+#         tracebloc/jobs-manager image, so it follows the jobs-manager
+#         digest with no extra registry call. Before #569 it was never
+#         refreshed: it stayed on its old build until some unrelated
+#         restart, then jumped to whatever the tag pointed at, so the two
+#         pods routinely ran different builds of one image.
+#       * daemonset/<release>-resource-monitor — in the node-agents
+#         namespace, reached via a second, narrower Role. Before #569 it
+#         had no deliberate update path at all (a chart release does not
+#         change its image ref either); it moved only when a pod happened
+#         to restart.
 #   - First observation (annotation absent on a fresh install): record
-#     the current digest without restarting. No evidence of drift, no
-#     reason to churn the pod.
+#     the current digest without re-imaging. Rewriting repo:tag to
+#     repo@digest for byte-identical content would roll every workload —
+#     including the DaemonSet on every node — for nothing. The cost is
+#     that a fresh edge runs repo:tag until the first real digest change:
+#     still restart-safe offline, just not yet reproducible.
 #   - Idle-cheap: when the recorded digest matches today's digest, the
-#     script exits without touching the deployment. Steady state is one
-#     HEAD per image per tick, well under Docker Hub's 100/6h anonymous
+#     script exits without touching anything. Steady state is one HEAD
+#     per image per tick, well under Docker Hub's 100/6h anonymous
 #     pull-rate limit.
+#   - Private mirrors (global.imageRegistry): the script resolves digests
+#     from docker.io, so pinning one onto a mirrored reference could pin
+#     an image the mirror does not hold. It logs and goes INERT instead.
+#     Under the old `rollout restart` the mismatch was merely useless; with
+#     `set image` it has to fail closed.
 #
-# Pinned-digest interaction: if BOTH images.jobsManager.digest and
-# images.podsMonitor.digest are set, the chart skips rendering this
-# CronJob entirely — digest pinning is an explicit opt-out from drift,
-# and auto-restart would defeat the purpose. If only one is pinned the
-# CronJob still runs but the script skips the pinned image at runtime.
+# Pinned-digest interaction: if images.jobsManager.digest,
+# images.podsMonitor.digest AND images.resourceMonitor.digest are all set,
+# the chart skips rendering this CronJob entirely — digest pinning is an
+# explicit opt-out from drift, and auto-refresh would defeat the purpose.
+# If only some are pinned the CronJob still runs and the script skips the
+# pinned images at runtime. requests-proxy needs no entry in that test: it
+# follows the jobs-manager pin. Setting images.requestsProxy.digest opts
+# requests-proxy alone out of following jobs-manager.
 #
 # Trust boundary: this CronJob's ServiceAccount is bound to a
 # namespace-scoped Role with get/list/patch/watch on the deployment
-# resource ONLY (no pods, no other resources, no cluster scope). Much
-# narrower than autoUpgrade — a compromise of this Pod can only kick
-# and annotate the jobs-manager Deployment in this one namespace. The
-# script reaches out only to docker.io's public registry endpoints; if
+# resource ONLY (no pods, no other resources, no cluster scope) — a
+# compromise can only re-image and annotate the jobs-manager and
+# requests-proxy Deployments in this one namespace. #569 adds a SECOND
+# Role in the node-agents namespace for the resource-monitor DaemonSet:
+# get/patch are resourceNames-scoped to that one DaemonSet, while
+# list/watch (which RBAC cannot scope by name, and `rollout status`
+# requires) are namespace-wide and read-only. Still far narrower than
+# autoUpgrade, which holds cluster-admin.
+#
+# The script reaches out only to docker.io's public registry endpoints; if
 # your cluster requires egress through a proxy, set HTTPS_PROXY via env
 # or disable this CronJob.
 #
@@ -833,8 +895,8 @@ imageRefresh:
   # re-restarting and flags the deployment for a human. A deployment whose
   # readiness FLAPS (becomes Ready, then crashes after warmup near the
   # rollout-status timeout) fails the rollout, so `recorded` never advances and
-  # every later settled tick re-issues the same restart. After this many in-a-row
-  # failures the job stops restarting and annotates a "flap detected" marker
+  # every later settled tick re-issues the same re-image. After this many in-a-row
+  # failures the job stops re-imaging and annotates a "flap detected" marker
   # (tracebloc.io/refresh-flap-detected) so monitoring can surface it. There is
   # no auto-resume: a human investigates and clears the
   # tracebloc.io/refresh-attempt annotation to re-arm (or a rollout that finally

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -887,10 +887,27 @@ imageRefresh:
   # against the 100/6h anonymous pull-rate limit (2 images × 4/hr = 8/hr,
   # well under the cap even shared with other workloads on the same IP).
   schedule: "7,22,37,52 * * * *"
-  # `kubectl rollout status --timeout`. Generous; jobs-manager image pulls
-  # on bare-metal first-boot can take minutes, and the CronJob slot
-  # shouldn't hold all night if a rollout genuinely wedges.
+  # `kubectl rollout status --timeout`, applied PER WORKLOAD. Generous;
+  # jobs-manager image pulls on bare-metal first-boot can take minutes, and
+  # the CronJob slot shouldn't hold all night if a rollout genuinely wedges.
+  #
+  # RAISING THIS MEANS RAISING activeDeadlineSeconds BELOW — since #569 a tick
+  # can wait on up to THREE workloads in sequence, so the Job's total budget
+  # must stay above 3 x this value.
   rolloutTimeout: "10m"
+  # Job-level wall-clock backstop (CronJob jobTemplate.spec.activeDeadlineSeconds).
+  # MUST exceed 3 x rolloutTimeout: a tick re-images jobs-manager, requests-proxy
+  # and the resource-monitor DaemonSet in sequence, waiting on each.
+  #
+  # This was a hardcoded 1800 (30m). With the default 10m rolloutTimeout that is
+  # EXACTLY 3 x 10m, i.e. no headroom at all. Blowing the deadline is not a benign
+  # timeout: the Job is killed mid-wait, so the post-success annotate never runs,
+  # the recorded digest never advances, and the shared `refresh-attempt` counter
+  # stays incremented. Three such ticks trip the flap lockout for EVERY
+  # control-plane image at once, while the CronJob still looks healthy.
+  #
+  # 3600 (60m) = 3 x the default rolloutTimeout plus 100% slack.
+  activeDeadlineSeconds: 3600
   # #563: consecutive failed rollout attempts after which the refresh STOPS
   # re-restarting and flags the deployment for a human. A deployment whose
   # readiness FLAPS (becomes Ready, then crashes after warmup near the


### PR DESCRIPTION
Closes #569. Splits out of #552 (the requests-proxy hardcoded-`Always` half landed in #570).

## The problem

The always-running control-plane pods rendered `imagePullPolicy: Always`, so a Docker Desktop / WSL2 restart forced a registry round-trip and landed in `ImagePullBackOff` **even with the image already cached in containerd**. The edge showed Offline until docker.io was reachable again — up to ~6h behind Docker Hub's anonymous pull-rate limit.

`Always` could not simply be flipped, because it *is* the update mechanism: image-refresh's `kubectl rollout restart` only picks up a new build because the pull policy re-resolves the floating tag. Offline-safety and restart-driven updates are mutually exclusive unless the image **reference** changes on update.

## The decision: option B (digest-on-update), not A (prodDigest pin)

The ticket framed both. B won on two grounds:

- **A is prod-only by construction** (gated on `CLIENT_ENV == "prod"`). The incident client runs dev, so A would not have fixed the reported incident.
- **A couples releases across repos.** These images ship from `client-runtime`, whose release train ran twice on 2026-08-12 and again on 08-13. Under A, every prod cut needs a `client` chart PR + lockstep version bump + chart publish before prod edges see it. `ingestor.prodDigest` shows how that ages: it is currently pinned to v0.8.2 while its own float resolves v0.8.4. For the ingestor that lag is deliberate (an ordering ceiling is being enforced); for jobs-manager there is no ceiling, so lag is just an unshipped fix.

The objections to B were weaker than the ticket implied. Auto-upgrade only runs `helm upgrade` when the published chart version is **newer** (`sort -V` compare, `auto-upgrade-cronjob.yaml`), so the re-render is not an hourly revert — it happens only on a chart release.

## What changed

**Pull policy.** All four call sites render `IfNotPresent` unconditionally — jobs-manager (`api` + the `pods-monitor-container` sidecar), requests-proxy, resource-monitor.

**Update path.** image-refresh swaps `kubectl rollout restart` for `kubectl set image <workload> <container>=repo@digest`, across three workloads instead of one:

| workload | image | before this PR |
|---|---|---|
| `deployment/<release>-jobs-manager` | jobs-manager + pods-monitor | reconciled (both containers now re-imaged in one patch → one rollout) |
| `deployment/<release>-requests-proxy` | **the same** jobs-manager image | **never reconciled** |
| `daemonset/<release>-resource-monitor` | resource-monitor | **never reconciled** |

Two bugs the ticket did not name, both fixed here:

- **requests-proxy was never refreshed.** The CronJob's `DEPLOYMENT_NAME` was only `<release>-jobs-manager`. So requests-proxy stayed on its old build until some unrelated restart, then jumped to whatever the tag pointed at — two pods routinely running different builds of one image. It now follows the jobs-manager digest in the same tick, with no second registry HEAD. `images.requestsProxy.digest` opts it out.
- **resource-monitor had no deliberate update path at all.** A chart release does not change its image ref either, so it only ever moved when a pod happened to restart. That is also why a naive flip to `IfNotPresent` would have frozen it permanently — it needed the reconcile to come with it.

**RBAC.** requests-proxy needed no new rule (same-namespace Deployment, already covered). resource-monitor needed a second Role in `tracebloc-node-agents` — the one genuinely new piece of trust surface here:

- `get` + `patch` are `resourceNames`-scoped to this chart's own DaemonSet. That namespace runs under the `privileged` PSA profile, so the CronJob cannot touch any *other* DaemonSet there.
- `list` + `watch` **cannot** be `resourceNames`-scoped (the authorizer ignores `resourceNames` for collection verbs) and `rollout status` needs both, so they stay namespace-wide and read-only. That residual widening is deliberate and asserted with `equal` so it cannot grow silently.
- Not rendered at all when `resourceMonitor: false`.

**Helper.** `imageRefreshEnabled` now requires all three refreshed images pinned before retiring the CronJob. Pinning only the two class-1 images used to render it away, which would have left the DaemonSet with no update path.

**Private mirrors.** The script resolves digests from docker.io, so pinning one onto a `global.imageRegistry` reference could pin an image the mirror does not hold. It logs and goes inert. Under `rollout restart` that mismatch was merely useless; with `set image` it has to fail closed.

## Bug caught during verification

`IMAGE_REGISTRY` first rendered as `""` — values.yaml ships `global.imageRegistry: ""`, so the key *exists* and `dig`'s default never applies. The mirror guard would then have seen `"" != "docker.io"` and gone inert on **every default install**, silently disabling auto-refresh fleet-wide. Fixed with a trailing `| default "docker.io"`; there is a test whose comment explains why that is not redundant.

## Deliberate trade-offs — please review these specifically

**The first-tick contract is kept.** Re-imaging on the first tick would rewrite `repo:tag` to `repo@digest` for byte-identical content on every fresh install — rolling the Deployment, and the DaemonSet on every node, for nothing. So a fresh edge runs `repo:tag` until the first real digest change: restart-safe offline (which is the point of this PR), just not yet reproducible.

**Two bounded limitations, documented in the script header rather than hidden.** Both self-heal at the next upstream release, and neither can break a running edge — `IfNotPresent` holds regardless.

1. **Helm re-render.** A chart version bump re-renders `repo:tag` and reverts the pin. This tick will *not* re-pin, because the annotation still records that digest and `recorded == latest` no-ops. Contrary to what the ticket predicted, refresh does not self-heal this; the edge floats until the next upstream release.
2. **Pre-existing skew is prevented, not repaired.** An edge upgrading *into* this version may already have requests-proxy and jobs-manager on different builds. They converge on the next digest change; this script never compares pod-vs-pod.

The proper fix for both is the same: reconcile against each workload's **live container image** instead of a shared annotation. `set image` makes that possible for the first time — `rollout restart` was a blind action, which is why the annotation exists at all. I kept it out of this PR to hold the diff to one change; happy to fold it in if you would rather have it here.

## Verification

```
helm unittest ./client
Tests: 5 failed, 5 errored, 405 passed, 410 total
```

405 passed, up from 395. The failures are **exactly** develop's pre-existing baseline (5 failed / 5 errored) — confirmed by diffing failing test names against a stashed baseline run on develop. **Zero new failures.**

Also green: `helm lint`, all four `client/ci/*-values.yaml` render, `scripts/check-style.sh`, `scripts/check-facts.sh`, `scripts/gen-manifest.sh --check`.

Chart bumped 1.9.38 → 1.9.39, `version` + `appVersion` in lockstep.

## Note

I could not read **#565**, referenced by the ticket as the installer-side context — it does not resolve in `client` or any other tracebloc repo I have access to. If it constrains this design, it did not feed into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core control-plane image update mechanics, CronJob RBAC across namespaces, and pull policies—misconfiguration could freeze images or break refresh fleet-wide.
> 
> **Overview**
> Fixes **offline Docker/WSL restarts** that hit `ImagePullBackOff` because control-plane pods used **`imagePullPolicy: Always`**. Updates now come from **`kubectl set image repo@digest`** (replacing **`rollout restart`**) so pods can use **`IfNotPresent`** when a real update path exists.
> 
> **Image-refresh** reconciles **three workloads**: jobs-manager (+ pods-monitor containers), **requests-proxy** (same jobs-manager image, same digest in one tick), and **resource-monitor** (cross-namespace DaemonSet). Adds a **separate RBAC Role** in the node-agents namespace (`tracebloc.imageRefreshNodeAgentsName`) so Role names do not collide when node-agents shares the release namespace. **`requests-proxy`** falls back to **`images.jobsManager.digest`** when its own digest is unset; deployment name is centralized via **`tracebloc.requestsProxyName`**.
> 
> **`tracebloc.controlPlanePullPolicy`** unifies pull policy: **`IfNotPresent`** when digest-pinned or when refresh is enabled on **docker.io**; **`Always`** on private mirrors or **`imageRefresh.enabled: false`** so floating tags still update via restart. **`tracebloc.resourceMonitorRefreshPinned`** aligns CronJob retirement with runtime skip when **`resourceMonitor: false`** or digest pinned.
> 
> **Operational fixes**: mirror installs fail closed (script exits 0, reconcile inert); **`activeDeadlineSeconds`** default **3600** for three sequential rollouts; resource-monitor **`maxUnavailable: 10%`**. Chart **1.9.39**; schema/values/docs and helm unittest coverage expanded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4d6015c49fada61ff5a8c3217b3168bf27c0a56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->