### PR TITLE
docs(values): the ingestor ceiling notes disagreed with the chart, and with themselves (backend#1528)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.40
-appVersion: "1.9.40"
+version: 1.9.41
+appVersion: "1.9.41"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -427,13 +427,21 @@ images:
     repository: "ghcr.io/tracebloc/ingestor"
     # Floating tag spawned by default (imagePullPolicy=Always). The team's
     # ghcr.io publishing convention uses semver-style float tags — `0` tracks
-    # the latest 0.x, `0.7` tracks the latest 0.7.x patch. `0.7` (patch-only
-    # auto-track) is the default: a future 0.8 release will NOT be picked up
-    # until this is moved to `0.8` (or set to `0` for minor auto-track too).
+    # the latest 0.x, `0.8` tracks the latest 0.8.x patch. Moving a line float
+    # (`0.8` -> `0.9`) is deliberate: a future 0.9 release is NOT picked up
+    # until someone changes it (or sets `0` for minor auto-track too).
     # `latest` is rejected by the schema.
     #
-    # Pinned to the 0.7 line so the spawned ingestor carries the current
-    # ingestion correctness fixes and task catalogue — case/whitespace
+    # THIS FIELD IS EMPTY BY DEFAULT — see `tag: ""` below. The per-environment
+    # floats in `channelTags` are what actually select a tag, and prod's is
+    # `"0.8"`. An earlier revision of this comment said `0.7` was the default
+    # and that the chart was "pinned to the 0.7 line"; both stopped being true
+    # when backend#1360 moved tag selection into `channelTags`, and the stale
+    # text survived long enough to disagree with the `prodDigest` note 90 lines
+    # down (backend#1528).
+    #
+    # The line the fleet tracks carries the ingestion correctness fixes and task
+    # catalogue accumulated to date — case/whitespace
     # label-column resolution (data-ingestors#340) and UTF-8 BOM header
     # handling (#338) from the 0.6 line, plus 0.7's tabular schema-inference
     # rules (#349), the semantic-segmentation mask_id contract (#358), and the
@@ -516,22 +524,27 @@ images:
     # index; matches the v0.8.2 GitHub Release digest). The `VERIFIED` note is
     # the audit trail: re-resolve it, do not trust a previous note's date.
     #
-    # DELIBERATELY BEHIND the `channelTags.prod: "0.8"` float. The float has
-    # since moved to v0.8.8 (sha256:4beb85da…), which REMOVED the edgeuser
-    # fallback — i.e. it crossed the boundary described below, and the gap is no
-    # longer "two patches". Do not "refresh" this to the float without
-    # reading the ordering constraint in docs/SECURITY.md §4.1.1: prod's
+    # DELIBERATELY BEHIND the `channelTags.prod: "0.8"` float, and the float has
+    # CROSSED THE BOUNDARY. Do not "refresh" this to the float without reading
+    # the ordering constraint in docs/SECURITY.md §4.1.1: prod's
     # `serviceDbAccountsByEnv.prod` is still `false`, and the boundary is not a
     # version number — it is whether the release you move to was cut before
     # data-ingestors#468. `prodPin: true` means this digest, not the float, is
     # what prod spawns, which is exactly the protection being relied on.
     #
-    # (Checked 2026-08-12: v0.8.4's config.py still defaults DB_USER to
-    # "edgeuser", so data-ingestors#468 — which removes that fallback, merged
-    # 2026-08-11, after v0.8.4 was cut on 08-10 — is NOT yet in any 0.8 release.
-    # The next 0.8 release is therefore the dangerous one, not v0.8.4. Recorded
-    # so the ceiling is respected for the right reason, and so whoever raises it
-    # re-derives this instead of inheriting a stale number.)
+    # WHERE THE BOUNDARY IS, stated so it cannot go stale with the next release:
+    # data-ingestors#468 (drops the edgeuser fallback) merged 2026-08-11 10:48.
+    # v0.8.4 was cut 08-10 and does NOT contain it; **v0.8.8 (2026-08-12) is the
+    # FIRST release that does**, and every 0.8.x after it therefore does too.
+    # Verified by ancestry against the tags, not by reading a changelog.
+    #
+    # So the safe set is exactly {v0.8.0 … v0.8.4}, and this pin (v0.8.2) is in
+    # it. Naming the first UNSAFE release rather than "the current float" is the
+    # point: an earlier revision of this note said #468 was "NOT yet in any 0.8
+    # release" and that "the next 0.8 release is the dangerous one" — true when
+    # written on 2026-08-12, false hours later when v0.8.8 shipped, and by then
+    # it contradicted the paragraph directly above it in this same comment.
+    # A boundary is a fact; "the latest release" is a moving target.
     prodDigest: "sha256:05e124945a2ef61868661a9137abb5e75dac96a090cb41a7b4e8be520c4b5873"
 
     # -- Whether `prodDigest` applies on this edge. Default true, which means
@@ -1078,15 +1091,23 @@ serviceDbAccounts:
 # was on nowhere. dev and staging edges float on the :dev/:stg ingestor
 # channels, took the change the same day, and every ingestion Job now fails at
 # Config() before reading a byte. Prod escaped only because its ingestor is
-# digest-pinned to the 0.7 line — a caution engineered for D16, not for this,
-# and one client#490 is about to spend.
+# digest-pinned — `prodDigest` is v0.8.2, cut 2026-08-04, a week before #468
+# merged — a caution engineered for D16 and spent on this instead.
+#
+# (That pin was v0.8.2 as of client#490, which merged. An earlier revision of
+# this paragraph said "the 0.7 line" and "one client#490 is about to spend";
+# the first was already wrong and the second described the future. Line 1091
+# below said "past 0.8.2" the whole time, so the file disagreed with itself
+# about which release prod actually runs.)
 #
 # dev/stg: TRUE. Both are already running the ingestor that requires the
 # per-Job credentials, so this is what makes them work again — and it exercises
 # #1528's S2 path where it is supposed to be exercised, before prod.
 #
-# prod: FALSE, deliberately and explicitly. Prod runs the 0.7-line ingestor,
-# which still has the fallback. Flipping prod is a separate windowed decision
+# prod: FALSE, deliberately and explicitly. Prod runs v0.8.2 (pinned via
+# `prodDigest`), which still has the fallback — the safe set is v0.8.0…v0.8.4,
+# and v0.8.8 is the first release that dropped it. Flipping prod is a separate
+# windowed decision
 # (#1528 S0 drill), and it must happen BEFORE prod's ingestor is repinned past
 # 0.8.2 — see the note on `prodDigest`.
 serviceDbAccountsByEnv:


### PR DESCRIPTION
`values.yaml` is the file an operator — or an agent — reads before touching the
prod ingestor pin. Four of its claims about that pin were false, and two of them
contradicted other lines in the same file.

**"Prod escaped only because its ingestor is digest-pinned to the 0.7 line"**
(and "Prod runs the 0.7-line ingestor"). `prodDigest` is v0.8.2 — an 0.8-line
build cut 2026-08-04. Line 1091 already said "repinned past 0.8.2", so the file
disagreed with itself about which release prod runs. The safety conclusion held
by luck: v0.8.2 predates data-ingestors#468 either way.

**"one client#490 is about to spend"** — client#490 merged; it is what set the
v0.8.2 pin. Written in the future tense about the past.

**"#468 … is NOT yet in any 0.8 release. The next 0.8 release is therefore the
dangerous one, not v0.8.4."** True when written on 2026-08-12 and false hours
later when v0.8.8 shipped — and it already contradicted the paragraph eight
lines above it, which said the float "REMOVED the edgeuser fallback".

**"`0.7` (patch-only auto-track) is the default"** — `tag: ""` is the default;
backend#1360 moved selection into `channelTags`, where prod is `"0.8"`.

## The fix is to state a boundary, not a latest

Every stale claim here named a moving target. Replaced with the fact that does
not move, derived by ancestry against the tags rather than from a changelog:

    data-ingestors#468 merged 2026-08-11 10:48
    v0.8.4 (08-10)  does NOT contain it
    v0.8.8 (08-12)  is the FIRST release that does
    => safe set is exactly {v0.8.0 … v0.8.4}; prodDigest v0.8.2 is inside it

"The first unsafe release is v0.8.8" stays true for every future 0.8.x.
"The float is at v0.8.8" was stale within two days — v0.8.9 shipped 08-14.

Each correction records what it replaced, so the next reader can tell the note
was re-derived rather than inherited.

## Verification

- **Comment-only**: no non-comment line differs (asserted with a filtered diff,
  not by eye). `prodDigest`, `prodPin`, `channelTags` and
  `serviceDbAccountsByEnv` are byte-identical.
- values.yaml still parses; the four values read back as
  v0.8.2 / true / prod:"0.8" / prod:false.
- `helm lint client` fails identically on this branch and on `origin/develop`
  (pre-existing empty `clientId`/`clientPassword`), so nothing regressed.
- Boundary verified with `compare/<tag>...5fcfb21c` for v0.8.4, v0.8.8, v0.8.9.

No behaviour change. The guard that enforces this ceiling is
`scripts/resolve-ingestor-digest.sh` (client#692) and is untouched.

Related: client#490, client#692, data-ingestors#468, backend#1528.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Chart.yaml version only; ingestor pins and feature flags are byte-identical, so cluster behavior is unchanged.
> 
> **Overview**
> **Comment-only documentation fix** in `client/values.yaml` plus a chart patch bump (`1.9.40` → `1.9.41`). Runtime values (`prodDigest`, `prodPin`, `channelTags`, `serviceDbAccountsByEnv`) are unchanged.
> 
> The edits correct **stale, self-contradictory operator notes** about prod ingestor selection: prod is pinned to **v0.8.2** via `prodDigest`, not the “0.7 line”; default tag selection comes from **`channelTags`** (prod `"0.8"`), not `tag: "0.7"`. The **`prodDigest` / `serviceDbAccountsByEnv`** narrative now states a **fixed safety boundary** for data-ingestors#468 (edgeuser fallback removed): safe releases are **v0.8.0–v0.8.4**, with **v0.8.8** as the first unsafe release—instead of wording that tracked “the current float” and went stale within hours.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf498d299c4b0ef0b9a0724d15619a05eaee1d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->