### PR TITLE
test(manifest): cover the installer's integrity surface (backend#1729 sweep 6)

### DIFF
--- a/scripts/gen-manifest.sh
+++ b/scripts/gen-manifest.sh
@@ -58,6 +58,20 @@ WINDOWS_FILES=(
 # looks up its own bash entries and install.ps1 only its .ps1 entry, so the extra
 # cross-platform lines are harmless to each; a single manifest lets one cosign
 # signature anchor both entrypoints.
+# An EMPTY surface must be refused explicitly. Emptying FILES makes the manifest
+# cover nothing, and `--check` would then compare an empty manifest against an
+# empty regeneration and agree. Today that happens to die on `set -u`'s
+# "FILES[@]: unbound variable" -- a failure by accident, whose message says
+# nothing about the integrity surface it just lost. backend#1729: a guard that
+# passes (or fails unintelligibly) because it was disconnected from what it
+# claims to check.
+if [[ -z "${FILES[*]-}" || -z "${WINDOWS_FILES[*]-}" ]]; then
+  echo "[ERROR] the manifest's file surface is empty." >&2
+  echo "        install.sh verifies every sub-script it fetches against this manifest" >&2
+  echo "        before running privileged steps; an empty manifest verifies nothing." >&2
+  exit 1
+fi
+
 ALL_FILES=("${FILES[@]}" "${WINDOWS_FILES[@]}")
 
 MANIFEST="scripts/manifest.sha256"

--- a/scripts/tests/gen-manifest.bats
+++ b/scripts/tests/gen-manifest.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# gen-manifest.sh — the installer's integrity surface (backend#1729, sweep 6).
+#
+# WHY THIS SUITE EXISTS
+# ---------------------
+# `scripts/install.sh` verifies every sub-script it fetches against
+# `scripts/manifest.sha256` BEFORE running the privileged steps. gen-manifest.sh
+# produces that manifest. It was one of only two scripts under scripts/ that no
+# bats suite referenced — measured, 2 of 24 — and it is the one that matters
+# most: nothing proved its guards fire.
+#
+# It carries three claims in its own comments, and this suite tests each of them
+# rather than trusting them:
+#
+#   1. "Keep in lockstep with the FILES array in scripts/install.sh — the --check
+#      mode below fails CI if a file the bootstrap fetches is missing from this
+#      list (or vice versa)."
+#   2. the same for install.ps1's $Files array.
+#   3. --check is a CI gate that is non-zero on drift.
+#
+# All three turned out to be TRUE — worth saying, because this epic is mostly a
+# record of such claims being false. What was missing was any test that would
+# notice if they stopped being true. The cross-checks are awk extractions of
+# another file's array literal, which is exactly the kind of parser that goes
+# quietly stale when the file it parses is reformatted.
+#
+# One real gap was found and fixed alongside this suite: emptying FILES made the
+# manifest cover nothing, and the script died on `set -u`'s "FILES[@]: unbound
+# variable" — a failure by accident, with a message that says nothing about the
+# integrity surface just lost. It now refuses explicitly.
+
+setup() {
+  REPO="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  # A copy, always: these tests deliberately corrupt install.sh / gen-manifest.sh
+  # and must never touch the working tree.
+  WORK="$(mktemp -d "${BATS_TMPDIR:-/tmp}/genman.XXXXXX")"
+  cp -R "$REPO/scripts" "$WORK/scripts"
+  GM="$WORK/scripts/gen-manifest.sh"
+}
+
+teardown() {
+  [ -n "${WORK:-}" ] && [ -d "$WORK" ] && rm -rf "$WORK"
+  return 0
+}
+
+run_check() { ( cd "$WORK" && scripts/gen-manifest.sh --check ) }
+
+@test "a clean tree passes --check" {
+  run run_check
+  [ "$status" -eq 0 ] || return 1
+}
+
+# --- claim 1: the bash bootstrap's array must match -----------------------
+
+@test "an entry in install.sh that gen-manifest lacks fails --check" {
+  # A script the bootstrap fetches with NO digest in the manifest is
+  # unverified code running privileged steps. This is the case the comment
+  # promises to catch.
+  perl -0pi -e 's/^FILES=\(\n/FILES=(\n  "scripts\/lib\/newthing.sh"\n/m' "$WORK/scripts/install.sh"
+  run run_check
+  [ "$status" -ne 0 ] || return 1
+  [[ "$output" == *"install.sh FILES array and gen-manifest.sh FILES differ"* ]] || return 1
+}
+
+@test "an entry in gen-manifest that install.sh lacks fails --check (the 'vice versa')" {
+  perl -0pi -e 's/^FILES=\(\n/FILES=(\n  "scripts\/lib\/newthing.sh"\n/m' "$GM"
+  run run_check
+  [ "$status" -ne 0 ] || return 1
+  [[ "$output" == *"differ"* ]] || return 1
+}
+
+@test "an install.sh whose FILES array cannot be parsed fails closed" {
+  # The cross-check is an awk extraction of another file's array literal. If
+  # install.sh is reformatted so the pattern stops matching, the extraction
+  # yields NOTHING — and a guard that compares nothing to nothing would pass.
+  # It must refuse instead.
+  perl -0pi -e 's/^FILES=\(/FILE_LIST=(/m' "$WORK/scripts/install.sh"
+  run run_check
+  [ "$status" -ne 0 ] || return 1
+  [[ "$output" == *"differ"* ]] || return 1
+}
+
+# --- claim 2: the Windows bootstrap's array must match --------------------
+
+@test "an install.ps1 \$Files divergence fails --check" {
+  perl -0pi -e 's/^\$Files = @\(\n/\$Files = @(\n  "scripts\/other.ps1"\n/m' "$WORK/scripts/install.ps1"
+  run run_check
+  [ "$status" -ne 0 ] || return 1
+  [[ "$output" == *"install.ps1"* ]] || return 1
+}
+
+@test "an install.ps1 whose \$Files array cannot be parsed fails closed" {
+  perl -0pi -e 's/^\$Files = @\(/\$FileList = @(/m' "$WORK/scripts/install.ps1"
+  run run_check
+  [ "$status" -ne 0 ] || return 1
+}
+
+# --- claim 3: --check is non-zero on drift -------------------------------
+
+@test "changing a covered file without regenerating fails --check" {
+  # The whole point of the manifest: content drift must be visible.
+  printf '\n# drift\n' >> "$WORK/scripts/lib/common.sh"
+  run run_check
+  [ "$status" -ne 0 ] || return 1
+}
+
+@test "regenerating after a change makes --check pass again" {
+  printf '\n# drift\n' >> "$WORK/scripts/lib/common.sh"
+  ( cd "$WORK" && scripts/gen-manifest.sh ) >/dev/null 2>&1
+  run run_check
+  [ "$status" -eq 0 ] || return 1
+}
+
+@test "a listed file missing from disk fails --check" {
+  rm -f "$WORK/scripts/lib/probe.sh"
+  run run_check
+  [ "$status" -ne 0 ] || return 1
+  [[ "$output" == *"missing file"* ]] || return 1
+}
+
+# --- the empty-surface guard added with this suite ------------------------
+
+@test "an empty FILES surface is refused with a diagnostic, not an unbound variable" {
+  # Before the explicit guard this died on `set -u` with "FILES[@]: unbound
+  # variable" — it failed, but by accident, and the message told an operator
+  # nothing about what had just stopped being verified.
+  perl -0pi -e 's/^FILES=\((?:.|\n)*?^\)/FILES=(\n)/m' "$GM"
+  run run_check
+  [ "$status" -ne 0 ] || return 1
+  [[ "$output" == *"file surface is empty"* ]] || return 1
+  [[ "$output" != *"unbound variable"* ]] || return 1
+  # The message must say what was lost, not merely that something is empty.
+  [[ "$output" == *"an empty manifest verifies nothing"* ]] || return 1
+}
+
+@test "an empty WINDOWS_FILES surface is refused too" {
+  perl -0pi -e 's/^WINDOWS_FILES=\((?:.|\n)*?^\)/WINDOWS_FILES=(\n)/m' "$GM"
+  run run_check
+  [ "$status" -ne 0 ] || return 1
+  [[ "$output" == *"file surface is empty"* ]] || return 1
+}
+
+# --- the manifest must actually cover both bootstraps --------------------
+
+@test "the committed manifest lists every file both bootstraps fetch" {
+  # Guards the premise rather than the mechanism: if the manifest were somehow
+  # current AND short, every test above could pass while a fetched script had
+  # no digest.
+  local manifest="$REPO/scripts/manifest.sha256"
+  [ -r "$manifest" ] || return 1
+  local missing=0
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    grep -qF -- "$f" "$manifest" || { echo "not in manifest: $f"; missing=1; }
+  done < <(
+    awk '/^FILES=\(/{f=1;next} /^\)/{f=0} f' "$REPO/scripts/install.sh" \
+      | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$'
+  )
+  [ "$missing" -eq 0 ] || return 1
+}

--- a/scripts/tests/gen-manifest.bats
+++ b/scripts/tests/gen-manifest.bats
@@ -145,16 +145,41 @@ run_check() { ( cd "$WORK" && scripts/gen-manifest.sh --check ) }
 @test "the committed manifest lists every file both bootstraps fetch" {
   # Guards the premise rather than the mechanism: if the manifest were somehow
   # current AND short, every test above could pass while a fetched script had
-  # no digest.
+  # no digest. Scrapes BOTH bootstraps — install.sh's bash FILES array and
+  # install.ps1's PowerShell $Files array — with the same extractions
+  # gen-manifest.sh uses, so a Windows-only fetch missing from the manifest is
+  # caught here too, not just the bash surface.
   local manifest="$REPO/scripts/manifest.sha256"
   [ -r "$manifest" ] || return 1
+
+  # The bash bootstrap's FILES=( ... ) entries. The trailing `|| true` keeps a
+  # broken scrape (grep matching nothing) from aborting the assignment, so the
+  # explicit emptiness guard below — not an incidental exit code — is what
+  # decides the outcome.
+  local bash_fetches
+  bash_fetches="$(
+    awk '/^FILES=\(/{f=1;next} /^\)/{f=0} f' "$REPO/scripts/install.sh" \
+      | sed -e 's/^[[:space:]]*"//' -e 's/"[[:space:]]*$//' | grep -v '^$' || true
+  )"
+  # The Windows bootstrap's $Files = @( ... ) entries.
+  local win_fetches
+  win_fetches="$(
+    awk '/^\$Files = @\($/{f=1;next} /^\)$/{f=0} f' "$REPO/scripts/install.ps1" \
+      | sed -nE 's/^[[:space:]]*"([^"]+)".*/\1/p' | grep -v '^$' || true
+  )"
+
+  # A non-empty extract is the premise of this check, not an afterthought: an
+  # empty list means the scrape broke (a bootstrap was reformatted so the awk
+  # pattern stopped matching), NOT that coverage is complete. Both arrays are
+  # non-empty in reality, so zero entries from EITHER is always a broken parser
+  # — fail loudly rather than let missing=0 sail through having verified nothing.
+  [ -n "$bash_fetches" ] || { echo "no fetch paths scraped from install.sh"; return 1; }
+  [ -n "$win_fetches" ]  || { echo "no fetch paths scraped from install.ps1"; return 1; }
+
   local missing=0
   while IFS= read -r f; do
     [ -n "$f" ] || continue
     grep -qF -- "$f" "$manifest" || { echo "not in manifest: $f"; missing=1; }
-  done < <(
-    awk '/^FILES=\(/{f=1;next} /^\)/{f=0} f' "$REPO/scripts/install.sh" \
-      | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$'
-  )
+  done < <(printf '%s\n%s\n' "$bash_fetches" "$win_fetches")
   [ "$missing" -eq 0 ] || return 1
 }


### PR DESCRIPTION

Sweep 6 is "mutation-check the existing suites". Measuring first: of the 24
shell scripts under scripts/ (excluding tests), exactly TWO are referenced
by no bats suite -- check-style.sh and gen-manifest.sh. Client is in good
shape; this closes the one that matters most.

gen-manifest.sh produces scripts/manifest.sha256, which install.sh
verifies every fetched sub-script against BEFORE running privileged steps.
It is the installer's integrity surface, and nothing proved its guards
fire.

It carries three claims in its own comments. All three are TRUE -- worth
stating, since this epic is largely a record of such claims being false:

  1. gen-manifest's FILES must match install.sh's FILES, "or vice versa"
  2. the same for install.ps1's $Files
  3. --check is non-zero on drift

What was missing is any test that would notice them ceasing to be true.
Both cross-checks are awk extractions of another file's array literal --
precisely the parser that goes quietly stale when the parsed file is
reformatted. 12 cases now pin them, including both stale-parser cases:
rename install.sh's array and the guard must REFUSE, not compare nothing
to nothing and agree.

ONE REAL GAP FOUND AND FIXED. Emptying FILES makes the manifest cover
nothing, and --check then compared an empty manifest to an empty
regeneration. It did fail -- on `set -u`'s "FILES[@]: unbound variable".
A failure by accident, whose message says nothing about the integrity
surface just lost. Now refused explicitly, naming the consequence: "an
empty manifest verifies nothing".

The first version of that guard used ${#FILES[@]}, which is ITSELF an
unbound-variable error on an empty array under bash 3.2 -- what macOS
ships and what this repo deliberately targets. So the guard reproduced,
by a different route, the exact unintelligible failure it was written to
replace. It now uses ${arr[*]-}, which expands safely whether the array
is unset, empty or populated. Caught by running it on bash 3.2, not by
reading it.

Also in the suite: a case asserting the COMMITTED manifest lists every
file install.sh fetches. That guards the premise rather than the
mechanism -- if the manifest were current AND short, every other test
here could pass while a fetched script had no digest at all.

12/12 pass; bats-hygiene passes, so every assertion is load-bearing
rather than advisory.

Remaining from the measurement: check-style.sh has no suite. Filed rather
than bundled -- one self-contained change per PR.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes strengthen supply-chain CI checks and installer manifest generation; no runtime auth or data-path behavior changes beyond clearer failure on misconfiguration.
> 
> **Overview**
> Adds **`scripts/tests/gen-manifest.bats`** to exercise `gen-manifest.sh --check` against copied `scripts/` trees: lockstep with **`install.sh`** `FILES` and **`install.ps1`** `$Files`, non-zero drift when hashes or files are wrong, and **fail-closed** behavior when those arrays can’t be parsed.
> 
> **`gen-manifest.sh`** now **refuses an empty `FILES` or `WINDOWS_FILES` surface** with a clear integrity message instead of failing indirectly under `set -u` (or agreeing on an empty manifest during `--check`). A final test asserts the **committed `manifest.sha256`** lists every path both bootstraps fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9176c191677a6732beafbd15a4e881dae048284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->