### PR TITLE
sec(chart): narrow auto-upgrade RBAC into the GPU device-plugin namespace (backend#1992)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.42
-appVersion: "1.9.42"
+version: 1.9.43
+appVersion: "1.9.43"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -142,6 +142,34 @@ mysql-pvc
 {{- end }}
 
 {{/*
+  Name of the GPU device-plugin DaemonSet, by vendor. Takes the resolved vendor
+  string as its context, NOT the root scope:
+    {{ include "tracebloc.gpuDevicePluginName" "nvidia" }}
+
+  These names are NOT release-scoped on purpose — they match the upstream
+  manifests the installer used to `kubectl apply`, so an installer re-run adopts
+  an existing DaemonSet in place instead of orphaning it (client#564).
+
+  Kept in ONE helper because two templates must agree on them: gpu-device-plugin
+  .yaml renders the DaemonSet, and auto-upgrade-rbac.yaml grants the auto-upgrade
+  ServiceAccount update/patch/delete restricted to exactly these resourceNames
+  (backend#1992). If those two ever disagreed, an `helm upgrade --atomic` tick
+  would 403 in the GPU namespace, roll back, and silently kill auto-upgrade on
+  every GPU edge — the failure this narrow Role exists to prevent. Deriving both
+  from here makes that drift impossible rather than merely unlikely.
+
+  Any vendor other than "amd" resolves to the NVIDIA name; gpu-device-plugin.yaml
+  `fail`s the render for a vendor outside {nvidia, amd} before that can matter.
+*/}}
+{{- define "tracebloc.gpuDevicePluginName" -}}
+{{- if eq . "amd" -}}
+amdgpu-device-plugin-daemonset
+{{- else -}}
+nvidia-device-plugin-daemonset
+{{- end -}}
+{{- end }}
+
+{{/*
   Release-scoped name shared by the auto-upgrade CronJob, ServiceAccount,
   ClusterRoleBinding, and the ConfigMap holding the upgrade script. Kept
   in one helper so the four resources stay in lockstep — the CRB references

--- a/client/templates/auto-upgrade-rbac.yaml
+++ b/client/templates/auto-upgrade-rbac.yaml
@@ -221,4 +221,138 @@ roleRef:
   name: {{ include "tracebloc.autoUpgradeName" . }}-node-agents
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+{{- /*
+  Nil-safe read of the GPU device-plugin namespace, mirroring
+  docker-registry-secret.yaml exactly: a `--reset-then-reuse-values` upgrade from
+  a release predating client#564 carries no `gpu` key, and Go template `and` is
+  not short-circuit, so `and .Values.gpu .Values.gpu.devicePlugin.enabled` would
+  still evaluate `.enabled` on a nil and panic. Coalescing each level to an empty
+  dict BEFORE any field access removes the nil entirely.
+*/ -}}
+{{- $dp := (.Values.gpu | default dict).devicePlugin | default dict }}
+{{- $gpuNs := $dp.namespace | default "kube-system" }}
+{{- if and $dp.enabled (ne $gpuNs .Release.Namespace) }}
+{{- $gpuRoleName := printf "%s-gpu-device-plugin" (include "tracebloc.autoUpgradeName" .) }}
+{{/*
+  backend#1992 (Bugbot, staging hop 2026-08-14): a Linux GPU install templates
+  NAMESPACED objects into `gpu.devicePlugin.namespace` (kube-system by default) —
+  the vendor DaemonSet (gpu-device-plugin.yaml) and, on an authenticated
+  mirror, the mirrored dockerconfigjson pull Secret (docker-registry-secret.yaml).
+  The release-namespace Role above does not reach that namespace and the
+  ClusterRole enumerates only CLUSTER-scoped kinds, so after the #953
+  cluster-admin cutover a `helm upgrade --atomic --wait` tick would 403 there,
+  roll back, and leave the auto-upgrade CronJob permanently failed — on a
+  customer GPU edge, not in CI, and disabling the very channel that would deliver
+  the fix. Rendered only when the device plugin is enabled AND its namespace is a
+  SEPARATE namespace (otherwise the release-namespace Role already covers it).
+
+  DELIBERATELY NOT `*` on `*` like the node-agents block above. That block's
+  namespace is a namespace THIS chart creates and owns; this one defaults to
+  kube-system, which holds the service-account tokens of kube-controller-manager
+  and friends. `*` on `*` there — or even a plain namespace-wide `secrets: list` —
+  would let anything that compromised this Pod read those tokens and become
+  cluster-admin, which is precisely the blast radius backend#953 set out to
+  remove. So the grant below is derived from what the chart actually renders here
+  and nothing else, and the write verbs are pinned to those objects by name:
+
+    * daemonsets — name-free `get, list, watch` because helm's readiness check
+      and three-way-merge diff must be able to read the kind (a `resourceNames`
+      rule cannot authorize `list`/`watch`, and a 403 on that path is this exact
+      outage). Mutating verbs are restricted to the plugin DaemonSet itself, so
+      this cannot be used to patch a privileged container into kube-proxy.
+      BOTH vendor names are listed: flipping `gpu.devicePlugin.vendor` makes one
+      upgrade delete the old vendor's DaemonSet and create the new one, and a
+      single-name grant would 403 on that delete.
+
+    * secrets — no namespace-wide read at all. `create` cannot be name-restricted
+      by RBAC, but every other verb is pinned to the one mirrored pull Secret, so
+      the token-read path above stays closed. Granted unconditionally inside this
+      block rather than behind `tracebloc.useImagePullSecrets`: turning
+      `dockerRegistry` off must still let the upgrade DELETE the Secret it
+      previously mirrored here, which a gated rule would forbid.
+
+    * roles/rolebindings — the two objects rendered just below. Helm re-applies
+      every object in the manifest on upgrade, and their `helm.sh/chart` label
+      changes on every chart bump, so without this the SA could not reconcile its
+      own grant and auto-upgrade would 403 on the tick after this one. NOTE the
+      absence of `escalate`/`bind`: they are not needed here and are not safe
+      here. Kubernetes' privilege-escalation check passes when the actor already
+      holds every permission in the Role it writes — and this Role grants exactly
+      what the binding gives the SA, so it is self-reproducing by construction.
+      `escalate` on roles in kube-system, by contrast, would allow authoring a
+      Role that reads every Secret there: cluster-admin by another route.
+
+  `create` is not name-restrictable for any kind, but it grants nothing new: the
+  release-namespace Role is already `*` on `*`, so the SA can create these kinds
+  somewhere regardless. What matters is that it cannot read or mutate objects it
+  does not own in kube-system.
+
+  No flag-day: the upgrade that first ships this rides the same release as the
+  #953 cutover, so it is still performed by the previous cluster-admin-bound SA,
+  which can create these objects; every later tick runs under this scoped grant.
+  Adding a new object to this namespace in a future chart version REQUIRES
+  extending the rules below in the same release.
+*/}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $gpuRoleName }}
+  namespace: {{ $gpuNs }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auto-upgrade
+rules:
+  # gpu-device-plugin.yaml — the vendor device-plugin DaemonSet.
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["get", "list", "watch", "create"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    resourceNames:
+      - {{ include "tracebloc.gpuDevicePluginName" "nvidia" | quote }}
+      - {{ include "tracebloc.gpuDevicePluginName" "amd" | quote }}
+    verbs: ["update", "patch", "delete"]
+  # docker-registry-secret.yaml — the mirrored dockerconfigjson pull Secret.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ include "tracebloc.registrySecretName" . | quote }}]
+    verbs: ["get", "update", "patch", "delete"]
+  # This Role and its RoleBinding, so the SA can reconcile its own grant.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["create"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    resourceNames: [{{ $gpuRoleName | quote }}]
+    verbs: ["get", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $gpuRoleName }}
+  namespace: {{ $gpuNs }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auto-upgrade
+subjects:
+  # The SA lives in the release namespace; the binding lives in the GPU
+  # namespace. A RoleBinding may name a subject from any namespace.
+  - kind: ServiceAccount
+    name: {{ include "tracebloc.autoUpgradeName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ $gpuRoleName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/client/templates/gpu-device-plugin.yaml
+++ b/client/templates/gpu-device-plugin.yaml
@@ -58,8 +58,11 @@ kind: DaemonSet
 metadata:
   # Name/namespace match the upstream NVIDIA manifest (v0.14.5) the installer
   # used to apply, so an installer re-run adopts an existing DaemonSet in place
-  # rather than orphaning it.
-  name: nvidia-device-plugin-daemonset
+  # rather than orphaning it. The name comes from a shared helper because
+  # auto-upgrade-rbac.yaml restricts the auto-upgrade SA's write verbs in this
+  # namespace to exactly this resourceName (backend#1992) — one declaration, so
+  # the two cannot drift into a 403.
+  name: {{ include "tracebloc.gpuDevicePluginName" $vendor }}
   namespace: {{ $ns }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
@@ -118,7 +121,8 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: amdgpu-device-plugin-daemonset
+  # Shared helper — see the NVIDIA DaemonSet above (backend#1992).
+  name: {{ include "tracebloc.gpuDevicePluginName" $vendor }}
   namespace: {{ $ns }}
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}

--- a/client/tests/auto_upgrade_test.yaml
+++ b/client/tests/auto_upgrade_test.yaml
@@ -274,6 +274,212 @@ tests:
           path: kind
           value: ClusterRole
 
+  # ---------------------------------------------------------------------------
+  # backend#1992 — RBAC in the GPU device-plugin namespace.
+  #
+  # A Linux GPU install templates namespaced objects into
+  # gpu.devicePlugin.namespace (kube-system by default): the vendor DaemonSet
+  # and, on an authenticated mirror, the mirrored pull Secret. Neither the
+  # release-namespace Role nor the cluster-scoped-only ClusterRole reaches them,
+  # so before this fix a `helm upgrade --atomic --wait` tick 403'd there and
+  # auto-upgrade stayed permanently failed on every GPU edge.
+  # ---------------------------------------------------------------------------
+
+  - it: does NOT render the GPU Role/RoleBinding on a default CPU-only install (backend#1992)
+    template: templates/auto-upgrade-rbac.yaml
+    asserts:
+      # Still 7 — the two GPU documents must not appear when the device plugin
+      # is off, which is the default. Counting is what proves absence here.
+      - hasDocuments:
+          count: 7
+
+  - it: does NOT render the GPU Role/RoleBinding when gpu is explicitly null (nil-safe, no panic)
+    template: templates/auto-upgrade-rbac.yaml
+    set:
+      gpu: null
+    asserts:
+      - hasDocuments:
+          count: 7
+
+  - it: renders a Role + RoleBinding in the GPU namespace when the device plugin is enabled (backend#1992)
+    template: templates/auto-upgrade-rbac.yaml
+    set:
+      gpu:
+        devicePlugin:
+          enabled: true
+          vendor: nvidia
+    asserts:
+      # 7 + the GPU Role and RoleBinding.
+      - hasDocuments:
+          count: 9
+      # documentIndex follows template order. isKind/name/namespace are asserted
+      # alongside it deliberately: if a future edit shifts the index, these fail
+      # loudly instead of silently asserting against the wrong document.
+      - isKind:
+          of: Role
+        documentIndex: 7
+      - equal:
+          path: metadata.name
+          value: stg-auto-upgrade-gpu-device-plugin
+        documentIndex: 7
+      - equal:
+          path: metadata.namespace
+          value: kube-system
+        documentIndex: 7
+      - isKind:
+          of: RoleBinding
+        documentIndex: 8
+      - equal:
+          path: metadata.namespace
+          value: kube-system
+        documentIndex: 8
+      # The binding must reach back to the auto-upgrade SA, which lives in the
+      # RELEASE namespace — a RoleBinding may name a subject from any namespace.
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+        documentIndex: 8
+      - equal:
+          path: subjects[0].name
+          value: stg-auto-upgrade
+        documentIndex: 8
+      - equal:
+          path: subjects[0].namespace
+          value: tracebloc
+        documentIndex: 8
+      # …and bind the chart's own narrow Role, never a ClusterRole or a built-in.
+      - equal:
+          path: roleRef.kind
+          value: Role
+        documentIndex: 8
+      - equal:
+          path: roleRef.name
+          value: stg-auto-upgrade-gpu-device-plugin
+        documentIndex: 8
+
+  - it: GPU Role grants EXACTLY the derived set — nothing wider (backend#1992 security property)
+    template: templates/auto-upgrade-rbac.yaml
+    set:
+      gpu:
+        devicePlugin:
+          enabled: true
+          vendor: nvidia
+    documentIndex: 7
+    asserts:
+      # The whole point of this ticket is that the grant is NARROW. This
+      # namespace defaults to kube-system, which holds the service-account
+      # tokens of kube-controller-manager and friends, so a namespace-wide
+      # `secrets` read here — never mind `*` on `*` — is cluster-admin by
+      # another route and would undo backend#953.
+      #
+      # Asserting the ENTIRE rules array (not a `contains` subset) is what makes
+      # this a real gate: any added resource, added verb, widened apiGroup, or
+      # dropped resourceNames restriction fails this test. In particular there
+      # is no `escalate` and no `bind` — the grant is self-reproducing because it
+      # already covers every permission it writes, so Kubernetes' escalation
+      # check passes without them.
+      #
+      # The two DaemonSet names come from tracebloc.gpuDevicePluginName, the same
+      # helper gpu-device-plugin.yaml uses for metadata.name — see
+      # gpu_device_plugin_test.yaml, which pins the rendered DaemonSet to the
+      # same strings. A drift between the two would redden both suites.
+      - equal:
+          path: rules
+          value:
+            - apiGroups: ["apps"]
+              resources: ["daemonsets"]
+              verbs: ["get", "list", "watch", "create"]
+            - apiGroups: ["apps"]
+              resources: ["daemonsets"]
+              resourceNames:
+                - "nvidia-device-plugin-daemonset"
+                - "amdgpu-device-plugin-daemonset"
+              verbs: ["update", "patch", "delete"]
+            - apiGroups: [""]
+              resources: ["secrets"]
+              verbs: ["create"]
+            - apiGroups: [""]
+              resources: ["secrets"]
+              resourceNames: ["stg-regcred"]
+              verbs: ["get", "update", "patch", "delete"]
+            - apiGroups: ["rbac.authorization.k8s.io"]
+              resources: ["roles", "rolebindings"]
+              verbs: ["create"]
+            - apiGroups: ["rbac.authorization.k8s.io"]
+              resources: ["roles", "rolebindings"]
+              resourceNames: ["stg-auto-upgrade-gpu-device-plugin"]
+              verbs: ["get", "update", "patch", "delete"]
+      # Redundant with the exact match above, but stated separately so the intent
+      # survives: a future "simplify it like the node-agents block" edit that
+      # copies `*`/`*`/`*` in here must fail the suite by name, not just by diff.
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["*"]
+            resources: ["*"]
+            verbs: ["*"]
+      # No namespace-wide secret READ. `create` cannot be name-restricted by
+      # RBAC; every other secret verb is pinned to the one mirrored pull Secret.
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: GPU Role covers BOTH vendor DaemonSet names so a vendor flip cannot 403 on the delete (backend#1992)
+    template: templates/auto-upgrade-rbac.yaml
+    set:
+      gpu:
+        devicePlugin:
+          enabled: true
+          vendor: amd
+    documentIndex: 7
+    asserts:
+      # Switching gpu.devicePlugin.vendor makes ONE upgrade delete the outgoing
+      # vendor's DaemonSet and create the incoming one, so the name-restricted
+      # write rule must list both regardless of which vendor is selected.
+      - equal:
+          path: rules[1].resourceNames
+          value:
+            - "nvidia-device-plugin-daemonset"
+            - "amdgpu-device-plugin-daemonset"
+
+  - it: omits the GPU Role/RoleBinding when the device-plugin namespace IS the release namespace (backend#1992)
+    template: templates/auto-upgrade-rbac.yaml
+    set:
+      gpu:
+        devicePlugin:
+          enabled: true
+          vendor: nvidia
+          namespace: tracebloc
+    asserts:
+      # The release-namespace Role (`*` on `*`, confined to that namespace)
+      # already covers everything the plugin renders, so a second Role would be
+      # dead weight.
+      - hasDocuments:
+          count: 7
+
+  - it: places the GPU Role/RoleBinding in a custom device-plugin namespace (backend#1992)
+    template: templates/auto-upgrade-rbac.yaml
+    set:
+      gpu:
+        devicePlugin:
+          enabled: true
+          vendor: nvidia
+          namespace: gpu-operator
+    asserts:
+      - hasDocuments:
+          count: 9
+      - equal:
+          path: metadata.namespace
+          value: gpu-operator
+        documentIndex: 7
+      - equal:
+          path: metadata.namespace
+          value: gpu-operator
+        documentIndex: 8
+
   - it: should accept operator overrides for schedule, image, and timeout
     template: templates/auto-upgrade-cronjob.yaml
     documentIndex: 1


### PR DESCRIPTION
## What

The auto-upgrade ServiceAccount had no RBAC in the GPU device-plugin namespace. This adds a **narrow** Role + RoleBinding there.

Fixes tracebloc/backend#1992 — Bugbot **High** on the staging promotion PR #719, which it held.

## Why

A Linux GPU install templates two **namespaced** objects into `gpu.devicePlugin.namespace` (`kube-system` by default):

| Template | Object |
|---|---|
| `templates/gpu-device-plugin.yaml` | `apps/v1 DaemonSet` — `nvidia-device-plugin-daemonset` / `amdgpu-device-plugin-daemonset` |
| `templates/docker-registry-secret.yaml` | `v1 Secret` — `<release>-regcred` (dockerconfigjson), when `dockerRegistry.create` |

Nothing granted the auto-upgrade SA access to either: its Role is confined to `.Release.Namespace` (plus, conditionally, the node-agents namespace) and its ClusterRole enumerates only **cluster-scoped** kinds. So after the backend#953 cluster-admin cutover a `helm upgrade --atomic --wait` tick 403s on those objects, rolls back, and leaves the auto-upgrade CronJob permanently failed — on a customer GPU edge, not in CI, and disabling the very channel that would deliver its own fix.

## How the rule set was derived

Not from the ticket prose. I rendered the whole chart across the GPU value matrix and enumerated every object whose `metadata.namespace` equals the device-plugin namespace:

```
gpuNs=kube-system   → apps/v1 DaemonSet nvidia-device-plugin-daemonset
                      v1      Secret    stg-regcred
gpuNs=gpu-operator  → same two, relocated
gpuNs=<release ns>  → nothing extra (collapses into the release-namespace Role)
vendor=amd          → amdgpu-device-plugin-daemonset instead
dockerRegistry off  → DaemonSet only
gpu absent/null     → nothing
```

Confirms the DaemonSet + Secret. **No ServiceAccount is templated there** (the plugin uses the namespace default SA), and no SCC. One thing the ticket did not list surfaced: the **Role and RoleBinding this change itself adds** are also namespaced objects in that namespace, so they must be self-reproducing — see below.

## Why it is narrow, not `*` on `*`

The node-agents block uses `apiGroups/resources/verbs: ["*"]`, but that namespace is one this chart creates and owns. This one **defaults to `kube-system`**, which holds the service-account tokens of `kube-controller-manager` and friends. `*` on `*` there — or even a plain namespace-wide `secrets: list` — is cluster-admin by another route, i.e. exactly the blast radius backend#953 set out to remove. So write verbs are pinned by `resourceNames`:

- **`daemonsets`** — name-free `get, list, watch` because helm's readiness check and three-way-merge diff must read the kind (`resourceNames` cannot authorize `list`/`watch`, and a 403 on that path is this very outage). `update, patch, delete` restricted to the plugin DaemonSet, so this cannot patch a privileged container into `kube-proxy`. **Both** vendor names are listed: flipping `gpu.devicePlugin.vendor` makes one upgrade delete the outgoing DaemonSet and create the incoming one, and a single-name grant would 403 on that delete.
- **`secrets`** — **no namespace-wide read at all.** `create` cannot be name-restricted by RBAC; every other verb is pinned to the one mirrored pull Secret. Granted unconditionally inside the block rather than behind `tracebloc.useImagePullSecrets`, so turning `dockerRegistry` off can still **delete** the Secret previously mirrored here.
- **`roles`/`rolebindings`** — the two objects rendered by this block. Helm re-applies every manifest object on upgrade and their `helm.sh/chart` label changes on every version bump, so without this the SA could not reconcile its own grant and auto-upgrade would 403 on the tick after this one. Note the **absence of `escalate`/`bind`**: they are not needed, because Kubernetes' escalation check passes when the actor already holds every permission in the Role it writes — and this Role grants exactly what the binding gives the SA, so it is self-reproducing by construction. `escalate` on roles in `kube-system`, by contrast, would allow authoring a Role that reads every Secret there.

`create` is not name-restrictable for any kind, but it grants nothing new: the release-namespace Role is already `*` on `*`, so the SA can create these kinds somewhere regardless. What matters is that it cannot read or mutate objects it does not own in `kube-system`.

Gating mirrors the nil-safe `default dict` pattern from `docker-registry-secret.yaml`, so a `--reset-then-reuse-values` upgrade from a release predating client#564 cannot panic on a missing `gpu` key.

**No flag-day:** this rides the same release as the #953 cutover, so the upgrade that installs it is still performed by the previous cluster-admin-bound SA.

## One declaration, not two

The DaemonSet name moves into a shared helper `tracebloc.gpuDevicePluginName`, used by both `gpu-device-plugin.yaml` (`metadata.name`) and `auto-upgrade-rbac.yaml` (`resourceNames`). A `resourceNames` restriction that drifts from the object it names fails **closed into exactly this outage**, so the two must not be independently restated. Mutating the helper reddens both `auto_upgrade_test.yaml` and `gpu_device_plugin_test.yaml`.

## Tests

8 new cases in `client/tests/auto_upgrade_test.yaml`: not rendered by default; not rendered when `gpu` is explicitly null; rendered and correctly bound to the release-namespace SA when enabled; **exactly** the derived rule set (whole-array equality, so any added resource, added verb, widened apiGroup or dropped `resourceNames` fails) plus explicit no-wildcard and no-namespace-wide-secret-read guards; both vendor names present; not rendered when the device-plugin namespace **is** the release namespace; placed in a custom namespace.

```
Test Suites: 31 passed, 31 total
Tests:       454 passed, 454 total
```

### Mutation evidence

Every mutation was verified to have actually applied before running the suite (an inert mutation and real coverage look identical in a log), and each was checked to still render — a parse error is not proof of coverage.

| Mutation | Result |
|---|---|
| Remove the GPU Role/RoleBinding block entirely (reintroduce the bug); template still renders | 4 failed — the 4 rendering tests, while the "not rendered" tests stayed correctly green |
| "Simplify" the Role to `*`/`*`/`*` like the node-agents block | 2 failed — exact-rules `equal` **and** the wildcard `notContains` guard fired by name |
| Widen `secrets` to a namespace-wide `get,list,watch,...` (the kube-system token-read hole) | 1 failed — exact-rules `equal` |
| Drift the shared `tracebloc.gpuDevicePluginName` helper | 3 failed **across two suites** — `auto_upgrade_test.yaml` + `gpu_device_plugin_test.yaml` |
| Drop the `(ne $gpuNs .Release.Namespace)` guard | 1 failed — the release-namespace case |
| Drop the `roles`/`rolebindings` self-reproduction rules | 1 failed — exact-rules `equal` |

Restored → 454/454 green.

## Other gates

- `make check` green (lint, drift, `helm lint --strict` across all four `ci/*-values.yaml`, env-vocabulary agreement).
- `make helm-template` renders all four platforms.
- `client/Chart.yaml` bumped 1.9.42 → 1.9.43 — `chart-version-guard.sh` run locally against `origin/develop`: `client chart content changed and client/Chart.yaml 'version:' was bumped. ✓`
- **`scripts/` untouched**, verified by `git status`, so `scripts/gen-manifest.sh` / `manifest.sha256` regeneration does not apply (the Static analysis R8 gate is not in play).

## Follow-up — deliberately OUT OF SCOPE here

Defaulting `gpu.devicePlugin.namespace` to the **release namespace** would remove this RBAC hole *and* the pull-Secret mirror at the root: device plugins have no requirement to live in `kube-system` — they talk to the kubelet over a hostPath socket, so `kube-system` is upstream convention, not a constraint. It is out of scope here because pre-client#564 leftovers live in `kube-system` and the installer's adoption path hard-codes it, so the migration would become delete-and-recreate rather than adopt in place. Worth its own ticket with a migration story; not something to smuggle into a fix that has to ship on this hop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-upgrade RBAC in kube-system (or another GPU namespace) on enabled GPU installs; mistakes could break upgrades or widen secret access, but the grant is tightly name-scoped and heavily tested.
> 
> **Overview**
> Fixes **backend#1992**: after the cluster-admin cutover, auto-upgrade could **403** on namespaced objects in `gpu.devicePlugin.namespace` (default **kube-system**)—the vendor **DaemonSet** and mirrored **pull Secret**—causing **`helm upgrade --atomic`** to roll back and leave the CronJob permanently failed on GPU edges.
> 
> When the device plugin is enabled and that namespace is **not** the release namespace, the chart now renders a **narrow Role + RoleBinding** there (not `*` on `*` like node-agents): DaemonSet **list/watch** plus **name-pinned** mutate on both NVIDIA and AMD plugin DaemonSets; **create** plus **name-pinned** secret verbs on `<release>-regcred` only; and self-reconciliation of that Role/Binding. Gating uses nil-safe `default dict` on `gpu` so old `--reuse-values` upgrades do not panic.
> 
> **`tracebloc.gpuDevicePluginName`** centralizes upstream DaemonSet names; **`gpu-device-plugin.yaml`** uses it for `metadata.name` so RBAC `resourceNames` cannot drift. Chart **1.9.42 → 1.9.43**. Eight new **`auto_upgrade_test.yaml`** cases lock document counts, binding wiring, exact rule set, vendor flip, and custom namespace behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac75e248b4fdd242861ff70b47a7451ea7c5e6a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->