### PR TITLE
release-train: staging -> main

### DIFF
--- a/.github/workflows/build-k3s-cuda.yaml
+++ b/.github/workflows/build-k3s-cuda.yaml
@@ -95,7 +95,7 @@ jobs:
           esac
           echo "Publish authorized: $ACTOR (triggering: $TRIGGERING_ACTOR) from $REF."
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Plain docker CLI (no unpinned marketplace actions -> passes action-pins).
       - name: Prepare buildx

--- a/.github/workflows/chart-version-guard.yml
+++ b/.github/workflows/chart-version-guard.yml
@@ -23,7 +23,7 @@ jobs:
     name: chart content ⇒ Chart.yaml version bump
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Require a Chart.yaml version bump when chart content changes

--- a/.github/workflows/digest-drift.yml
+++ b/.github/workflows/digest-drift.yml
@@ -33,7 +33,7 @@ jobs:
   watch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Public read of a public index needs no credential. Left unauthenticated
       # on purpose: a watcher that requires a secret is a watcher that silently

--- a/.github/workflows/drift-checks.yaml
+++ b/.github/workflows/drift-checks.yaml
@@ -43,7 +43,7 @@ jobs:
     name: Source-of-truth drift
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -12,6 +12,10 @@ on:
       - 'scripts/tests/lib/e2e-common.sh'
       - 'scripts/tests/chart-env-vocabulary.sh'
       - 'scripts/lib/**'
+      # This workflow's `lint` job runs `make helm-lint helm-vocab`, so the
+      # Makefile is part of what the gate executes: an edit to those targets
+      # has to be able to start it.
+      - 'Makefile'
       - '.github/workflows/helm-ci.yaml'
   pull_request:
     branches: [main, develop, openshift]
@@ -24,6 +28,10 @@ on:
       - 'scripts/tests/lib/e2e-common.sh'
       - 'scripts/tests/chart-env-vocabulary.sh'
       - 'scripts/lib/**'
+      # This workflow's `lint` job runs `make helm-lint helm-vocab`, so the
+      # Makefile is part of what the gate executes: an edit to those targets
+      # has to be able to start it.
+      - 'Makefile'
       - '.github/workflows/helm-ci.yaml'
   # Manual runs — mainly to fire full-seal-e2e on demand (e.g. right after the
   # e2e-test-agent secrets are provisioned, or to re-record a seal run).
@@ -44,54 +52,40 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # helm is not on the runner image at a version we choose, so it is
+      # installed here at the pin this repo standardises on. That is
+      # environment bootstrapping, not a duplicated command -- the same
+      # distinction that keeps the shellcheck apt install in
+      # standard-checks.yml. Both `helm-lint` and `helm-vocab` shell out to
+      # `helm`, and chart-env-vocabulary.sh's helper-backstop cases branch on
+      # the helm VERSION (they self-skip below 3.16), so an unpinned runner
+      # helm would silently change which assertions run. drift-checks.yaml
+      # pins the identical action + version for the same reason.
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.15.4
 
-      - name: Helm lint (strict) — parent client chart, all platforms
-        run: |
-          for f in client/ci/*-values.yaml; do
-            echo "=== Linting client with $f ==="
-            helm lint --strict ./client -f "$f"
-          done
-
-      - name: Helm lint (strict) — ingestor subchart
-        # The ingestor subchart has no per-platform CI values files because
-        # its templates don't branch on platform — they only render a
-        # ConfigMap + Job + SA. The chart's one required value
-        # (`ingestConfig`) is supplied by customers at install time via
-        # `--set-file`; missing it during lint emits an INFO, not a FAIL,
-        # so plain `helm lint --strict ./ingestor` exercises the templates
-        # cleanly. See #135 for why we lint it here at all (publish workflow
-        # now packages both charts).
-        run: helm lint --strict ./ingestor
-
-      - name: CLIENT_ENV + channelTags vocabularies are closed
-        # `helm lint` does not exercise the values.schema.json `enum` /
-        # `additionalProperties` against out-of-vocabulary inputs, and
-        # helm-unittest structurally cannot: it reports a schema violation as a
-        # plugin-level error rather than a template failure, and exposes no flag
-        # to skip validation and reach the `fail` in tracebloc.clientEnv. So
-        # both gates are asserted from outside the plugin, every rejection
-        # paired with an accept control on the same command line. ~2 s.
+      - name: make helm-lint helm-vocab
+        # Both targets, from the Makefile that already declares them
+        # (backend#1606). This job restated the `client/ci/*-values.yaml` loop,
+        # the `helm lint --strict ./ingestor` call, and the chart-vocabulary
+        # script verbatim.
         #
-        # The helper-backstop cases self-skip when helm predates
-        # --skip-schema-validation (3.16); the pin above is v3.15.4, so they are
-        # skipped here today and run for anyone local on 3.16+. Bumping the pin
-        # turns them on with no change to this file.
-        run: bash scripts/tests/chart-env-vocabulary.sh
-
-      # The CLIENT_ENV vocabulary-agreement guard (backend#1729 sweep 5) used to
-      # run here. It now runs in drift-checks.yaml's `Source-of-truth drift` job,
-      # which is a REQUIRED check on develop and main -- `Helm lint` is not, so
-      # here the guard could only advise. `scripts/install-k8s.ps1` came into
-      # this workflow's `paths:` with it and left with it: this is the repo's
-      # heaviest workflow (a real k3d cluster plus two 4-platform matrices) and
-      # a PowerShell installer edit has no other reason to start it. The
-      # explicit `scripts/lib/common.sh` entry went too, but that one was always
-      # redundant -- the pre-existing `scripts/lib/**` glob still matches it, so
-      # helm-ci's triggering on a common.sh change is unchanged.
+        # `helm-vocab` is the chart vocabulary only. The CLIENT_ENV
+        # vocabulary-agreement guard (backend#1729 sweep 5) used to run in this
+        # job too; #715 moved it to drift-checks.yaml's `Source-of-truth drift`
+        # job, which is a REQUIRED check on develop and main -- `Helm lint` is
+        # not, so here the guard could only advise. Calling the Makefile must
+        # not quietly undo that, so the guard sits in `make drift` (the target
+        # that mirrors the drift gate) and not in `helm-vocab`; `make check`
+        # runs both, so the local tier is unchanged.
+        #
+        # The helper-backstop cases inside chart-env-vocabulary.sh self-skip
+        # when helm predates --skip-schema-validation (3.16); the pin above is
+        # v3.15.4, so they are skipped here today and run for anyone local on
+        # 3.16+. Bumping the pin turns them on with no change to this file.
+        run: make helm-lint helm-vocab
 
   template:
     timeout-minutes: 10

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -42,7 +42,7 @@ jobs:
     name: Helm lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
@@ -107,7 +107,7 @@ jobs:
       KUBECONFORM_VERSION: "0.8.0"
       KUBECONFORM_SHA256: "9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883"
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
@@ -168,7 +168,7 @@ jobs:
     name: Helm unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
@@ -197,7 +197,7 @@ jobs:
     name: Spawned ingestor image is multi-arch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Assert the ingestor tag and pinned digests are multi-arch
         run: |
           repo=$(yq '.images.ingestor.repository' client/values.yaml)
@@ -270,7 +270,7 @@ jobs:
     name: Fleet auto-upgrade E2E (k3d)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Upgrade from last published release through both flag paths
         run: bash scripts/tests/e2e-auto-upgrade.sh
 
@@ -289,7 +289,7 @@ jobs:
     name: Seal-check egress-enforcement (k3d)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run the live egress-enforcement seal-check
         run: bash scripts/tests/e2e-seal-check.sh
 
@@ -320,7 +320,7 @@ jobs:
       TB_E2E_CLIENT_ID: ${{ secrets.TB_E2E_CLIENT_ID }}
       TB_E2E_CLIENT_PASSWORD: ${{ secrets.TB_E2E_CLIENT_PASSWORD }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run the full seal suite (skips until the e2e-test-agent is provisioned)
         run: |
           if [ -z "$TB_E2E_CLIENT_ID" ] || [ -z "$TB_E2E_CLIENT_PASSWORD" ]; then

--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -55,7 +55,7 @@ jobs:
     name: Static analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: bash -n (syntax) on every shell script
         run: |
@@ -132,7 +132,7 @@ jobs:
     name: bats (bash unit, mocked)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install bats
         run: sudo apt-get update -qq && sudo apt-get install -y -qq bats
       - name: Run bats
@@ -149,7 +149,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run Pester
         shell: pwsh
         env:
@@ -193,7 +193,7 @@ jobs:
           - 'fedora:latest'       # dnf, falls through to get.docker.com
           - 'opensuse/leap:15.6'  # zypper
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Pull the distro image FIRST, bounded and retried. `docker run` pulls
       # implicitly with no timeout, so Docker Hub connectivity trouble either
       # fails the job in seconds (registry-1.docker.io timeout, exit 125) or
@@ -235,7 +235,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Bring up a real k3d cluster + run a workload
         run: bash scripts/tests/e2e-cluster.sh
 
@@ -250,7 +250,7 @@ jobs:
     name: E2E auth-proxy (squid)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Cluster up through an authenticated proxy
         run: bash scripts/tests/e2e-proxy.sh
 
@@ -282,7 +282,7 @@ jobs:
           - 'opensuse/leap:15.6'  # zypper
           - 'alpine:3'            # busybox sh + apk (optional, minimal)
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Pull the distro image FIRST, bounded and retried. `docker run` pulls
       # implicitly with no timeout, so Docker Hub connectivity trouble either
       # fails the job in seconds (registry-1.docker.io timeout, exit 125) or
@@ -338,7 +338,7 @@ jobs:
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'e2e')
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install → CLI → cluster info (fresh shell) → dataset push --dry-run
         env:
           TRACEBLOC_CLI_REF: ${{ vars.TRACEBLOC_CLI_REF }}

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -29,7 +29,7 @@ jobs:
       prerelease: ${{ steps.guard.outputs.prerelease }}
     steps:
       - name: Checkout the released tag
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
 
@@ -86,7 +86,7 @@ jobs:
         # runs (actions/runner#2788, still open). An empty default would cause
         # checkout to fall back to the repo default branch and package the
         # chart from the wrong commit.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
@@ -242,7 +242,7 @@ jobs:
       - name: Checkout the released tag
         # Same actions/runner#2788 guard as above — pin to the release tag so the
         # manifest covers exactly the bytes published at this immutable ref.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
@@ -469,7 +469,7 @@ jobs:
       # one that shipped. A post-publish check reading a different script than the
       # release is worse than no check, because it still reports.
       - name: Check out the released tag (for scripts/index-invariants.sh)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Assert the public index holds only stable versions

--- a/.github/workflows/standard-checks.yml
+++ b/.github/workflows/standard-checks.yml
@@ -32,19 +32,33 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: bash -n (syntax) on every shell script
-        run: |
-          find scripts -type f -name '*.sh' -print0 \
-            | while IFS= read -r -d '' f; do bash -n "$f" || exit 1; done
-          echo "all shell scripts parse"
-
-      - name: ShellCheck (libs + entrypoints), error severity
+      # shellcheck itself is not on the runner image, so it is installed here.
+      # That is environment bootstrapping, not a duplicated command.
+      - name: Install shellcheck
         run: |
           sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
           shellcheck --version | grep version
-          shellcheck --severity=error --shell=bash \
-            scripts/install.sh scripts/install-k8s.sh scripts/resolve-ingestor-digest.sh scripts/lib/*.sh \
-            scripts/tests/distro-prereqs.sh scripts/tests/e2e-cluster.sh scripts/tests/e2e-proxy.sh scripts/tests/e2e-auto-upgrade.sh scripts/tests/e2e-seal-check.sh scripts/tests/lib/e2e-common.sh
+
+      - name: make lint
+        # `make lint` (backend#1606). This job used to restate the parse loop AND
+        # spell out the shellcheck file list inline, while the Makefile kept the
+        # same list in SHELLCHECK_FILES. The two had ALREADY drifted, and in the
+        # direction nobody notices: the Makefile carried 19 entries and this file
+        # 9, so ten scripts were shellchecked on a contributor's machine and NOT
+        # at the merge gate --
+        #
+        #   scripts/gen-manifest.sh          scripts/check-facts.sh
+        #   scripts/check-style.sh           scripts/lib/*.sh
+        #   scripts/tests/check-drift.sh     scripts/tests/e2e-full-seal.sh
+        #   scripts/tests/e2e-journey.sh     scripts/tests/path-persist.sh
+        #   scripts/tests/chart-env-vocabulary.sh
+        #   scripts/tests/env-vocabulary-agreement.sh
+        #
+        # gen-manifest.sh is the installer's integrity manifest generator, so a
+        # shell defect there was invisible to this gate. Measured green across
+        # all 19 before this landed, so it arms a green check rather than
+        # importing a backlog.
+        run: make lint
 
   unit-tests:
     name: Unit tests

--- a/.github/workflows/standard-checks.yml
+++ b/.github/workflows/standard-checks.yml
@@ -30,7 +30,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: bash -n (syntax) on every shell script
         run: |
@@ -50,7 +50,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install bats
         run: sudo apt-get update -qq && sudo apt-get install -y -qq bats

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -42,7 +42,7 @@ jobs:
       # else — and $USERPROFILE isn't available in the ${{ env }} context, only at runtime).
       CLUSTER_NAME: tbe2ewin
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Resolve isolated data dir + tool PATH
         shell: pwsh

--- a/Makefile
+++ b/Makefile
@@ -164,14 +164,24 @@ lint:
 	@echo "all shell scripts parse"
 	shellcheck --severity=error --shell=bash $(SHELLCHECK_FILES)
 
-# drift: the three single-source guards from installer-tests.yaml's
-# `static` job. All three are pure local file comparisons (~0.2 s) and
-# all three have a --write / regenerate mode named in their own output.
+# drift: the repo's duplicated-declaration guards. The first three come from
+# installer-tests.yaml's `static` job; all three are pure local file
+# comparisons (~0.2 s) and all three have a --write / regenerate mode named in
+# their own output.
+#
+# The fourth is the CLIENT_ENV vocabulary-agreement guard (backend#1729
+# sweep 5). It lives here, not in `helm-vocab`, because #715 moved it out of
+# helm-ci's `Helm lint` into drift-checks.yaml's `Source-of-truth drift` job --
+# the one that is a REQUIRED check, so the guard can block rather than advise.
+# helm-ci's lint job calls `make helm-lint helm-vocab`, so keeping the guard in
+# `helm-vocab` would silently put it back where #715 took it from. ~2 s, bash
+# and python3 only.
 .PHONY: drift
 drift:
 	scripts/gen-manifest.sh --check
 	scripts/check-facts.sh --check
 	bash scripts/check-style.sh
+	bash scripts/tests/env-vocabulary-agreement.sh
 
 # digest-drift: the watcher on every mutable label that points at a pinned
 # digest (backend#1853). NOT in `check`: it needs the network and a docker
@@ -206,10 +216,13 @@ helm-lint:
 # can assert NEITHER: it treats a schema violation as a plugin-level error
 # rather than a template failure, and offers no way to skip validation and reach
 # the helper. So the gates are exercised from outside the plugin. ~2 s.
+#
+# CHART vocabulary only. env-vocabulary-agreement.sh is in `drift`, not here --
+# see that target for why (#715 moved it to the required drift gate, and
+# helm-ci's lint job runs this target).
 .PHONY: helm-vocab
 helm-vocab:
 	bash scripts/tests/chart-env-vocabulary.sh
-	bash scripts/tests/env-vocabulary-agreement.sh
 
 # helm-template: helm-ci.yaml `template`. kubeconform is pinned by
 # version AND digest in CI; rather than re-implement that download here,


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-main` branch (a mirror of `staging`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI/Makefile wiring and a third-party action pin bump; they tighten merge gates (more shellcheck coverage) without altering runtime product code.
> 
> **Overview**
> **CI workflows** now use pinned `actions/checkout@v7.0.1` everywhere that previously used v4/v4.4.0.
> 
> The required **Lint** job in `standard-checks.yml` installs shellcheck and runs **`make lint`** instead of duplicating the bash parse loop and a shorter shellcheck file list—closing a gap where ten scripts were checked locally but not at merge.
> 
> **Helm Chart CI**’s lint job runs **`make helm-lint helm-vocab`** (with `Makefile` added to workflow `paths:` so target changes re-trigger the gate). Inline helm loops and vocabulary steps are removed in favor of the Makefile (backend#1606).
> 
> **Makefile**: `env-vocabulary-agreement.sh` moves from **`helm-vocab`** to **`drift`**, so helm-ci calling `make helm-vocab` does not re-run the CLIENT_ENV guard in the non-required Helm lint job; it stays on the required drift gate and in `make check` via `drift`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2475b8c0074276fc0a2e05ed344f0abb5522e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->