### PR TITLE
feat(chart): stop injecting the fixed training-job envelope; let jobs-manager size it (backend#664)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.44
-appVersion: "1.9.44"
+version: 1.9.45
+appVersion: "1.9.45"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -417,23 +417,23 @@ spec:
           value: {{ printf "%s/" (dig "imageRegistry" "docker.io" (.Values.global | default dict) | default "docker.io") | quote }}
         - name: CLIENT_ENV
           value: {{ include "tracebloc.clientEnv" . | quote }}
-        # backend#664 (Utilization Ladder L0): RESOURCE_REQUESTS/RESOURCE_LIMITS
-        # are rendered only when the operator sets them — an explicit envelope
-        # override, honored exactly as before. When UNSET the vars are omitted
-        # and jobs-manager sizes the envelope from node allocatable (75% with
-        # cpu=2/memory=8Gi floors, requests == limits / Guaranteed QoS). Older
-        # client-runtime images fall back to their built-in cpu=2,memory=8Gi
-        # literal — the same value this template used to inject — so chart and
-        # image can upgrade in either order without a behavior flip. The
-        # standalone installer writes explicit values (backend#1236), so the
-        # derivation path applies to chart-direct installs only.
-        {{- if hasKey .Values.env "RESOURCE_REQUESTS" }}
+        # backend#664 (Utilization Ladder L0): with NEITHER env.RESOURCE_REQUESTS
+        # nor env.RESOURCE_LIMITS set, BOTH vars are omitted and jobs-manager
+        # sizes the envelope from node allocatable (75% with cpu=2/memory=8Gi
+        # floors, requests == limits / Guaranteed QoS). Older client-runtime
+        # images fall back to their built-in cpu=2,memory=8Gi literal — the same
+        # value this template used to inject — so chart and image can upgrade in
+        # either order without a behavior flip. When EITHER key is set the pair
+        # renders exactly as before (the missing one gets the literal): the two
+        # vars share one gate, like the GPU block below, so a half-set config
+        # never emits a lone var. The standalone installer writes explicit
+        # values (backend#1236), so the derivation path applies to chart-direct
+        # installs only.
+        {{- if or (hasKey .Values.env "RESOURCE_REQUESTS") (hasKey .Values.env "RESOURCE_LIMITS") }}
         - name: RESOURCE_REQUESTS
-          value: {{ .Values.env.RESOURCE_REQUESTS | quote }}
-        {{- end }}
-        {{- if hasKey .Values.env "RESOURCE_LIMITS" }}
+          value: {{ if hasKey .Values.env "RESOURCE_REQUESTS" }}{{ .Values.env.RESOURCE_REQUESTS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         - name: RESOURCE_LIMITS
-          value: {{ .Values.env.RESOURCE_LIMITS | quote }}
+          value: {{ if hasKey .Values.env "RESOURCE_LIMITS" }}{{ .Values.env.RESOURCE_LIMITS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         {{- end }}
         # #343: only stamp the GPU vars when a GPU is actually configured. A
         # CPU-only install writes GPU_LIMITS: "" (empty), and a chart-direct
@@ -514,16 +514,15 @@ spec:
           value: {{ printf "%s/" (dig "imageRegistry" "docker.io" (.Values.global | default dict) | default "docker.io") | quote }}
         - name: CLIENT_ENV
           value: {{ include "tracebloc.clientEnv" . | quote }}
-        # Rendered only when set — see the api container's RESOURCE_REQUESTS
-        # note (backend#664): unset lets jobs-manager derive the envelope from
-        # node allocatable; older images keep their built-in literal.
-        {{- if hasKey .Values.env "RESOURCE_REQUESTS" }}
+        # See the api container's RESOURCE_REQUESTS note (backend#664): both
+        # omitted when neither is set (jobs-manager derives from node
+        # allocatable; older images keep their built-in literal), both rendered
+        # as before when either is set.
+        {{- if or (hasKey .Values.env "RESOURCE_REQUESTS") (hasKey .Values.env "RESOURCE_LIMITS") }}
         - name: RESOURCE_REQUESTS
-          value: {{ .Values.env.RESOURCE_REQUESTS | quote }}
-        {{- end }}
-        {{- if hasKey .Values.env "RESOURCE_LIMITS" }}
+          value: {{ if hasKey .Values.env "RESOURCE_REQUESTS" }}{{ .Values.env.RESOURCE_REQUESTS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         - name: RESOURCE_LIMITS
-          value: {{ .Values.env.RESOURCE_LIMITS | quote }}
+          value: {{ if hasKey .Values.env "RESOURCE_LIMITS" }}{{ .Values.env.RESOURCE_LIMITS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         {{- end }}
         # #343: only stamp the GPU vars when a GPU is actually configured (see
         # the api container above) — GPU_REQUESTS and GPU_LIMITS share one gate

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -417,10 +417,24 @@ spec:
           value: {{ printf "%s/" (dig "imageRegistry" "docker.io" (.Values.global | default dict) | default "docker.io") | quote }}
         - name: CLIENT_ENV
           value: {{ include "tracebloc.clientEnv" . | quote }}
+        # backend#664 (Utilization Ladder L0): RESOURCE_REQUESTS/RESOURCE_LIMITS
+        # are rendered only when the operator sets them — an explicit envelope
+        # override, honored exactly as before. When UNSET the vars are omitted
+        # and jobs-manager sizes the envelope from node allocatable (75% with
+        # cpu=2/memory=8Gi floors, requests == limits / Guaranteed QoS). Older
+        # client-runtime images fall back to their built-in cpu=2,memory=8Gi
+        # literal — the same value this template used to inject — so chart and
+        # image can upgrade in either order without a behavior flip. The
+        # standalone installer writes explicit values (backend#1236), so the
+        # derivation path applies to chart-direct installs only.
+        {{- if hasKey .Values.env "RESOURCE_REQUESTS" }}
         - name: RESOURCE_REQUESTS
-          value: {{ if hasKey .Values.env "RESOURCE_REQUESTS" }}{{ .Values.env.RESOURCE_REQUESTS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
+          value: {{ .Values.env.RESOURCE_REQUESTS | quote }}
+        {{- end }}
+        {{- if hasKey .Values.env "RESOURCE_LIMITS" }}
         - name: RESOURCE_LIMITS
-          value: {{ if hasKey .Values.env "RESOURCE_LIMITS" }}{{ .Values.env.RESOURCE_LIMITS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
+          value: {{ .Values.env.RESOURCE_LIMITS | quote }}
+        {{- end }}
         # #343: only stamp the GPU vars when a GPU is actually configured. A
         # CPU-only install writes GPU_LIMITS: "" (empty), and a chart-direct
         # install may omit the key entirely — in both cases emitting the var
@@ -500,10 +514,17 @@ spec:
           value: {{ printf "%s/" (dig "imageRegistry" "docker.io" (.Values.global | default dict) | default "docker.io") | quote }}
         - name: CLIENT_ENV
           value: {{ include "tracebloc.clientEnv" . | quote }}
+        # Rendered only when set — see the api container's RESOURCE_REQUESTS
+        # note (backend#664): unset lets jobs-manager derive the envelope from
+        # node allocatable; older images keep their built-in literal.
+        {{- if hasKey .Values.env "RESOURCE_REQUESTS" }}
         - name: RESOURCE_REQUESTS
-          value: {{ if hasKey .Values.env "RESOURCE_REQUESTS" }}{{ .Values.env.RESOURCE_REQUESTS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
+          value: {{ .Values.env.RESOURCE_REQUESTS | quote }}
+        {{- end }}
+        {{- if hasKey .Values.env "RESOURCE_LIMITS" }}
         - name: RESOURCE_LIMITS
-          value: {{ if hasKey .Values.env "RESOURCE_LIMITS" }}{{ .Values.env.RESOURCE_LIMITS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
+          value: {{ .Values.env.RESOURCE_LIMITS | quote }}
+        {{- end }}
         # #343: only stamp the GPU vars when a GPU is actually configured (see
         # the api container above) — GPU_REQUESTS and GPU_LIMITS share one gate
         # so a CPU-only install emits neither (no phantom GPU in the CLI view)

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -291,39 +291,32 @@ tests:
             value: "false"
           count: 1
 
-  # tracebloc/backend#745: the per-spawned-training-job resource request/limit
-  # the jobs-manager hands to each Job it creates. The chart is the single
-  # effective source of truth — it ALWAYS injects RESOURCE_REQUESTS /
-  # RESOURCE_LIMITS, so client-runtime's jobs_manager.py only falls back to its
-  # own default when they are absent. Pin the rendered value here so the two
-  # cannot silently diverge again, on BOTH containers that receive it
+  # backend#664 (Utilization Ladder L0, supersedes the backend#745 pin): with
+  # no operator value the chart must NOT inject RESOURCE_REQUESTS /
+  # RESOURCE_LIMITS — an omitted var is what lets jobs-manager size the
+  # training-job envelope from node allocatable. Older client-runtime images
+  # fall back to their built-in cpu=2,memory=8Gi (the exact literal the chart
+  # used to inject), so omission is behavior-identical on any pre-#664 image.
+  # Assert absence on BOTH containers that used to receive it
   # (api + pods-monitor).
-  - it: defaults spawned-job RESOURCE_REQUESTS/LIMITS to cpu=2,memory=8Gi (req==limit)
+  - it: omits spawned-job RESOURCE_REQUESTS/LIMITS by default (jobs-manager derives from node)
     asserts:
-      - contains:
+      - notContains:
           path: spec.template.spec.containers[0].env
-          content:
-            name: RESOURCE_REQUESTS
-            value: "cpu=2,memory=8Gi"
-          count: 1
-      - contains:
+          content: {name: RESOURCE_REQUESTS}
+          any: true
+      - notContains:
           path: spec.template.spec.containers[0].env
-          content:
-            name: RESOURCE_LIMITS
-            value: "cpu=2,memory=8Gi"
-          count: 1
-      - contains:
+          content: {name: RESOURCE_LIMITS}
+          any: true
+      - notContains:
           path: spec.template.spec.containers[1].env
-          content:
-            name: RESOURCE_REQUESTS
-            value: "cpu=2,memory=8Gi"
-          count: 1
-      - contains:
+          content: {name: RESOURCE_REQUESTS}
+          any: true
+      - notContains:
           path: spec.template.spec.containers[1].env
-          content:
-            name: RESOURCE_LIMITS
-            value: "cpu=2,memory=8Gi"
-          count: 1
+          content: {name: RESOURCE_LIMITS}
+          any: true
 
   - it: lets operators override spawned-job resources via env.RESOURCE_REQUESTS/LIMITS
     set:
@@ -339,6 +332,18 @@ tests:
           count: 1
       - contains:
           path: spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_LIMITS
+            value: "cpu=4,memory=16Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: RESOURCE_REQUESTS
+            value: "cpu=4,memory=16Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[1].env
           content:
             name: RESOURCE_LIMITS
             value: "cpu=4,memory=16Gi"

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -349,6 +349,40 @@ tests:
             value: "cpu=4,memory=16Gi"
           count: 1
 
+  # Bugbot on the #664 PR: the two vars share ONE gate, so a values file that
+  # sets only one still renders the PAIR (the missing one gets the historic
+  # literal, exactly as the always-inject template did) — a lone
+  # RESOURCE_REQUESTS/RESOURCE_LIMITS env var must never be emitted.
+  - it: pairs the literal when only one of RESOURCE_REQUESTS/LIMITS is set
+    set:
+      env:
+        RESOURCE_LIMITS: "cpu=4,memory=16Gi"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_REQUESTS
+            value: "cpu=2,memory=8Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESOURCE_LIMITS
+            value: "cpu=4,memory=16Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: RESOURCE_REQUESTS
+            value: "cpu=2,memory=8Gi"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: RESOURCE_LIMITS
+            value: "cpu=4,memory=16Gi"
+          count: 1
+
   - it: does not render PER_INGESTION_TABLES by default (RFC-0003 D16 knob off)
     asserts:
       - notContains:

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -39,15 +39,13 @@
         },
         "RESOURCE_REQUESTS": {
           "type": "string",
-          "default": "cpu=2,memory=8Gi",
           "pattern": "^(cpu=\\S+,memory=\\S+)?$",
-          "description": "Optional resource requests for spawned jobs (defaults to 'cpu=2,memory=8Gi' if not set)"
+          "description": "Optional explicit resource requests for spawned training jobs. Unset: jobs-manager derives the envelope from node allocatable (75% with cpu=2/memory=8Gi floors, backend#664); older images fall back to 'cpu=2,memory=8Gi'."
         },
         "RESOURCE_LIMITS": {
           "type": "string",
-          "default": "cpu=2,memory=8Gi",
           "pattern": "^(cpu=\\S+,memory=\\S+)?$",
-          "description": "Optional resource limits for spawned jobs (defaults to 'cpu=2,memory=8Gi' if not set)"
+          "description": "Optional explicit resource limits for spawned training jobs. Unset: jobs-manager derives the envelope from node allocatable (75% with cpu=2/memory=8Gi floors, backend#664); older images fall back to 'cpu=2,memory=8Gi'."
         },
         "GPU_REQUESTS": {
           "type": "string",

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -25,9 +25,14 @@ env: {
   # HTTP_PROXY_PORT: ""
   # HTTP_PROXY_USERNAME: ""
   # HTTP_PROXY_PASSWORD: ""
-  # Optional: resource requests for spawned jobs (defaults to "cpu=2,memory=8Gi" if not provided)
+  # Optional: explicit resource requests/limits for spawned training jobs.
+  # UNSET (the default): jobs-manager sizes the envelope from node allocatable
+  # capacity — cpu = max(2, floor(allocatable*0.75)), memory = max(8Gi,
+  # floor(allocatable*0.75)), requests == limits (Guaranteed QoS) — instead of
+  # the historic fixed "cpu=2,memory=8Gi" (backend#664, Utilization Ladder L0).
+  # Older client-runtime images fall back to that same literal, so leaving
+  # these unset is safe on any image. SET: pins the envelope exactly as before.
   # RESOURCE_REQUESTS: "cpu=2,memory=8Gi"
-  # Optional: resource limits for spawned jobs (defaults to "cpu=2,memory=8Gi" if not provided)
   # RESOURCE_LIMITS: "cpu=2,memory=8Gi"
   # Optional: GPU requests for spawned jobs (defaults to "nvidia.com/gpu=1" if not provided)
   # GPU_REQUESTS: "nvidia.com/gpu=1"

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -537,7 +537,7 @@ If the customer enables the policy on a CNI that doesn't enforce (default EKS, F
 
 ### 8.8 DoS via resource exhaustion — **out of scope**
 
-A malicious model can allocate memory / consume CPU up to the pod's resource limits. `resources.limits` are applied (defaults `cpu=2,memory=8Gi`). A pod running at 100% of its limits is expected behavior for training; OOMKill or eviction is the Kubernetes-native response. The chart does not attempt to detect or prevent resource-intensive pathological inputs.
+A malicious model can allocate memory / consume CPU up to the pod's resource limits. `resources.limits` are always applied: sized from node allocatable (75% with `cpu=2`/`memory=8Gi` floors, backend#664) unless the operator pins an explicit envelope via `env.RESOURCE_REQUESTS`/`env.RESOURCE_LIMITS`. A pod running at 100% of its limits is expected behavior for training; OOMKill or eviction is the Kubernetes-native response. The chart does not attempt to detect or prevent resource-intensive pathological inputs.
 
 ### 8.9 Cosign-bootstrap trust root on boxes without cosign — **security / operator**
 


### PR DESCRIPTION
## Utilization Ladder Step 01 (L0) — chart half (plan PR 1.21)

Part of the org Utilization Ladder review for tracebloc/backend#664; delivery plan PR 1.21 on tracebloc-engine PR #647. Companion to **tracebloc/client-runtime#339**, which makes jobs-manager derive training-job resources from node allocatable.

### Problem

The fixed `cpu=2, memory=8Gi` envelope exists in two places kept in lockstep on purpose (backend#745): the in-code fallback in client-runtime's `jobs_manager.py`, and this chart — which **always injected** `RESOURCE_REQUESTS`/`RESOURCE_LIMITS`, defaulting to the literal. Nothing reads node capacity: a 4-core NUC and a 128-core Xeon produce the same Job spec; on a 16-core/32GB machine 14 cores and 24GB are allocated to nothing.

### What this does

With `env.RESOURCE_REQUESTS`/`env.RESOURCE_LIMITS` **unset**, the jobs-manager deployment now **omits** the vars instead of injecting the literal, so jobs-manager sizes the envelope from node allocatable (75% with cpu=2/8Gi floors, requests == limits / Guaranteed QoS — see client-runtime#339). **Set** values render exactly as before (explicit override, unchanged semantics).

### No behavior flip ahead of the code (readers-before-writers)

Upgrade order between chart and image does not matter:

- **New chart + old image:** var omitted → old jobs-manager falls back to its built-in `cpu=2,memory=8Gi` literal — the exact value this chart used to inject. Identical behavior.
- **Old chart + new image:** literal still injected → env-override path → literal. Identical behavior.
- **New chart + new image:** derivation activates.

Installer-provisioned clusters are unaffected either way: the installer writes explicit `RESOURCE_REQUESTS`/`RESOURCE_LIMITS` sized at install time (backend#1236), which remains an explicit override. Guaranteed QoS is preserved on every path; burst (requests < limits) is an explicitly open product decision (ladder L0/L4) and out of scope. GPU vars untouched.

### Changes

- `templates/jobs-manager-deployment.yaml`: render `RESOURCE_REQUESTS`/`RESOURCE_LIMITS` only when set (both api + pods-monitor containers)
- `values.yaml` + `values.schema.json`: document unset → derived-from-node, set → explicit override
- `tests/jobs_manager_test.yaml`: default case now asserts the vars are omitted; override test extended to both containers
- `docs/SECURITY.md` §8.8: limits wording updated (limits are still always applied)
- `Chart.yaml`: version + appVersion → 1.9.45 (lockstep)

### Evidence

`make check` green (incl. all 28 chart-env-vocabulary checks); `helm unittest` — Jobs Manager Deployment suite passes; the 4 failing suites (auto-upgrade, image-refresh, network-policy, priority-class) fail identically on clean `develop` with local helm v4 (pre-existing negative-schema-test quirk, not introduced here). No `.bats` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default training-job CPU/memory scheduling for chart-direct installs once paired with a new jobs-manager image; upgrade order is designed to stay behavior-identical until both chart and runtime ship.
> 
> **Overview**
> **Utilization Ladder L0 (chart half):** When `env.RESOURCE_REQUESTS` and `env.RESOURCE_LIMITS` are both unset, the jobs-manager deployment **no longer injects** the fixed `cpu=2,memory=8Gi` pair on the **api** and **pods-monitor** containers—omission lets jobs-manager derive training-job envelopes from node allocatable (with companion client-runtime behavior). **Explicit** values still render the same pair as before; if only one key is set, both env vars are emitted and the missing side keeps the historic literal so a lone var is never published.
> 
> Docs and schema drop the implied chart default and describe unset-vs-set semantics; **helm unittest** now asserts default omission, full override, and the half-set pairing case. Chart version **1.9.45**; **SECURITY.md** §8.8 notes limits are always applied (derived or pinned).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c626c9cbbedd4fd84a74b29fc146aefb894acdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->