### PR TITLE
ci: move checkout and setup-python off Node 20 before the fallback goes

### DIFF
--- a/.github/workflows/build-k3s-cuda.yaml
+++ b/.github/workflows/build-k3s-cuda.yaml
@@ -95,7 +95,7 @@ jobs:
           esac
           echo "Publish authorized: $ACTOR (triggering: $TRIGGERING_ACTOR) from $REF."
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Plain docker CLI (no unpinned marketplace actions -> passes action-pins).
       - name: Prepare buildx

--- a/.github/workflows/chart-version-guard.yml
+++ b/.github/workflows/chart-version-guard.yml
@@ -23,7 +23,7 @@ jobs:
     name: chart content ⇒ Chart.yaml version bump
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Require a Chart.yaml version bump when chart content changes

--- a/.github/workflows/digest-drift.yml
+++ b/.github/workflows/digest-drift.yml
@@ -33,7 +33,7 @@ jobs:
   watch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Public read of a public index needs no credential. Left unauthenticated
       # on purpose: a watcher that requires a secret is a watcher that silently

--- a/.github/workflows/drift-checks.yaml
+++ b/.github/workflows/drift-checks.yaml
@@ -43,7 +43,7 @@ jobs:
     name: Source-of-truth drift
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -42,7 +42,7 @@ jobs:
     name: Helm lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
@@ -107,7 +107,7 @@ jobs:
       KUBECONFORM_VERSION: "0.8.0"
       KUBECONFORM_SHA256: "9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883"
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
@@ -168,7 +168,7 @@ jobs:
     name: Helm unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
@@ -197,7 +197,7 @@ jobs:
     name: Spawned ingestor image is multi-arch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Assert the ingestor tag and pinned digests are multi-arch
         run: |
           repo=$(yq '.images.ingestor.repository' client/values.yaml)
@@ -270,7 +270,7 @@ jobs:
     name: Fleet auto-upgrade E2E (k3d)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Upgrade from last published release through both flag paths
         run: bash scripts/tests/e2e-auto-upgrade.sh
 
@@ -289,7 +289,7 @@ jobs:
     name: Seal-check egress-enforcement (k3d)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run the live egress-enforcement seal-check
         run: bash scripts/tests/e2e-seal-check.sh
 
@@ -320,7 +320,7 @@ jobs:
       TB_E2E_CLIENT_ID: ${{ secrets.TB_E2E_CLIENT_ID }}
       TB_E2E_CLIENT_PASSWORD: ${{ secrets.TB_E2E_CLIENT_PASSWORD }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run the full seal suite (skips until the e2e-test-agent is provisioned)
         run: |
           if [ -z "$TB_E2E_CLIENT_ID" ] || [ -z "$TB_E2E_CLIENT_PASSWORD" ]; then

--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -55,7 +55,7 @@ jobs:
     name: Static analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: bash -n (syntax) on every shell script
         run: |
@@ -132,7 +132,7 @@ jobs:
     name: bats (bash unit, mocked)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install bats
         run: sudo apt-get update -qq && sudo apt-get install -y -qq bats
       - name: Run bats
@@ -149,7 +149,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run Pester
         shell: pwsh
         env:
@@ -193,7 +193,7 @@ jobs:
           - 'fedora:latest'       # dnf, falls through to get.docker.com
           - 'opensuse/leap:15.6'  # zypper
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Pull the distro image FIRST, bounded and retried. `docker run` pulls
       # implicitly with no timeout, so Docker Hub connectivity trouble either
       # fails the job in seconds (registry-1.docker.io timeout, exit 125) or
@@ -235,7 +235,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Bring up a real k3d cluster + run a workload
         run: bash scripts/tests/e2e-cluster.sh
 
@@ -250,7 +250,7 @@ jobs:
     name: E2E auth-proxy (squid)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Cluster up through an authenticated proxy
         run: bash scripts/tests/e2e-proxy.sh
 
@@ -282,7 +282,7 @@ jobs:
           - 'opensuse/leap:15.6'  # zypper
           - 'alpine:3'            # busybox sh + apk (optional, minimal)
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Pull the distro image FIRST, bounded and retried. `docker run` pulls
       # implicitly with no timeout, so Docker Hub connectivity trouble either
       # fails the job in seconds (registry-1.docker.io timeout, exit 125) or
@@ -338,7 +338,7 @@ jobs:
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'e2e')
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install → CLI → cluster info (fresh shell) → dataset push --dry-run
         env:
           TRACEBLOC_CLI_REF: ${{ vars.TRACEBLOC_CLI_REF }}

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -29,7 +29,7 @@ jobs:
       prerelease: ${{ steps.guard.outputs.prerelease }}
     steps:
       - name: Checkout the released tag
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
 
@@ -86,7 +86,7 @@ jobs:
         # runs (actions/runner#2788, still open). An empty default would cause
         # checkout to fall back to the repo default branch and package the
         # chart from the wrong commit.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
@@ -242,7 +242,7 @@ jobs:
       - name: Checkout the released tag
         # Same actions/runner#2788 guard as above — pin to the release tag so the
         # manifest covers exactly the bytes published at this immutable ref.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
@@ -469,7 +469,7 @@ jobs:
       # one that shipped. A post-publish check reading a different script than the
       # release is worse than no check, because it still reports.
       - name: Check out the released tag (for scripts/index-invariants.sh)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Assert the public index holds only stable versions

--- a/.github/workflows/standard-checks.yml
+++ b/.github/workflows/standard-checks.yml
@@ -30,7 +30,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: bash -n (syntax) on every shell script
         run: |
@@ -50,7 +50,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install bats
         run: sudo apt-get update -qq && sudo apt-get install -y -qq bats

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -42,7 +42,7 @@ jobs:
       # else — and $USERPROFILE isn't available in the ${{ env }} context, only at runtime).
       CLUSTER_NAME: tbe2ewin
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Resolve isolated data dir + tool PATH
         shell: pwsh


### PR DESCRIPTION
Part of the fleet-wide sweep tracked in tracebloc/backend#2004. Sibling of tracebloc/backend#2005, which is green.

## Why

Every job in this repo emits:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24.

The forced run is a **temporary GitHub fallback**. When it is withdrawn, every job using these two actions fails. Same defect class as tracebloc/backend#1816, which moved `add-to-project` off `using: node20`.

## Measured, from each tag's own `action.yml`

Read `runs.using` at the tag rather than trusting release prose:

| action | tag | `using:` |
|---|---|---|
| checkout | v4.x *(was pinned here)* | `node20` |
| checkout | v5.1.0 / v6.1.0 / v7.0.1 | `node24` |
| setup-python | v5.x *(was pinned here)* | `node20` |
| setup-python | v6.0.0 / v6.3.0 / v7.0.0 | `node24` |

checkout needs **v5+**, setup-python needs **v6+**. Note v4.4.0 was published 2026-07-20 *alongside* v5.1.0/v6.1.0/v7.0.1 — the v4 line is still maintained but stays on node20, so waiting does not fix this.

## Why latest rather than the minimal v5/v6 hop

- **`cli` already ran exactly these two SHAs** before this sweep, so latest is proven in the org, and the fleet converges on **one pin per action** instead of gaining a third variant.
- One bump instead of two.
- **Neither v7 breaking change applies** — checked per repo, not assumed:
  - *setup-python v7 drops the `pip-install` input* → unused anywhere in the org.
  - *checkout v7 blocks fork-PR checkout under `pull_request_target`/`workflow_run`* → every workflow's **resolved triggers were parsed as YAML**, not grepped, so a comment naming a trigger cannot be mistaken for using one. No workflow in this repo pairs those triggers with a checkout.

This also normalises the pin comments: some lines carried a bare `# v4`, which is a mutable major alias in comment form rather than the full-semver convention.

## Verification

- `git diff -U0` inspected: **only `uses:` lines changed**, in either direction
- Every workflow in the repo still parses as YAML
- Anchor asserted: no occurrence of any old SHA survives under `.github/workflows/`
- CI on this PR is the real proof **for the two actions in scope**: `checkout` and `setup-python` no longer appear in the run's Node 20 deprecation annotation, with no other behavioural change.
- **The annotation itself does not disappear, and should not be read as the pass/fail signal.** This repo still pins 5 other action(s) whose `action.yml` declares `using: node20` (`azure/setup-helm` ×5, `actions/upload-artifact` ×2, `softprops/action-gh-release` ×2, `actions/download-artifact` ×1, `actions/stale` ×1) — out of scope here, measured the same way (read `runs.using` at the pinned SHA).
- In caller repos the `quality / *` jobs come from `code-quality.yml@main`, so their annotation also keeps naming the old `checkout` pin until `.github` promotes develop → main. That is a sequencing artefact of the reusable, not a defect in this PR.

## Ordering

No sequencing constraint. `caller-drift.py` byte-compares only the entries marked `copies:` in `repo-inventory.yml`, and **there are none fleet-wide** — so these PRs may merge in any order, including `.github`.

## Two repo-specific notes

**1. Self-hosted runner.** `windows-e2e.yaml` runs `runs-on: [self-hosted, windows, nested-virt]`, and **checkout v5+ requires runner ≥ v2.327.1**. The API reports `total_count: 0` registered runners at both repo and org level, so nothing is live to break today — but confirm the agent version if that runner is ever re-registered. Flagging rather than assuming. (`installer-tests.yaml` only *mentions* self-hosted in a comment; every job in it is `ubuntu-latest`.)

**2. Duplicate pins collapsed.** This repo carried **two different pins of checkout** — v4.4.0 and v4.3.1 — which is drift in its own right. Both now point at one SHA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pin-only workflow edits with no application or release logic changes; main caveat is self-hosted Windows runners needing a recent actions runner version for checkout v7.
> 
> **Overview**
> **Fleet-wide pin update:** every `actions/checkout` step under `.github/workflows/` now uses the same SHA (`3d3c42e5…`, **v7.0.1**) instead of mixed **v4** / **v4.4.0** pins.
> 
> This is part of the org sweep to move off **Node 20** actions before GitHub drops the forced Node 24 fallback. Checkout v4 runs on `node20`; v7 runs on `node24`. **Only `uses:` lines change** — no job logic, triggers, or step inputs were touched.
> 
> Workflows touched include helm CI, installer tests, release chart, drift/digest guards, k3s-cuda build, standard checks, and the self-hosted **windows-e2e** job (note: checkout v5+ needs runner **≥ v2.327.1** if that runner is re-enabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12abf5dc98c92aca30c20c0fcc7400dea66ceda5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
