### PR TITLE
ci(env): move the CLIENT_ENV vocabulary guard into the job that gates (backend#1729)

### DIFF
--- a/.github/workflows/drift-checks.yaml
+++ b/.github/workflows/drift-checks.yaml
@@ -1,10 +1,17 @@
 name: Drift checks
 
-# Source-of-truth drift: values duplicated across files (the backend API hosts)
-# or coupled across artifacts (the chart's workload names <-> the names the
-# readiness-wait and --diagnose bundle grep for). Mocked unit tests can't see
-# these — a rename ships green and breaks in the field. This guards both sides.
+# Source-of-truth drift: values duplicated across files (the backend API hosts,
+# the CLIENT_ENV alias vocabulary) or coupled across artifacts (the chart's
+# workload names <-> the names the readiness-wait and --diagnose bundle grep
+# for). Mocked unit tests can't see these — a rename ships green and breaks in
+# the field. This guards both sides.
 # Triggers on scripts/ OR client/ because either side moving is the drift.
+#
+# This job is the home for every duplicated-declaration guard in this repo,
+# because it is the one that GATES: `Source-of-truth drift` is required on
+# develop and on main, so a disagreement blocks the merge rather than merely
+# printing red on a workflow nobody has to wait for. A guard that cannot block
+# is advice (backend#1729).
 #
 # NO `paths:` ON pull_request, deliberately. `Source-of-truth drift` is a
 # REQUIRED status check on develop and on main, and a required check that is
@@ -43,3 +50,12 @@ jobs:
           version: v3.15.4
       - name: check-drift
         run: bash scripts/tests/check-drift.sh
+      # One CLIENT_ENV vocabulary, four declarations (Go template, JSON Schema,
+      # bash, PowerShell), backend#1729 sweep 5. Lives here rather than in
+      # helm-ci because helm-ci's `Helm lint` is NOT a required check, so the
+      # guard could only advise: a PR that made the four disagree was mergeable
+      # with it red. It needs bash + python3 only (~2s), and drift-checks runs
+      # unfiltered on every PR, so it reports on the installer-only PRs that
+      # helm-ci's `paths:` filter would have skipped entirely.
+      - name: CLIENT_ENV vocabulary agreement (backend#1729)
+        run: bash scripts/tests/env-vocabulary-agreement.sh

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -11,9 +11,6 @@ on:
       - 'scripts/tests/e2e-full-seal.sh'
       - 'scripts/tests/lib/e2e-common.sh'
       - 'scripts/tests/chart-env-vocabulary.sh'
-      - 'scripts/tests/env-vocabulary-agreement.sh'
-      - 'scripts/lib/common.sh'
-      - 'scripts/install-k8s.ps1'
       - 'scripts/lib/**'
       - '.github/workflows/helm-ci.yaml'
   pull_request:
@@ -26,9 +23,6 @@ on:
       - 'scripts/tests/e2e-full-seal.sh'
       - 'scripts/tests/lib/e2e-common.sh'
       - 'scripts/tests/chart-env-vocabulary.sh'
-      - 'scripts/tests/env-vocabulary-agreement.sh'
-      - 'scripts/lib/common.sh'
-      - 'scripts/install-k8s.ps1'
       - 'scripts/lib/**'
       - '.github/workflows/helm-ci.yaml'
   # Manual runs — mainly to fire full-seal-e2e on demand (e.g. right after the
@@ -88,10 +82,16 @@ jobs:
         # turns them on with no change to this file.
         run: bash scripts/tests/chart-env-vocabulary.sh
 
-      # One vocabulary, four languages (backend#1729 sweep 5). Runs on a change
-      # to ANY of the four declarations, including the two installers.
-      - name: CLIENT_ENV vocabulary agreement (backend#1729)
-        run: bash scripts/tests/env-vocabulary-agreement.sh
+      # The CLIENT_ENV vocabulary-agreement guard (backend#1729 sweep 5) used to
+      # run here. It now runs in drift-checks.yaml's `Source-of-truth drift` job,
+      # which is a REQUIRED check on develop and main -- `Helm lint` is not, so
+      # here the guard could only advise. `scripts/install-k8s.ps1` came into
+      # this workflow's `paths:` with it and left with it: this is the repo's
+      # heaviest workflow (a real k3d cluster plus two 4-platform matrices) and
+      # a PowerShell installer edit has no other reason to start it. The
+      # explicit `scripts/lib/common.sh` entry went too, but that one was always
+      # redundant -- the pre-existing `scripts/lib/**` glob still matches it, so
+      # helm-ci's triggering on a common.sh change is unchanged.
 
   template:
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

The vocabulary-agreement guard from #706 ran in `helm-ci.yaml` → job **`Helm lint`**. That job is **not a required status check** on this repo. The required contexts on `develop` are:

```
Unit tests · Lint · quality/gitleaks · quality/house-rules · quality/shellcheck
quality/action-pins · version-bump-gate/version-check · Source-of-truth drift
```

So a PR that made the four `CLIENT_ENV` declarations disagree was **mergeable with the guard red**. It advised; it did not gate.

That is backend#1729's own class, in backend#1729's own flagship deliverable — a mechanism that looks like verification but isn't connected to the outcome it claims to control.

## What changed

Move the step into `drift-checks.yaml` → **`Source-of-truth drift`**, which needed no new configuration to make this real:

- **required on `develop` and on `main`** — a disagreement now blocks the merge
- **no `paths:` on `pull_request`, deliberately** (its header records why: a path-filtered required check bricks PRs outside those paths — #651/#657/#660 on 2026-08-11). So the guard now also runs on the installer-only PRs helm-ci's filter skipped entirely
- already the home of the sibling duplicated-declaration guard (`check-drift.sh`)
- needs only bash + python3, ~2s

`helm-ci` loses the step and the two `paths:` entries that arrived with it in #706:

| entry | why |
|---|---|
| `scripts/install-k8s.ps1` | genuinely leaves — helm-ci is the heaviest workflow here (real k3d cluster + two 4-platform matrices); a PowerShell installer edit has no other reason to start it |
| `scripts/lib/common.sh` | also goes, but was **always redundant** — the pre-existing `scripts/lib/**` glob still matches it, so triggering is unchanged |

**No branch-protection change is required or included.** The gate comes from landing in an already-required job.

## Test plan

Mutation-proved rather than assumed:

```
mutation applied  (staging) → stagingXX) in scripts/lib/common.sh)
guard exit after mutation = 1
guard exit after restore  = 0
```

The mutation anchor was asserted to have applied before trusting the result — an inert mutation and good coverage look identical in a log.

Armed while green. On this branch all four declarations agree and every accepted spelling is exercised: `dev` 12, `development` 2, `prod` 11, `production` 4, `staging` 9, `stg` 6.

Both workflow files re-parse as valid YAML; `Source-of-truth drift` now lists `check-drift` + `CLIENT_ENV vocabulary agreement`.

## Checklist

- [x] Targets `develop`
- [x] No new required-check contexts added (uses an existing one)
- [x] Guard verified green before arming
- [x] Guard verified able to go red

Refs backend#1729

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow wiring only; no application or chart runtime behavior changes. Effect is stronger enforcement of an existing guard via an already-required check.
> 
> **Overview**
> Moves the **CLIENT_ENV vocabulary agreement** step (`env-vocabulary-agreement.sh`) from **`helm-ci`**’s `Helm lint` job into **`drift-checks`**’s **`Source-of-truth drift`** job so a mismatch across the four declarations (Go template, JSON Schema, bash, PowerShell) **blocks merge** instead of only failing a non-required check.
> 
> **`drift-checks`** gains the new step and header comments that position it as the home for duplicated-declaration guards and note **CLIENT_ENV** alongside existing drift checks. **`helm-ci`** drops that step and removes **`paths:`** entries for `scripts/tests/env-vocabulary-agreement.sh`, `scripts/install-k8s.ps1`, and the explicit `scripts/lib/common.sh` line (installer-only edits no longer trigger the heavy workflow; `scripts/lib/**` still covers `common.sh`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa967d10bf47cd50a94af764ba1aca28ed4f2cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->