### PR TITLE
fix(image-refresh): a bookkeeping write must not abort the tick (backend#2007)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.43
-appVersion: "1.9.43"
+version: 1.9.44
+appVersion: "1.9.44"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/image-refresh-cronjob.yaml
+++ b/client/templates/image-refresh-cronjob.yaml
@@ -355,10 +355,24 @@ data:
     # Deliberately NOT auto-clearing FLAP_KEY/ATTEMPT_KEY: those two mean "a
     # rollout kept failing" and #563 requires a human to clear them. This one
     # means "the deployment was busy", which resolving it genuinely resolves.
+    # The CLEAR is non-fatal too (backend#2007). The read above was already
+    # deliberately non-fatal; leaving the WRITE fatal under `set -e` was an
+    # asymmetry, not a decision -- and it aborted the tick BEFORE Pass 1, so a
+    # transient API error on a bookkeeping annotation froze the refresh of
+    # requests-proxy and resource-monitor on the very tick that proved the
+    # deployment had recovered. That is #1964's own recovery path failing the
+    # same way #1964 did, only red instead of green. Nothing below reads
+    # SKIP_KEY, so a stale value costs exactly one thing: the NEXT unsettled
+    # tick resumes counting from the old number instead of from zero, which
+    # trips the ceiling EARLIER -- fail-safe in the direction #1964 wants.
+    # Reported as a WARNING line rather than swallowed: "images did not update"
+    # must never be inferable only from the Job's colour (backend#1964).
     if skips="$(get_annotation "$SKIP_KEY")" && [ -n "$skips" ]; then
       log "deployment/${DEPLOYMENT_NAME} is settled again after ${skips} skipped tick(s) -- clearing ${SKIP_KEY}"
-      kubectl annotate deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" \
-        "${SKIP_KEY}-" --request-timeout=15s >/dev/null
+      if ! clear_err="$(kubectl annotate deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT_NAME" \
+        "${SKIP_KEY}-" --request-timeout=15s 2>&1 >/dev/null)"; then
+        log "  WARNING: could not clear ${SKIP_KEY} on deployment/${DEPLOYMENT_NAME}: ${clear_err:-unknown error}. Continuing with this tick anyway -- the annotation is bookkeeping and a stale value only makes the next skip streak trip its ceiling sooner. Clear it by hand if that is unwanted: kubectl annotate deployment -n ${RELEASE_NAMESPACE} ${DEPLOYMENT_NAME} ${SKIP_KEY}-"
+      fi
     fi
 
     # =================================================================

--- a/scripts/tests/image-refresh-skip-streak.bats
+++ b/scripts/tests/image-refresh-skip-streak.bats
@@ -230,6 +230,43 @@ _unsettled_with_streak() {
   grep -q 'refresh-skip-streak-' "$ANNOTATIONS" || return 1
 }
 
+# --- backend#2007: the CLEAR must not be able to abort the tick ---------------
+#
+# #1964 made a permanently-unsettled deployment a loud finding. Its RECOVERY path
+# then had its own way to freeze: the settled branch clears the bookkeeping
+# annotation under `set -e`, so a transient API error on that one write aborted
+# the tick BEFORE Pass 1 -- requests-proxy and resource-monitor stayed frozen on
+# the very tick that proved jobs-manager had recovered.
+#
+# "Reached Pass 1" is the assertion, not the exit status: Pass 1 logs a `checking
+# <repo>` line per image, and under the hermetic curl stub it then takes the
+# documented "could not resolve latest digest" no-op. Asserting the log line
+# pins the SPECIFIC thing the bug destroyed (work after the clear), where an
+# exit-status assertion would also pass if the script died somewhere later.
+
+@test "a failed streak clear does NOT abort the tick before Pass 1 (backend#2007)" {
+  export STUB_ROLLOUT_RC=0 STUB_GET_RC=0
+  export STUB_JSON='{"metadata":{"annotations":{"tracebloc.io/refresh-skip-streak":"5"}}}'
+  # Every annotate fails -- the clear is the first one the settled path reaches.
+  export STUB_ANNOTATE_RC=1
+  run sh "$RENDERED"
+  # It genuinely attempted the clear (otherwise this case proves nothing).
+  grep -q 'settled again after 5 skipped tick' <<<"$output" || return 1
+  # ...and carried on into Pass 1 instead of dying at the failed write.
+  grep -q 'checking tracebloc/jobs-manager' <<<"$output" || return 1
+  grep -q 'checking tracebloc/resource-monitor' <<<"$output" || return 1
+}
+
+@test "a failed streak clear is reported as a WARNING, not swallowed (backend#2007)" {
+  # The shared lesson of #1964 and #2007: "images did not update" must never be
+  # inferable only from the Job's colour. Non-fatal must still mean visible.
+  export STUB_ROLLOUT_RC=0 STUB_GET_RC=0
+  export STUB_JSON='{"metadata":{"annotations":{"tracebloc.io/refresh-skip-streak":"5"}}}'
+  export STUB_ANNOTATE_RC=1
+  run sh "$RENDERED"
+  grep -q 'WARNING: could not clear tracebloc.io/refresh-skip-streak' <<<"$output" || return 1
+}
+
 @test "a healthy edge with no streak is not patched every tick" {
   export STUB_ROLLOUT_RC=0 STUB_GET_RC=0
   export STUB_JSON='{"metadata":{"annotations":{}}}'


### PR DESCRIPTION
## Summary

Closes the second half of the `image-refresh-cronjob.yaml` pair. backend#2007.

The settled branch clears `tracebloc.io/refresh-skip-streak` under `set -eu` with no guard (`client/templates/image-refresh-cronjob.yaml:360`). The **read** two lines above is deliberately non-fatal; the **write** was left fatal — and the comment shows the asymmetry was never decided: it reasons about the read and says nothing about the write.

That matters because the clear runs **before Pass 1**. A transient API error on one bookkeeping annotation aborts the tick, so `requests-proxy` and `resource-monitor` stay frozen on the very tick that proved `jobs-manager` had recovered.

| | what happens | operator sees |
|---|---|---|
| backend#1964 (already on prod) | a never-Ready jobs-manager makes the tick a benign skip, exit 0 | **green** CronJob, no image updates |
| **this** | once it settles, the annotation clear can abort the tick before Pass 1 | **red** Job, no image updates |

So #1964's own recovery path had its own way to stay frozen.

## The change

Make the clear non-fatal and **report it**. Nothing below reads `SKIP_KEY`, so a stale value costs exactly one thing: the next unsettled tick resumes counting from the old number instead of zero, tripping the ceiling **earlier** — fail-safe in the direction #1964 wants.

Logged as a WARNING rather than swallowed, because the shared lesson of both findings is that "images did not update" must never be inferable only from the Job's colour.

**Scoped to this one call site on purpose.** I checked the other five `kubectl annotate` calls; all are deliberately fatal with recorded reasoning — the streak record fails closed so the ceiling cannot be dodged (#1964), the attempt counter must persist before a restart, and the success reset is split from the digest write precisely so a failure there cannot stick a flap lockout (#626). Only this one is pure cleanup.

## Tests

Extends #1964's harness, which renders the chart, extracts the script the pod actually runs, and executes it against a stubbed kubectl — `STUB_ANNOTATE_RC` was already a knob.

The assertion is that **Pass 1 is reached** (its per-image "checking &lt;repo&gt;" lines), not the exit status: a status assertion would also pass if the script died later for an unrelated reason.

**Mutation-proved.** With the template hunk reverted, both new cases fail:

    not ok 1 a failed streak clear does NOT abort the tick before Pass 1 (backend#2007)
    #   `grep -q 'checking tracebloc/jobs-manager' <<<"$output" || return 1' failed
    not ok 2 a failed streak clear is reported as a WARNING, not swallowed (backend#2007)
    #   `grep -q 'WARNING: could not clear tracebloc.io/refresh-skip-streak' ...' failed

Case 1 failing at `checking tracebloc/jobs-manager` is the bug reproduced — the tick really did abort before Pass 1. The mutation anchor was **confirmed absent** from the reverted file rather than assumed.

16/16 green with the fix restored; `helm lint` clean; `Chart.yaml` bumped 1.9.43 → 1.9.44 (chart-version-guard run locally against the real base).

## Why this is on the critical path

This is the one genuine fix among the three findings holding the `client` leg of the 2026-08-14 staging hop. The other two need no code: backend#2008 is refuted on the arithmetic (Helm's `daemonSetReady` tolerates `Desired - maxUnavailable`, and maxUnavailable defaults to 1), and the AMD thread is refuted against the upstream manifest.

Related: backend#2007, backend#1964, backend#2008, client#719, client#718.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guarded annotate in the image-refresh script with documented fail-safe stale-annotation behavior; other annotate sites stay fatal by design.
> 
> **Overview**
> When **jobs-manager** settles after a skip streak, clearing `tracebloc.io/refresh-skip-streak` no longer aborts the CronJob tick under `set -e`. A failed `kubectl annotate` is logged as **WARNING** and execution continues into **Pass 1**, so `requests-proxy` and `resource-monitor` can refresh on the recovery tick instead of failing red with no image updates.
> 
> Stale skip-streak values only shorten the next streak ceiling (fail-safe vs. #1964). Chart version **1.9.44**; bats cover “reaches Pass 1 after failed clear” and “WARNING is visible.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9c9dd4cd27f5241f394efaabd966a51b469304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->