### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/workflows/build-k3s-cuda.yaml
+++ b/.github/workflows/build-k3s-cuda.yaml
@@ -95,7 +95,7 @@ jobs:
           esac
           echo "Publish authorized: $ACTOR (triggering: $TRIGGERING_ACTOR) from $REF."
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Plain docker CLI (no unpinned marketplace actions -> passes action-pins).
       - name: Prepare buildx

--- a/.github/workflows/chart-version-guard.yml
+++ b/.github/workflows/chart-version-guard.yml
@@ -23,7 +23,7 @@ jobs:
     name: chart content ⇒ Chart.yaml version bump
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Require a Chart.yaml version bump when chart content changes

--- a/.github/workflows/digest-drift.yml
+++ b/.github/workflows/digest-drift.yml
@@ -33,7 +33,7 @@ jobs:
   watch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Public read of a public index needs no credential. Left unauthenticated
       # on purpose: a watcher that requires a secret is a watcher that silently

--- a/.github/workflows/drift-checks.yaml
+++ b/.github/workflows/drift-checks.yaml
@@ -43,7 +43,7 @@ jobs:
     name: Source-of-truth drift
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -42,7 +42,7 @@ jobs:
     name: Helm lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
@@ -107,7 +107,7 @@ jobs:
       KUBECONFORM_VERSION: "0.8.0"
       KUBECONFORM_SHA256: "9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883"
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
@@ -168,7 +168,7 @@ jobs:
     name: Helm unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
@@ -197,7 +197,7 @@ jobs:
     name: Spawned ingestor image is multi-arch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Assert the ingestor tag and pinned digests are multi-arch
         run: |
           repo=$(yq '.images.ingestor.repository' client/values.yaml)
@@ -270,7 +270,7 @@ jobs:
     name: Fleet auto-upgrade E2E (k3d)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Upgrade from last published release through both flag paths
         run: bash scripts/tests/e2e-auto-upgrade.sh
 
@@ -289,7 +289,7 @@ jobs:
     name: Seal-check egress-enforcement (k3d)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run the live egress-enforcement seal-check
         run: bash scripts/tests/e2e-seal-check.sh
 
@@ -320,7 +320,7 @@ jobs:
       TB_E2E_CLIENT_ID: ${{ secrets.TB_E2E_CLIENT_ID }}
       TB_E2E_CLIENT_PASSWORD: ${{ secrets.TB_E2E_CLIENT_PASSWORD }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run the full seal suite (skips until the e2e-test-agent is provisioned)
         run: |
           if [ -z "$TB_E2E_CLIENT_ID" ] || [ -z "$TB_E2E_CLIENT_PASSWORD" ]; then

--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -55,7 +55,7 @@ jobs:
     name: Static analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: bash -n (syntax) on every shell script
         run: |
@@ -132,7 +132,7 @@ jobs:
     name: bats (bash unit, mocked)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install bats
         run: sudo apt-get update -qq && sudo apt-get install -y -qq bats
       - name: Run bats
@@ -149,7 +149,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run Pester
         shell: pwsh
         env:
@@ -193,7 +193,7 @@ jobs:
           - 'fedora:latest'       # dnf, falls through to get.docker.com
           - 'opensuse/leap:15.6'  # zypper
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Pull the distro image FIRST, bounded and retried. `docker run` pulls
       # implicitly with no timeout, so Docker Hub connectivity trouble either
       # fails the job in seconds (registry-1.docker.io timeout, exit 125) or
@@ -235,7 +235,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Bring up a real k3d cluster + run a workload
         run: bash scripts/tests/e2e-cluster.sh
 
@@ -250,7 +250,7 @@ jobs:
     name: E2E auth-proxy (squid)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Cluster up through an authenticated proxy
         run: bash scripts/tests/e2e-proxy.sh
 
@@ -282,7 +282,7 @@ jobs:
           - 'opensuse/leap:15.6'  # zypper
           - 'alpine:3'            # busybox sh + apk (optional, minimal)
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Pull the distro image FIRST, bounded and retried. `docker run` pulls
       # implicitly with no timeout, so Docker Hub connectivity trouble either
       # fails the job in seconds (registry-1.docker.io timeout, exit 125) or
@@ -338,7 +338,7 @@ jobs:
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'e2e')
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install → CLI → cluster info (fresh shell) → dataset push --dry-run
         env:
           TRACEBLOC_CLI_REF: ${{ vars.TRACEBLOC_CLI_REF }}

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -29,7 +29,7 @@ jobs:
       prerelease: ${{ steps.guard.outputs.prerelease }}
     steps:
       - name: Checkout the released tag
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
 
@@ -86,7 +86,7 @@ jobs:
         # runs (actions/runner#2788, still open). An empty default would cause
         # checkout to fall back to the repo default branch and package the
         # chart from the wrong commit.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
@@ -242,7 +242,7 @@ jobs:
       - name: Checkout the released tag
         # Same actions/runner#2788 guard as above — pin to the release tag so the
         # manifest covers exactly the bytes published at this immutable ref.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
@@ -469,7 +469,7 @@ jobs:
       # one that shipped. A post-publish check reading a different script than the
       # release is worse than no check, because it still reports.
       - name: Check out the released tag (for scripts/index-invariants.sh)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Assert the public index holds only stable versions

--- a/.github/workflows/standard-checks.yml
+++ b/.github/workflows/standard-checks.yml
@@ -30,7 +30,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: bash -n (syntax) on every shell script
         run: |
@@ -50,7 +50,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install bats
         run: sudo apt-get update -qq && sudo apt-get install -y -qq bats

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -42,7 +42,7 @@ jobs:
       # else — and $USERPROFILE isn't available in the ${{ env }} context, only at runtime).
       CLUSTER_NAME: tbe2ewin
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Resolve isolated data dir + tool PATH
         shell: pwsh


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical third-party action pin bump in CI only; no application, auth, or release logic changes.
> 
> **Overview**
> **Pins `actions/checkout` to commit `3d3c42e5aac5ba805825da76410c181273ba90b1` (v7.0.1)** everywhere it appears under `.github/workflows/`, replacing older v4 / v4.4.0 SHAs.
> 
> Touched workflows include Helm CI, installer tests, drift/digest guards, standard checks, Windows e2e, k3s-cuda build, and release-helm-chart (including verify, release, sign-installer-manifest, and verify-index jobs). **No job logic, triggers, or permissions change**—only the checkout action reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca86b2c5eb08ffcdb0fa87a05234b7f67fa49627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->