### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -12,6 +12,10 @@ on:
       - 'scripts/tests/lib/e2e-common.sh'
       - 'scripts/tests/chart-env-vocabulary.sh'
       - 'scripts/lib/**'
+      # This workflow's `lint` job runs `make helm-lint helm-vocab`, so the
+      # Makefile is part of what the gate executes: an edit to those targets
+      # has to be able to start it.
+      - 'Makefile'
       - '.github/workflows/helm-ci.yaml'
   pull_request:
     branches: [main, develop, openshift]
@@ -24,6 +28,10 @@ on:
       - 'scripts/tests/lib/e2e-common.sh'
       - 'scripts/tests/chart-env-vocabulary.sh'
       - 'scripts/lib/**'
+      # This workflow's `lint` job runs `make helm-lint helm-vocab`, so the
+      # Makefile is part of what the gate executes: an edit to those targets
+      # has to be able to start it.
+      - 'Makefile'
       - '.github/workflows/helm-ci.yaml'
   # Manual runs — mainly to fire full-seal-e2e on demand (e.g. right after the
   # e2e-test-agent secrets are provisioned, or to re-record a seal run).
@@ -44,54 +52,40 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # helm is not on the runner image at a version we choose, so it is
+      # installed here at the pin this repo standardises on. That is
+      # environment bootstrapping, not a duplicated command -- the same
+      # distinction that keeps the shellcheck apt install in
+      # standard-checks.yml. Both `helm-lint` and `helm-vocab` shell out to
+      # `helm`, and chart-env-vocabulary.sh's helper-backstop cases branch on
+      # the helm VERSION (they self-skip below 3.16), so an unpinned runner
+      # helm would silently change which assertions run. drift-checks.yaml
+      # pins the identical action + version for the same reason.
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.15.4
 
-      - name: Helm lint (strict) — parent client chart, all platforms
-        run: |
-          for f in client/ci/*-values.yaml; do
-            echo "=== Linting client with $f ==="
-            helm lint --strict ./client -f "$f"
-          done
-
-      - name: Helm lint (strict) — ingestor subchart
-        # The ingestor subchart has no per-platform CI values files because
-        # its templates don't branch on platform — they only render a
-        # ConfigMap + Job + SA. The chart's one required value
-        # (`ingestConfig`) is supplied by customers at install time via
-        # `--set-file`; missing it during lint emits an INFO, not a FAIL,
-        # so plain `helm lint --strict ./ingestor` exercises the templates
-        # cleanly. See #135 for why we lint it here at all (publish workflow
-        # now packages both charts).
-        run: helm lint --strict ./ingestor
-
-      - name: CLIENT_ENV + channelTags vocabularies are closed
-        # `helm lint` does not exercise the values.schema.json `enum` /
-        # `additionalProperties` against out-of-vocabulary inputs, and
-        # helm-unittest structurally cannot: it reports a schema violation as a
-        # plugin-level error rather than a template failure, and exposes no flag
-        # to skip validation and reach the `fail` in tracebloc.clientEnv. So
-        # both gates are asserted from outside the plugin, every rejection
-        # paired with an accept control on the same command line. ~2 s.
+      - name: make helm-lint helm-vocab
+        # Both targets, from the Makefile that already declares them
+        # (backend#1606). This job restated the `client/ci/*-values.yaml` loop,
+        # the `helm lint --strict ./ingestor` call, and the chart-vocabulary
+        # script verbatim.
         #
-        # The helper-backstop cases self-skip when helm predates
-        # --skip-schema-validation (3.16); the pin above is v3.15.4, so they are
-        # skipped here today and run for anyone local on 3.16+. Bumping the pin
-        # turns them on with no change to this file.
-        run: bash scripts/tests/chart-env-vocabulary.sh
-
-      # The CLIENT_ENV vocabulary-agreement guard (backend#1729 sweep 5) used to
-      # run here. It now runs in drift-checks.yaml's `Source-of-truth drift` job,
-      # which is a REQUIRED check on develop and main -- `Helm lint` is not, so
-      # here the guard could only advise. `scripts/install-k8s.ps1` came into
-      # this workflow's `paths:` with it and left with it: this is the repo's
-      # heaviest workflow (a real k3d cluster plus two 4-platform matrices) and
-      # a PowerShell installer edit has no other reason to start it. The
-      # explicit `scripts/lib/common.sh` entry went too, but that one was always
-      # redundant -- the pre-existing `scripts/lib/**` glob still matches it, so
-      # helm-ci's triggering on a common.sh change is unchanged.
+        # `helm-vocab` is the chart vocabulary only. The CLIENT_ENV
+        # vocabulary-agreement guard (backend#1729 sweep 5) used to run in this
+        # job too; #715 moved it to drift-checks.yaml's `Source-of-truth drift`
+        # job, which is a REQUIRED check on develop and main -- `Helm lint` is
+        # not, so here the guard could only advise. Calling the Makefile must
+        # not quietly undo that, so the guard sits in `make drift` (the target
+        # that mirrors the drift gate) and not in `helm-vocab`; `make check`
+        # runs both, so the local tier is unchanged.
+        #
+        # The helper-backstop cases inside chart-env-vocabulary.sh self-skip
+        # when helm predates --skip-schema-validation (3.16); the pin above is
+        # v3.15.4, so they are skipped here today and run for anyone local on
+        # 3.16+. Bumping the pin turns them on with no change to this file.
+        run: make helm-lint helm-vocab
 
   template:
     timeout-minutes: 10

--- a/.github/workflows/standard-checks.yml
+++ b/.github/workflows/standard-checks.yml
@@ -32,19 +32,33 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: bash -n (syntax) on every shell script
-        run: |
-          find scripts -type f -name '*.sh' -print0 \
-            | while IFS= read -r -d '' f; do bash -n "$f" || exit 1; done
-          echo "all shell scripts parse"
-
-      - name: ShellCheck (libs + entrypoints), error severity
+      # shellcheck itself is not on the runner image, so it is installed here.
+      # That is environment bootstrapping, not a duplicated command.
+      - name: Install shellcheck
         run: |
           sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
           shellcheck --version | grep version
-          shellcheck --severity=error --shell=bash \
-            scripts/install.sh scripts/install-k8s.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
-            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/lib/e2e-common.sh
+
+      - name: make lint
+        # `make lint` (backend#1606). This job used to restate the parse loop AND
+        # spell out the shellcheck file list inline, while the Makefile kept the
+        # same list in SHELLCHECK_FILES. The two had ALREADY drifted, and in the
+        # direction nobody notices: the Makefile carried 19 entries and this file
+        # 9, so ten scripts were shellchecked on a contributor's machine and NOT
+        # at the merge gate --
+        #
+        #   scripts/gen-manifest.sh          scripts/check-facts.sh
+        #   scripts/check-style.sh           scripts/lib/*.sh
+        #   scripts/tests/check-drift.sh     scripts/tests/e2e-full-seal.sh
+        #   scripts/tests/e2e-journey.sh     scripts/tests/path-persist.sh
+        #   scripts/tests/chart-env-vocabulary.sh
+        #   scripts/tests/env-vocabulary-agreement.sh
+        #
+        # gen-manifest.sh is the installer's integrity manifest generator, so a
+        # shell defect there was invisible to this gate. Measured green across
+        # all 19 before this landed, so it arms a green check rather than
+        # importing a backlog.
+        run: make lint
 
   unit-tests:
     name: Unit tests

--- a/Makefile
+++ b/Makefile
@@ -164,14 +164,24 @@ lint:
 	@echo "all shell scripts parse"
 	shellcheck --severity=error --shell=bash $(SHELLCHECK_FILES)
 
-# drift: the three single-source guards from installer-tests.yaml's
-# `static` job. All three are pure local file comparisons (~0.2 s) and
-# all three have a --write / regenerate mode named in their own output.
+# drift: the repo's duplicated-declaration guards. The first three come from
+# installer-tests.yaml's `static` job; all three are pure local file
+# comparisons (~0.2 s) and all three have a --write / regenerate mode named in
+# their own output.
+#
+# The fourth is the CLIENT_ENV vocabulary-agreement guard (backend#1729
+# sweep 5). It lives here, not in `helm-vocab`, because #715 moved it out of
+# helm-ci's `Helm lint` into drift-checks.yaml's `Source-of-truth drift` job --
+# the one that is a REQUIRED check, so the guard can block rather than advise.
+# helm-ci's lint job calls `make helm-lint helm-vocab`, so keeping the guard in
+# `helm-vocab` would silently put it back where #715 took it from. ~2 s, bash
+# and python3 only.
 .PHONY: drift
 drift:
 	scripts/gen-manifest.sh --check
 	scripts/check-facts.sh --check
 	bash scripts/check-style.sh
+	bash scripts/tests/env-vocabulary-agreement.sh
 
 # digest-drift: the watcher on every mutable label that points at a pinned
 # digest (backend#1853). NOT in `check`: it needs the network and a docker
@@ -206,10 +216,13 @@ helm-lint:
 # can assert NEITHER: it treats a schema violation as a plugin-level error
 # rather than a template failure, and offers no way to skip validation and reach
 # the helper. So the gates are exercised from outside the plugin. ~2 s.
+#
+# CHART vocabulary only. env-vocabulary-agreement.sh is in `drift`, not here --
+# see that target for why (#715 moved it to the required drift gate, and
+# helm-ci's lint job runs this target).
 .PHONY: helm-vocab
 helm-vocab:
 	bash scripts/tests/chart-env-vocabulary.sh
-	bash scripts/tests/env-vocabulary-agreement.sh
 
 # helm-template: helm-ci.yaml `template`. kubeconform is pinned by
 # version AND digest in CI; rather than re-implement that download here,


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only how CI invokes existing Makefile targets; shellcheck coverage widens to match local dev and was verified green before merge.
> 
> **Overview**
> **CI workflows now delegate to the Makefile** instead of duplicating shell and Helm commands inline, so local `make` and GitHub Actions stay aligned (backend#1606).
> 
> The **Lint** job in `standard-checks.yml` runs `make lint` after installing shellcheck. That closes a real drift gap: CI had been shellchecking nine scripts while `SHELLCHECK_FILES` listed nineteen, so ten scripts (including `gen-manifest.sh`) were checked locally but not at merge.
> 
> The **Helm lint** job in `helm-ci.yaml` runs `make helm-lint helm-vocab` after pinning Helm; **`Makefile`** is added to that workflow’s `paths` so edits to those targets still trigger the gate.
> 
> **`make drift`** now runs `env-vocabulary-agreement.sh`, and **`helm-vocab`** no longer does. That keeps the CLIENT_ENV agreement guard on the required drift gate (#715) instead of re-attaching it to the non-required Helm lint job when CI calls the Makefile. `make check` still runs both `drift` and `helm-vocab`, so the local pre-push tier is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef9c71dcd18f63ed359544490360beb474a66bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->