### PR TITLE
fix(chart): un-vacuum the order-of-ops assertion, and make the mysqlClient pin watchable

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.39
-appVersion: "1.9.39"
+version: 1.9.40
+appVersion: "1.9.40"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/mysql-deployment.yaml
+++ b/client/templates/mysql-deployment.yaml
@@ -116,7 +116,7 @@ spec:
           mountPath: /var/lib/mysql/
           readOnly: true
       containers:
-      - image: {{ include "tracebloc.image" (dict "repository" "tracebloc/mysql-client" "tag" (.Values.images.mysqlClient.tag | default "prod") "digest" .Values.images.mysqlClient.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
+      - image: {{ include "tracebloc.image" (dict "repository" (.Values.images.mysqlClient.repository | default "tracebloc/mysql-client") "tag" (.Values.images.mysqlClient.tag | default "prod") "digest" .Values.images.mysqlClient.digest "registry" (dig "imageRegistry" "docker.io" (.Values.global | default dict))) | quote }}
         imagePullPolicy: IfNotPresent
         name: mysql-client
         securityContext:

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -287,15 +287,22 @@ tests:
       - matchRegex:
           path: data["image-refresh.sh"]
           pattern: "first observation; recording without re-imaging"
-      # Order-of-operations contract: `rollout restart` + `rollout
-      # status` MUST run before `kubectl annotate`. If we annotated
-      # first and the rollout then failed, the next tick would see
-      # recorded == latest and skip — leaving the deployment frozen
-      # on the old image with no signal. The test asserts that the
-      # rollout block appears in the script BEFORE the annotate block.
+      # Order-of-operations contract: the re-image (`kubectl set image` +
+      # `kubectl rollout status`) MUST run before the `kubectl annotate` that
+      # records the digest. If we annotated first and the rollout then failed,
+      # the next tick would see recorded == latest and skip — leaving the
+      # deployment frozen on the old image with no signal.
+      #
+      # ANCHORED TO COMMAND LINES (`(?m)^\s+kubectl`). This assertion used to
+      # name `kubectl rollout restart`, which #569 REMOVED — and the sibling
+      # notMatchRegex above forbids it on a command line. So the only thing it
+      # could still match was the header comments that explain the old
+      # mechanism, and it passed no matter what order the real commands ran in.
+      # A regress that annotated before re-imaging would have frozen workloads
+      # on the old image with a green suite (Bugbot, client#713).
       - matchRegex:
           path: data["image-refresh.sh"]
-          pattern: '(?s)kubectl rollout restart.*kubectl annotate deployment'
+          pattern: '(?ms)^\s+kubectl set image.*^\s+kubectl rollout status.*^\s+kubectl annotate deployment'
       # The ingestor is spawned by jobs-manager from a floating tag and is
       # no longer reconciled by this script — the entire class-2 pass was
       # removed (no `kubectl set env` on INGESTOR_IMAGE_DIGEST, no ghcr.io

--- a/client/tests/image_refresh_test.yaml
+++ b/client/tests/image_refresh_test.yaml
@@ -300,9 +300,20 @@ tests:
       # mechanism, and it passed no matter what order the real commands ran in.
       # A regress that annotated before re-imaging would have frozen workloads
       # on the old image with a green suite (Bugbot, client#713).
+      #
+      # PINNED TO THE DIGEST ANNOTATE (`$annotate_args`), not just any annotate.
+      # A bare `kubectl annotate deployment` also matches the flap-counter-reset
+      # annotate (`${ATTEMPT_KEY}- ${FLAP_KEY}-`), which sits after the rollout BY
+      # DESIGN. So moving ONLY the digest-recording annotate above the re-image
+      # left that reset still satisfying the old pattern — the suite stayed green
+      # while the digest was recorded BEFORE the image was applied, which is the
+      # exact freeze the guard exists to catch. Requiring the `$annotate_args`
+      # continuation line ties the ordering to the digest write itself; the flap
+      # reset carries different arguments and can no longer stand in for it
+      # (Bugbot, client#714).
       - matchRegex:
           path: data["image-refresh.sh"]
-          pattern: '(?ms)^\s+kubectl set image.*^\s+kubectl rollout status.*^\s+kubectl annotate deployment'
+          pattern: '(?ms)^\s+kubectl set image.*^\s+kubectl rollout status.*^\s+kubectl annotate deployment[^\n]*\n\s*\$annotate_args'
       # The ingestor is spawned by jobs-manager from a floating tag and is
       # no longer reconciled by this script — the entire class-2 pass was
       # removed (no `kubectl set env` on INGESTOR_IMAGE_DIGEST, no ghcr.io

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -571,11 +571,19 @@ images:
   requestsProxy:
     digest: ""
   mysqlClient:
+    # Repository and tag are stated rather than left to template defaults so the
+    # digest below is WATCHABLE: check-digest-drift.sh pairs a pin with the
+    # repo/float in its own block, and this block had neither — so the daily
+    # watch classified it UNWATCHABLE and exited non-zero, staying red forever
+    # while the pin it was meant to compare was never checked at all
+    # (Bugbot, client#713). Both values are what the templates already default
+    # to, so the rendered image is byte-identical.
+    repository: "tracebloc/mysql-client"
     # mysql-client is only published under the "prod" tag — it has no dev/
     # staging variants, so we decouple it from env.CLIENT_ENV. Override only
     # if you are publishing your own fork with a different tag. Never use
     # "latest"; pin via digest instead.
-    tag: ""
+    tag: "prod"
     # Pinned (2026-07-28) to the current MySQL 5.7-lineage :prod image
     # (pushed 2026-04-24). Workspace datadirs are 5.7-format and MySQL
     # supports only staged upgrades (5.7 -> 8.0 -> 8.4), while this repo's


### PR DESCRIPTION
Two Bugbot **Medium**s on the staging promotion PR #713.

## 1. The order-of-operations assertion was vacuous

It required `kubectl rollout restart` before `kubectl annotate` — but **#569 removed that command**, and a sibling `notMatchRegex` forbids it on a command line. The only text it could still match was the **header comments** explaining the old mechanism, so it passed regardless of what order the real commands ran in.

Measured on the rendered script rather than argued. Hoisting the post-re-image annotates above the first `kubectl set image` — the actual regress, header comments left in place:

| | old assertion | new assertion |
|---|---|---|
| real script | passes | passes |
| **regressed script** | **passes** ← ships the bug green | **fails** |

A regress that recorded the digest before re-imaging would have frozen every workload on its old image with a green suite.

Now anchored to **command lines** and to the mechanism that exists: `set image` → `rollout status` → `annotate`.

> Two earlier attempts at that mutation were themselves broken — one hoisted the annotates above the comments too, one popped by stale indices after inserting. Both "proved" the wrong thing. The mutation quoted above is verified to have actually moved the lines before its result is used.

## 2. The mysqlClient pin was never watched

`images.mysqlClient` carried a real digest but **no `repository` and an empty `tag`** — both live as template defaults. `check-digest-drift.sh` pairs a pin with the repo/float in its own block, found neither, and classified it `UNWATCHABLE`, which exits non-zero.

So the **daily drift watch stays red forever** while the pin it exists to compare is never checked. A guard that cannot pass teaches everyone to ignore it.

Now stated in values **and consumed by the template**, so the value is real config rather than decoration.

```
BEFORE  UNWATCHABLE: images.mysqlClient is pinned to sha256:f546e47…
AFTER   ok    tracebloc/mysql-client:prod    sha256:f546e47fb339…
```

## Verified

- render **byte-identical** across aks/bm/eks values (only `POD_TOKEN_SIGNING_SECRET` differs — helm regenerates it every run); mysql image line unchanged
- `helm lint` clean; **`helm unittest` 36/36**, including the edited suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are chart version bump, stricter unit tests, and values/template wiring that mirrors existing defaults; no intentional runtime behavior change to workloads or image-refresh script logic in this diff.
> 
> **Overview**
> Bumps the client chart to **1.9.40** and fixes two CI/guard gaps that let real regressions ship with a green suite.
> 
> The **image-refresh** helm unittest no longer checks ordering via the removed `kubectl rollout restart` path (which could still match header comments). It now requires **command-line** order: `kubectl set image` → `kubectl rollout status` → digest recording via `kubectl annotate` with **`$annotate_args`**, so flap-counter annotates cannot satisfy the test if the digest is written before re-imaging.
> 
> **`images.mysqlClient`** now sets explicit `repository` and `tag: prod` in `values.yaml`, and the mysql deployment template reads those fields so **`check-digest-drift.sh`** can pair the pin with repo/tag instead of marking it **UNWATCHABLE**. Rendered mysql image stays byte-identical to the previous template defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18956ad87461c6e9620e902c8e7f36b376f14c48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->