### PR TITLE
fix(image-refresh): a skip that never ends is a finding, not an exit 0 (backend#1964)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.41
-appVersion: "1.9.41"
+version: 1.9.42
+appVersion: "1.9.42"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -122,6 +122,32 @@ data:
     ATTEMPT_KEY="tracebloc.io/refresh-attempt"
     FLAP_KEY="tracebloc.io/refresh-flap-detected"
 
+    # backend#1964: guard a SKIP THAT NEVER ENDS. The settled guard below is
+    # correct to skip a tick while a rollout is in flight, but it cannot tell
+    # "in flight" from "will never settle" -- and the second case freezes image
+    # refresh for ALL FOUR workloads while every tick exits 0 and the CronJob
+    # stays green. Nobody looks at a green CronJob.
+    #
+    # This is reachable without anything crashing. jobs-manager's readiness
+    # probe (jobs-manager-deployment.yaml) is a TCP connect to 8080, and
+    # jobs_manager.py CATCHES a failed run_server_in_thread on purpose so
+    # Service Bus polling and training survive. The pod then runs forever,
+    # useful, and never Ready -- so `rollout status` never settles. Measured
+    # triggers, all operator-reachable: a malformed ingestion-authz.yaml
+    # (load_authz_policy raises), edgeuser losing CREATE/ALTER on the
+    # ingestion_runs table (ensure_ingestion_runs_table raises), or 8080
+    # already bound (make_server binds in _ServerThread.__init__).
+    #
+    # The flap counter above CANNOT cover this: it counts failed ROLLOUTS, and
+    # everything after the settled guard is unreachable when the deployment
+    # never settles. Hence a second counter with the same shape.
+    #
+    # Default 8 ticks = ~2h at the default 15m schedule: comfortably longer than
+    # any legitimate rollout (including a resource-monitor DaemonSet roll across
+    # every node) and far shorter than the days this went unnoticed.
+    MAX_SKIP_TICKS="${MAX_SKIP_TICKS:-8}"
+    SKIP_KEY="tracebloc.io/refresh-skip-streak"
+
     log "release=$RELEASE_NAME namespace=$RELEASE_NAMESPACE deployment=$DEPLOYMENT_NAME"
     log "  client images: tracebloc/{jobs-manager,pods-monitor,resource-monitor} on docker.io under tag=$IMAGE_TAG"
     log "  also reconciling: deployment/${REQUESTS_PROXY_DEPLOYMENT} (jobs-manager image), daemonset/${RESOURCE_MONITOR_DAEMONSET} in ${NODE_AGENTS_NAMESPACE}"
@@ -277,7 +303,38 @@ data:
     # concurrencyPolicy: Forbid blocks every later tick.
     if ! kubectl rollout status -n "$RELEASE_NAMESPACE" "deployment/${DEPLOYMENT_NAME}" --request-timeout=15s --timeout=10s >/dev/null 2>&1; then
       if kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" --request-timeout=15s >/dev/null 2>&1; then
-        log "deployment/${DEPLOYMENT_NAME} not settled (rollout in progress or pod not Ready) -- skipping this refresh tick; will retry when settled"
+        # COUNT the skip before taking it (backend#1964). A single skip is
+        # normal; an unbroken run of them means refresh has stopped for all four
+        # workloads and no rollout will ever happen to say so.
+        #
+        # Read FAIL-CLOSED, same reasoning as the ATTEMPT_KEY read below: we just
+        # proved this deployment is readable, so an annotation read that fails
+        # here is anomalous. Collapsing it to "0 skips" would restart the streak
+        # every tick and the ceiling would never be reached -- the freeze would
+        # be permanent AND unreported, which is strictly worse than today.
+        if ! skips="$(get_annotation "$SKIP_KEY")"; then
+          log "ERROR: deployment/${DEPLOYMENT_NAME} is not settled AND the ${SKIP_KEY} annotation could not be read (kubectl/jq error), so the skip streak cannot be counted. Failing the tick rather than skipping silently: an uncounted skip is how this freezes forever."
+          exit 1
+        fi
+        case "$skips" in ''|*[!0-9]*) skips=0 ;; esac
+        skips=$(( skips + 1 ))
+        kubectl annotate deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" \
+          "${SKIP_KEY}=${skips}" --overwrite --request-timeout=15s
+
+        if [ "$skips" -ge "$MAX_SKIP_TICKS" ]; then
+          # The freeze is now a FINDING, not an exit 0. Every image the CronJob
+          # owns has been frozen for MAX_SKIP_TICKS ticks; a rollout in progress
+          # does not last that long, so this deployment is not going to settle
+          # on its own.
+          log "ERROR: deployment/${DEPLOYMENT_NAME} has been unsettled for ${skips} consecutive ticks (>= MAX_SKIP_TICKS=${MAX_SKIP_TICKS}). IMAGE REFRESH IS FROZEN, and not only for jobs-manager: deployment/${REQUESTS_PROXY_DEPLOYMENT} and daemonset/${RESOURCE_MONITOR_DAEMONSET} are reconciled after this guard, so they have received NO image updates either."
+          log "  MANUAL ATTENTION NEEDED. Most likely the jobs-manager pod is Running but never Ready, which the readiness probe reports and nothing kills:"
+          log "    kubectl -n ${RELEASE_NAMESPACE} get pods -l app.kubernetes.io/component=jobs-manager"
+          log "    kubectl -n ${RELEASE_NAMESPACE} logs deployment/${DEPLOYMENT_NAME} -c api | grep -i 'ingestion HTTP server'"
+          log "  A 'Failed to start ingestion HTTP server' line means 8080 never opened: check ingestion-authz.yaml parses, that the DB user may create the ingestion_runs table, and that 8080 is free. Refresh resumes by itself once the pod goes Ready."
+          exit 1
+        fi
+
+        log "deployment/${DEPLOYMENT_NAME} not settled (rollout in progress or pod not Ready) -- skipping this refresh tick ${skips}/${MAX_SKIP_TICKS}; will retry when settled"
         exit 0
       fi
       # Surface the REAL API error instead of swallowing it: the generic
@@ -287,6 +344,21 @@ data:
       err="$(kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" --request-timeout=15s 2>&1 >/dev/null || true)"
       log "ERROR: cannot read deployment/${DEPLOYMENT_NAME} (NotFound, RBAC denial, or API error): ${err:-unknown error} -- not a benign skip; failing the tick so it is visible"
       exit 1
+    fi
+
+    # Settled: the streak is over, so clear it (backend#1964). Only written when
+    # there is something to clear, so a healthy edge is not patched every 15
+    # minutes for nothing. A read error is NOT fatal here -- unlike the skip path
+    # above, being unable to confirm a streak we are about to reset cannot hide a
+    # freeze: we have just proved the deployment settled. Say so and carry on.
+    #
+    # Deliberately NOT auto-clearing FLAP_KEY/ATTEMPT_KEY: those two mean "a
+    # rollout kept failing" and #563 requires a human to clear them. This one
+    # means "the deployment was busy", which resolving it genuinely resolves.
+    if skips="$(get_annotation "$SKIP_KEY")" && [ -n "$skips" ]; then
+      log "deployment/${DEPLOYMENT_NAME} is settled again after ${skips} skipped tick(s) -- clearing ${SKIP_KEY}"
+      kubectl annotate deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" \
+        "${SKIP_KEY}-" --request-timeout=15s >/dev/null
     fi
 
     # =================================================================
@@ -620,6 +692,11 @@ spec:
                 # #563: consecutive failed-rollout threshold; stop + flag after this.
                 - name: MAX_REFRESH_ATTEMPTS
                   value: {{ .Values.imageRefresh.maxRefreshAttempts | default 3 | quote }}
+                # backend#1964: consecutive UNSETTLED-skip threshold. The failed-
+                # rollout counter above cannot cover this — it lives after the
+                # settled guard, which a never-Ready pod never gets past.
+                - name: MAX_SKIP_TICKS
+                  value: {{ .Values.imageRefresh.maxSkipTicks | default 8 | quote }}
                 # Per-image opt-out flags. Pinning a class-1 image is
                 # signalled by setting `images.<image>.digest` to a non-empty
                 # value — the same signal the deployment uses to switch

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -976,6 +976,20 @@ imageRefresh:
   # tracebloc.io/refresh-attempt annotation to re-arm (or a rollout that finally
   # settles resets the counter on its own).
   maxRefreshAttempts: 3
+  # backend#1964. The OTHER way refresh stops: the job skips a tick whenever the
+  # jobs-manager Deployment is not settled, which is right for a rollout in
+  # flight and wrong forever if the pod never becomes Ready. Because the skip
+  # happens BEFORE anything is reconciled, requests-proxy and resource-monitor
+  # stop updating too — and every tick exits 0, so the CronJob stays green.
+  #
+  # After this many consecutive skips the job FAILS instead, annotating
+  # tracebloc.io/refresh-skip-streak so monitoring can surface it. It auto-resumes
+  # the moment the deployment settles (unlike maxRefreshAttempts, which needs a
+  # human): a skip streak means "it was busy", and settling really does resolve it.
+  #
+  # 8 ticks is ~2h at the default 15m schedule — longer than any legitimate
+  # rollout, including a resource-monitor DaemonSet roll across every node.
+  maxSkipTicks: 8
   # CronJob spec knobs. Override per-cluster if needed.
   suspend: false
   # Lower history limits than autoUpgrade — this Job runs ~96x/day, the

--- a/scripts/tests/image-refresh-skip-streak.bats
+++ b/scripts/tests/image-refresh-skip-streak.bats
@@ -1,0 +1,264 @@
+#!/usr/bin/env bats
+# =============================================================================
+#  image-refresh-skip-streak.bats — backend#1964
+#
+#  The image-refresh CronJob skips a whole tick when the jobs-manager Deployment
+#  is not settled. That is right for a rollout in flight and wrong forever for a
+#  pod that never becomes Ready — and because the skip happens BEFORE anything is
+#  reconciled, requests-proxy and resource-monitor stop updating too while every
+#  tick exits 0 and the CronJob stays green.
+#
+#  WHY THIS RUNS THE SCRIPT INSTEAD OF GREPPING THE TEMPLATE.
+#  The chart's helm-unittest suite can only assert that some string is present in
+#  the rendered ConfigMap. A guard proved by "the text mentions MAX_SKIP_TICKS"
+#  is exactly the inert verification backend#1729 catalogued: it passes forever,
+#  including against logic that can never fire. So this suite RENDERS the chart,
+#  EXTRACTS the script the pod actually runs, and EXECUTES it against a stubbed
+#  kubectl — the exit code and the annotation writes are the assertions.
+#
+#  The stub is driven entirely by env vars, so each case states the cluster it is
+#  describing and nothing is shared between cases.
+# =============================================================================
+
+setup_file() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  CHART_DIR="${REPO_ROOT}/client"
+  # The same values file the other chart tests render with (chart-env-vocabulary.sh),
+  # rather than a hand-rolled minimum: a private --set list here would drift from
+  # what CI actually renders, and storage-class.yaml already refuses a bare render.
+  CI_VALUES="${REPO_ROOT}/client/ci/bm-values.yaml"
+  export REPO_ROOT CHART_DIR CI_VALUES
+
+  # Render once for the whole file: helm is the slow part, the script is static.
+  RENDERED="${BATS_FILE_TMPDIR}/image-refresh.sh"
+  export RENDERED
+
+  helm template stg "$CHART_DIR" -f "$CI_VALUES" \
+    --namespace tracebloc \
+    --show-only templates/image-refresh-cronjob.yaml \
+    2>/dev/null \
+    | python3 -c '
+import sys, yaml
+for doc in yaml.safe_load_all(sys.stdin.read()):
+    if doc and doc.get("kind") == "ConfigMap":
+        sys.stdout.write(doc["data"]["image-refresh.sh"])
+        break
+else:
+    sys.exit("no ConfigMap with image-refresh.sh in the rendered output")
+' > "$RENDERED"
+
+  chmod +x "$RENDERED"
+}
+
+setup() {
+  STUB_DIR="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "$STUB_DIR"
+  ANNOTATIONS="${BATS_TEST_TMPDIR}/annotate.log"
+  : > "$ANNOTATIONS"
+  export ANNOTATIONS
+
+  # kubectl stub. Only the calls this script makes before/at the settled guard
+  # are modelled; anything else is a loud failure rather than a silent 0, so a
+  # future call cannot be mistaken for a passing case.
+  cat > "$STUB_DIR/kubectl" <<'STUB'
+#!/bin/sh
+case "$1 $2" in
+  "config "*|"config")
+    # #634's in-cluster kubeconfig build. Local file writes, no API call.
+    exit 0 ;;
+  "rollout status")
+    exit "${STUB_ROLLOUT_RC:-0}" ;;
+  "get deployment")
+    # Two distinct calls share this verb: the bare existence probe, and the
+    # -o json read behind get_annotation(). Distinguished by -o json.
+    for a in "$@"; do
+      if [ "$a" = "json" ]; then
+        [ "${STUB_JSON_RC:-0}" = "0" ] || exit "${STUB_JSON_RC}"
+        printf '%s' "${STUB_JSON:-\{\"metadata\":\{\"annotations\":\{\}\}\}}"
+        exit 0
+      fi
+    done
+    exit "${STUB_GET_RC:-0}" ;;
+  "annotate deployment")
+    shift 2
+    printf '%s\n' "$*" >> "$ANNOTATIONS"
+    exit "${STUB_ANNOTATE_RC:-0}" ;;
+esac
+echo "kubectl stub: unmodelled call: $*" >&2
+exit 97
+STUB
+  chmod +x "$STUB_DIR/kubectl"
+
+  # curl stub: HERMETIC BY CONSTRUCTION. On the settled path the script goes on
+  # to resolve manifest digests from docker.io, so without this the suite would
+  # reach the real registry -- a unit test that fails on a plane, and one that
+  # burns the anonymous pull-rate limit the chart is careful about. Failing the
+  # fetch takes the script's documented "could not resolve latest digest
+  # (rate-limited or transient); skipping this tick" branch, which is exactly the
+  # deterministic no-op these cases want after the guard they are testing.
+  cat > "$STUB_DIR/curl" <<'CURLSTUB'
+#!/bin/sh
+echo "curl stub: refusing network access in a unit test: $*" >&2
+exit 6
+CURLSTUB
+  chmod +x "$STUB_DIR/curl"
+
+  # The env the pod supplies. IMAGE_REGISTRY must be docker.io or the mirror
+  # guard exits 0 long before the settled guard is reached.
+  export PATH="$STUB_DIR:$PATH"
+  export RELEASE_NAME=stg RELEASE_NAMESPACE=tracebloc
+  export DEPLOYMENT_NAME=stg-jobs-manager
+  export REQUESTS_PROXY_DEPLOYMENT=stg-requests-proxy
+  export RESOURCE_MONITOR_DAEMONSET=stg-resource-monitor
+  export NODE_AGENTS_NAMESPACE=tracebloc-node-agents
+  export IMAGE_REGISTRY=docker.io IMAGE_TAG=stg
+  export ROLLOUT_TIMEOUT=300s
+  # The script builds an explicit in-cluster kubeconfig from these (#634) and
+  # runs under `set -u`, so they are not optional.
+  export KUBERNETES_SERVICE_HOST=10.96.0.1 KUBERNETES_SERVICE_PORT=443
+  export JOBS_MANAGER_PINNED=0 PODS_MONITOR_PINNED=0 RESOURCE_MONITOR_PINNED=0
+  export MAX_SKIP_TICKS=8
+}
+
+# "the streak annotation was never written". NOT `grep -qv`: that returns 1 on an
+# empty file (no lines at all, matching or otherwise) and 0 on a file holding any
+# unrelated line, so it is wrong in both directions -- it failed the missing-
+# deployment case and PASSED the healthy-edge case for the wrong reason, because
+# Pass 1 writes digest annotations. Count the lines that actually matter.
+_assert_no_streak_write() {
+  local n
+  n="$(grep -c 'refresh-skip-streak' "$ANNOTATIONS" || true)"
+  if [ "$n" != "0" ]; then
+    printf 'expected no skip-streak write, found %s:\n%s\n' \
+      "$n" "$(grep 'refresh-skip-streak' "$ANNOTATIONS")" >&2
+    return 1
+  fi
+}
+
+# A deployment that is present but unsettled. The streak so far is $1.
+_unsettled_with_streak() {
+  export STUB_ROLLOUT_RC=1 STUB_GET_RC=0
+  export STUB_JSON="{\"metadata\":{\"annotations\":{\"tracebloc.io/refresh-skip-streak\":\"$1\"}}}"
+}
+
+@test "the harness really extracted the script the pod runs (not an empty file)" {
+  [ -s "$RENDERED" ] || return 1
+  head -1 "$RENDERED" | grep -q '^#!/bin/sh' || return 1
+  grep -q 'MAX_SKIP_TICKS' "$RENDERED" || return 1
+}
+
+@test "first unsettled tick still skips benignly, and records streak=1" {
+  export STUB_ROLLOUT_RC=1 STUB_GET_RC=0
+  export STUB_JSON='{"metadata":{"annotations":{}}}'
+  run sh "$RENDERED"
+  [ "$status" -eq 0 ] || return 1
+  grep -q 'skipping this refresh tick 1/8' <<<"$output" || return 1
+  grep -q 'refresh-skip-streak=1' "$ANNOTATIONS" || return 1
+}
+
+@test "an ongoing streak below the ceiling keeps skipping and increments" {
+  _unsettled_with_streak 6
+  run sh "$RENDERED"
+  [ "$status" -eq 0 ] || return 1
+  grep -q 'skipping this refresh tick 7/8' <<<"$output" || return 1
+  grep -q 'refresh-skip-streak=7' "$ANNOTATIONS" || return 1
+}
+
+@test "at the ceiling the tick FAILS instead of exiting 0 — the whole point of #1964" {
+  _unsettled_with_streak 7
+  run sh "$RENDERED"
+  [ "$status" -eq 1 ] || return 1
+  grep -q 'IMAGE REFRESH IS FROZEN' <<<"$output" || return 1
+  grep -q 'refresh-skip-streak=8' "$ANNOTATIONS" || return 1
+}
+
+@test "the frozen message names the OTHER workloads that stopped updating" {
+  # The reason this ticket outranks its severity: three more components are
+  # silently frozen, and an operator reading only "jobs-manager not settled"
+  # has no reason to think so.
+  #
+  # SCOPED TO THE FROZEN LINE on purpose. The startup banner already prints
+  # "also reconciling: deployment/<release>-requests-proxy ...", so grepping the
+  # whole output passes even if the frozen message names nothing at all — this
+  # assertion was vacuous in its first revision, and caught by watching it pass
+  # while the script was exiting long before the guard.
+  local frozen
+  _unsettled_with_streak 7
+  run sh "$RENDERED"
+  frozen="$(grep 'IMAGE REFRESH IS FROZEN' <<<"$output")"
+  [ -n "$frozen" ] || return 1
+  grep -q 'stg-requests-proxy' <<<"$frozen" || return 1
+  grep -q 'stg-resource-monitor' <<<"$frozen" || return 1
+}
+
+@test "the frozen message points at the never-Ready ingestion server, the reachable cause" {
+  _unsettled_with_streak 7
+  run sh "$RENDERED"
+  grep -q 'ingestion HTTP server' <<<"$output" || return 1
+  grep -q 'ingestion-authz.yaml' <<<"$output" || return 1
+}
+
+@test "a streak past the ceiling stays failed rather than lapsing back to green" {
+  _unsettled_with_streak 40
+  run sh "$RENDERED"
+  [ "$status" -eq 1 ] || return 1
+  grep -q 'IMAGE REFRESH IS FROZEN' <<<"$output" || return 1
+}
+
+@test "an unreadable streak annotation FAILS the tick — it must not collapse to zero" {
+  # Fail-open here would reset the streak every tick, so the ceiling would never
+  # be reached: the freeze would become permanent AND unreported.
+  export STUB_ROLLOUT_RC=1 STUB_GET_RC=0 STUB_JSON_RC=1
+  run sh "$RENDERED"
+  [ "$status" -eq 1 ] || return 1
+  grep -q 'skip streak cannot be counted' <<<"$output" || return 1
+}
+
+@test "a MISSING deployment is still the pre-existing exit 1, not a skip (#571 unchanged)" {
+  export STUB_ROLLOUT_RC=1 STUB_GET_RC=1
+  run sh "$RENDERED"
+  [ "$status" -eq 1 ] || return 1
+  grep -q 'not a benign skip' <<<"$output" || return 1
+  _assert_no_streak_write || return 1
+}
+
+@test "settling again clears the streak annotation" {
+  export STUB_ROLLOUT_RC=0 STUB_GET_RC=0
+  export STUB_JSON='{"metadata":{"annotations":{"tracebloc.io/refresh-skip-streak":"5"}}}'
+  run sh "$RENDERED"
+  grep -q 'settled again after 5 skipped tick' <<<"$output" || return 1
+  grep -q 'refresh-skip-streak-' "$ANNOTATIONS" || return 1
+}
+
+@test "a healthy edge with no streak is not patched every tick" {
+  export STUB_ROLLOUT_RC=0 STUB_GET_RC=0
+  export STUB_JSON='{"metadata":{"annotations":{}}}'
+  run sh "$RENDERED"
+  _assert_no_streak_write || return 1
+}
+
+@test "MAX_SKIP_TICKS is honoured from the environment, not hardcoded" {
+  export MAX_SKIP_TICKS=2
+  _unsettled_with_streak 1
+  run sh "$RENDERED"
+  [ "$status" -eq 1 ] || return 1
+  grep -q 'MAX_SKIP_TICKS=2' <<<"$output" || return 1
+}
+
+@test "the chart wires MAX_SKIP_TICKS into the CronJob env (default 8)" {
+  # Without this the script would silently fall back to its own default and
+  # imageRefresh.maxSkipTicks in values.yaml would be decoration.
+  run helm template stg "$CHART_DIR" -f "$CI_VALUES" --namespace tracebloc \
+    --show-only templates/image-refresh-cronjob.yaml
+  [ "$status" -eq 0 ] || return 1
+  grep -q 'name: MAX_SKIP_TICKS' <<<"$output" || return 1
+  grep -A1 'name: MAX_SKIP_TICKS' <<<"$output" | grep -q '"8"' || return 1
+}
+
+@test "imageRefresh.maxSkipTicks overrides the rendered value" {
+  run helm template stg "$CHART_DIR" -f "$CI_VALUES" --namespace tracebloc \
+    --set imageRefresh.maxSkipTicks=3 \
+    --show-only templates/image-refresh-cronjob.yaml
+  [ "$status" -eq 0 ] || return 1
+  grep -A1 'name: MAX_SKIP_TICKS' <<<"$output" | grep -q '"3"' || return 1
+}


### PR DESCRIPTION
Part 1 of tracebloc/backend#1964 (surfacing). Does **not** close it — see "Deliberately not here".

## The problem

The settled guard skips the whole tick when the jobs-manager Deployment is not settled. That is right for a rollout in flight and wrong forever for a pod that never becomes Ready — and because the skip sits **before Pass 1**, `requests-proxy` and `resource-monitor` stop being reconciled too, while every tick exits 0 and the CronJob stays green.

## It is reachable, and reachable by an operator

Nothing has to crash. jobs-manager's readiness probe is a TCP connect to 8080, and `jobs_manager.py:3529` catches a failed `run_server_in_thread` **on purpose** so Service Bus polling and training survive. The pod then runs forever, useful, and never Ready.

`run_server_in_thread` → `create_app()` → `ensure_ingestion_runs_table()` (a MySQL DDL migration) and `load_authz_policy(authz_path)`; then `_ServerThread.__init__` → `make_server()`, which **binds in the constructor**:

| trigger | raises in |
|---|---|
| malformed `ingestion-authz.yaml` — an operator-supplied ConfigMap | `load_authz_policy` |
| DB user without CREATE/ALTER on `ingestion_runs` (RFC-0003 grant narrowing) | `ensure_ingestion_runs_table` |
| 8080 already bound | `make_server` |

So a `helm upgrade` typo silently freezes image refresh for four workloads on a customer edge.

**The existing flap counter cannot cover it.** `MAX_REFRESH_ATTEMPTS` counts failed *rollouts*, and everything after the settled guard is unreachable when the deployment never settles.

## What this does

A second counter with the same shape — `MAX_SKIP_TICKS`, default **8** (~2h at the 15m schedule), exposed as `imageRefresh.maxSkipTicks`:

| situation | before | after |
|---|---|---|
| 1st–7th unsettled tick | `exit 0`, silent | `exit 0`, annotates `refresh-skip-streak=N` |
| 8th consecutive | `exit 0`, silent, forever | **`exit 1`**, names all four frozen workloads + the likely cause |
| settled again | — | clears the annotation; **auto-resumes** |
| annotation unreadable | — | `exit 1` — fail-open would reset the streak every tick, so the ceiling would never be reached |
| deployment missing | `exit 1` (#571) | unchanged, and asserted |

Auto-resume is deliberate and differs from `maxRefreshAttempts`, which needs a human: a skip streak means "it was busy", and settling genuinely resolves that.

## Deliberately not here

The ticket's decision 1 — reconcile the other three components past an unsettled jobs-manager — is **unsafe as written for pods-monitor**. `pods-monitor-container` is a *sidecar in the jobs-manager Deployment* (`jobs-manager-deployment.yaml:458`) and the CronJob re-images both containers in one patch, so refreshing it requires rolling a Deployment that cannot go Ready — incident #545's restart storm, which this guard exists to prevent. Only `requests-proxy` (own Deployment) and `resource-monitor` (own DaemonSet) can be decoupled. That is a separate PR once the decision is confirmed on the ticket.

## Tests run the script, they do not grep the template

`scripts/tests/image-refresh-skip-streak.bats` renders the chart, extracts the script the pod actually runs, and **executes it** against a stubbed `kubectl`. Exit codes and annotation writes are the assertions. A "the ConfigMap contains MAX_SKIP_TICKS" test would pass against logic that can never fire — the inert-verification shape backend#1729 catalogued.

Hermetic: `curl` is stubbed to refuse, so the suite never reaches docker.io or spends the anonymous pull-rate limit the chart is careful about. Verified stable across repeated runs.

## Mutation proof

Each anchor asserted, because an inert mutation and good coverage look identical in a log:

```
revert the ceiling to exit 0 (the original defect)   4 tests redden
fail-open the unreadable annotation read             1 test  reddens
drop the other-workload names from the message       1 test  reddens (the right one)
remove clear-on-settled                              1 test  reddens
baseline, 3 consecutive runs                         14/14 ok
```

Two of my own assertions were **vacuous** on the first pass and are fixed in place with the reason recorded in the file:

- `grep -qv PATTERN file` does not mean "no matching line" — it returns 1 on an empty file and 0 on any file with an unrelated line. Wrong in both directions; it failed one case and passed another for the wrong reason.
- A whole-output grep for `requests-proxy` matches the **startup banner**, so that assertion passed while the script was exiting long before the guard.

## Adjacent, not changed

The flap branch (#563) also `exit 0`s after logging "MANUAL ATTENTION NEEDED" — the same green-while-frozen shape. Left alone deliberately: it is documented behaviour and deserves its own ticket rather than a drive-by in this diff.

## Test plan

- [x] `bats scripts/tests/image-refresh-skip-streak.bats` — 14/14, stable over 3 runs
- [x] `bats scripts/tests/bats-hygiene.bats` — 18/18 (new file satisfies the `|| return 1` gate)
- [x] `helm unittest client` — 433/433 across 30 suites
- [x] `helm lint client -f client/ci/bm-values.yaml` — clean
- [x] 4 mutations, each reddening with its anchor asserted
- [x] `scripts/manifest.sha256` unaffected — it covers installer scripts, not chart templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fleet-wide image-refresh behavior on customer edges; mis-tuned thresholds or guard bugs could false-fail jobs or miss freezes, though scope is bounded and covered by executable BATS tests.
> 
> **Overview**
> **Image-refresh** now detects when the jobs-manager Deployment stays unsettled tick after tick (e.g. Running but never Ready) and stops treating that as a silent success.
> 
> When rollout status says “not settled” but the deployment exists, the script increments **`tracebloc.io/refresh-skip-streak`** on the jobs-manager Deployment. Below **`imageRefresh.maxSkipTicks`** (default **8**, ~2h at the 15m schedule) it still **`exit 0`** but logs **`N/MAX`**. At the ceiling it **`exit 1`** with **IMAGE REFRESH IS FROZEN**, naming **requests-proxy** and **resource-monitor** (reconciliation never runs while the guard skips) and hints for a never-Ready ingestion HTTP server. Unreadable streak annotations **fail the tick** (no fail-open reset). Once settled, the streak annotation is **cleared** and refresh **auto-resumes**—unlike the flap counter.
> 
> **`MAX_SKIP_TICKS`** is wired from values into the CronJob env. Chart version **1.9.41 → 1.9.42**.
> 
> **`scripts/tests/image-refresh-skip-streak.bats`** renders the chart, runs the real **`image-refresh.sh`** against stubbed **`kubectl`**/**`curl`**, and asserts exit codes and annotations (plus helm template checks for the env default/override).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d5481b6b6b1e5137382256e633230f5ad9ba03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->