### PR TITLE
fix(installer): bootstrap the amd64 cosign on Windows-on-ARM — the arm64 asset does not exist (client#734)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -273,13 +273,28 @@ function Resolve-Cosign {
   $onPath = Get-Command cosign -ErrorAction SilentlyContinue
   if ($onPath) { return $onPath.Source }
 
+  # BOTH architectures fetch the amd64 build, deliberately.
+  #
+  # Sigstore has never published a Windows arm64 cosign — not at $CosignVersion,
+  # not at any release. `cosign-windows-amd64.exe` is the only Windows asset there
+  # is. Asking for `cosign-windows-arm64.exe` (as this did) 404s, Resolve-Cosign
+  # returns $null, and a Windows-on-ARM install fails closed reading like a network
+  # blip — permanently, since retrying cannot conjure the asset.
+  #
+  # Running it under Windows-on-ARM's x64 emulation costs nothing that matters:
+  # cosign verifies a signature over BYTES, so the instruction set it was compiled
+  # for cannot change the verdict, and the binary we hand it is still the native
+  # arm64 one. The bootstrapped cosign is checksum-verified below exactly as on
+  # amd64, so the trust chain is identical.
+  #
+  # Do not "fix" this back to $arch. There is nothing on the other end.
   switch ($env:PROCESSOR_ARCHITECTURE) {
-    "AMD64" { $arch = "amd64" }
-    "ARM64" { $arch = "arm64" }
+    "AMD64" { }
+    "ARM64" { }
     default { return $null }
   }
   $base  = "https://github.com/sigstore/cosign/releases/download/$CosignVersion"
-  $asset = "cosign-windows-$arch.exe"
+  $asset = "cosign-windows-amd64.exe"
   $bin   = Join-Path $TmpDir "cosign.exe"
   $sums  = Join-Path $TmpDir "cosign_checksums.txt"
 
@@ -317,6 +332,34 @@ function Resolve-Cosign {
 #  - stderr is merged to stdout and discarded: a native tool writing to stderr would
 #    otherwise surface as a NativeCommandError dumping this script's source line +
 #    internal identifiers into the console/transcript (#576).
+# Can this cosign actually EXECUTE here? A trivial `cosign version`.
+#
+# Invoke-CosignVerifyBlob fails closed on a binary that won't start (the 255
+# sentinel is never overwritten, or the call throws) — correct, but it reports it
+# identically to a signature that did not verify. Those are different events with
+# different remedies, and only one of them means "this artifact may be tampered
+# with". Windows-on-ARM makes the distinction real: the amd64 cosign we fetch runs
+# under x64 emulation, and where that emulation is absent the binary cannot start
+# at all. Telling that user their download failed verification would be alarming
+# and wrong.
+#
+# Same shape as Invoke-CosignVerifyBlob deliberately: the 255 preset means a
+# binary that never runs cannot leave a stale 0 behind.
+function Test-CosignRuns {
+  param([Parameter(Mandatory)][string]$Cosign)
+  $global:LASTEXITCODE = 255
+  $prevEAP = $ErrorActionPreference
+  try {
+    $ErrorActionPreference = 'Continue'
+    & $Cosign version 2>&1 | Out-Null
+  } catch {
+    return $false
+  } finally {
+    $ErrorActionPreference = $prevEAP
+  }
+  return ($LASTEXITCODE -eq 0)
+}
+
 function Invoke-CosignVerifyBlob {
   param([Parameter(Mandatory)][string]$Cosign, [Parameter(Mandatory)][string[]]$VerifyArgs)
   $global:LASTEXITCODE = 255
@@ -368,6 +411,20 @@ function Confirm-ManifestSignature {
       return
     }
     throw "cosign is required to verify the installer's signature and couldn't be found or bootstrapped. Refusing to fall back to an unauthenticated, same-channel checksum. Fix: install cosign (https://docs.sigstore.dev/cosign/installation/) and re-run, or for local development only set `$env:TRACEBLOC_ALLOW_UNVERIFIED = '1'`."
+  }
+
+  # We have a cosign; prove it can run before any failure it reports is read as a
+  # bad signature. On Windows-on-ARM the amd64 build (the only one sigstore ships)
+  # needs x64 emulation; without it the binary never starts. Still fail closed —
+  # but say the true reason, because "your download may be tampered with" and "the
+  # verifier won't start on this machine" call for opposite reactions.
+  if (-not (Test-CosignRuns $cosign)) {
+    if ($AllowUnverified) {
+      Warn "cosign can't run on this machine -- the installer's signature NOT verified (TRACEBLOC_ALLOW_UNVERIFIED=1)."
+      Warn "Proceeding on checksum-only integrity. Not for production."
+      return
+    }
+    throw "cosign was obtained but won't run on this machine, so the installer's signature can't be checked. This is NOT a failed verification -- nothing suggests the download is bad. On Windows-on-ARM it usually means x64 emulation is unavailable (sigstore publishes no native arm64 cosign for Windows). Fix: install a cosign that runs here -- 'winget install sigstore.cosign' -- and re-run, or for local development only set `$env:TRACEBLOC_ALLOW_UNVERIFIED = '1'`."
   }
 
   # The keyless signing identity: the release workflow's OIDC cert. SAME pins as

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -424,7 +424,13 @@ function Confirm-ManifestSignature {
       Warn "Proceeding on checksum-only integrity. Not for production."
       return
     }
-    throw "cosign was obtained but won't run on this machine, so the installer's signature can't be checked. This is NOT a failed verification -- nothing suggests the download is bad. On Windows-on-ARM it usually means x64 emulation is unavailable (sigstore publishes no native arm64 cosign for Windows). Fix: install a cosign that runs here -- 'winget install sigstore.cosign' -- and re-run, or for local development only set `$env:TRACEBLOC_ALLOW_UNVERIFIED = '1'`."
+    # Deliberately does NOT suggest `winget install sigstore.cosign` (Bugbot).
+    # We already HAVE a cosign here -- it will not start. Installing another copy
+    # of the same amd64 build, which is the only one winget and sigstore publish,
+    # reproduces the failure exactly. A remedy that cannot clear the error is
+    # worse than none: it costs the user a round trip and teaches them the
+    # message is noise.
+    throw "cosign was obtained but won't run on this machine, so the installer's signature can't be checked. This is NOT a failed verification -- nothing suggests the download is bad. Two things cause it: security software may have quarantined or blocked the downloaded cosign.exe (check your antivirus / SmartScreen and allow it); or, on Windows-on-ARM, x64 emulation is unavailable -- Windows 11 on ARM includes it, Windows 10 on ARM may not, and sigstore publishes no native arm64 cosign to fall back on, so one would have to be built from source and put on PATH. For local development only you can set `$env:TRACEBLOC_ALLOW_UNVERIFIED = '1'`."
   }
 
   # The keyless signing identity: the release workflow's OIDC cert. SAME pins as

--- a/scripts/tests/install.Tests.ps1
+++ b/scripts/tests/install.Tests.ps1
@@ -266,10 +266,27 @@ Describe "A cosign that won't execute is not a failed signature (client#734)" {
       Should -Throw -ExpectedMessage "*NOT a failed verification*"
   }
 
-  It "names the real cause and a remedy that works on Windows-on-ARM" {
+  It "names both real causes -- quarantine and missing x64 emulation" {
     Mock Test-CosignRuns { $false }
     { Confirm-ManifestSignature -Manifest 'm' -RepoRel 'r' -TmpDir $TestDrive -AllowUnverified $false } |
-      Should -Throw -ExpectedMessage "*winget install sigstore.cosign*"
+      Should -Throw -ExpectedMessage "*quarantined*"
+    { Confirm-ManifestSignature -Manifest 'm' -RepoRel 'r' -TmpDir $TestDrive -AllowUnverified $false } |
+      Should -Throw -ExpectedMessage "*x64 emulation*"
+  }
+
+  # Bugbot: winget's cosign is amd64-only, the same build that just failed to
+  # start -- and we already HAVE a cosign in this branch. Suggesting it sends the
+  # user to reproduce the error. A remedy that cannot clear the failure must not
+  # appear in the failure it claims to remedy.
+  It "does NOT send the user to winget, which ships the same amd64 build" {
+    Mock Test-CosignRuns { $false }
+    # Capture the message and assert on it: `Should -Not -Throw -ExpectedMessage`
+    # asserts it does not throw AT ALL, which would pass for the wrong reason here.
+    $msg = $null
+    try { Confirm-ManifestSignature -Manifest 'm' -RepoRel 'r' -TmpDir $TestDrive -AllowUnverified $false }
+    catch { $msg = $_.Exception.Message }
+    $msg | Should -Not -BeNullOrEmpty      # it must still fail closed
+    $msg | Should -Not -Match 'winget'
   }
 
   It "never reaches the verify when cosign can't run" {

--- a/scripts/tests/install.Tests.ps1
+++ b/scripts/tests/install.Tests.ps1
@@ -200,6 +200,10 @@ Describe "Confirm-ManifestSignature: offline-bundle -> sig/cert fallback behavio
   BeforeEach {
     $env:TRACEBLOC_CA_BUNDLE = $null; $env:CURL_CA_BUNDLE = $null   # skip the CA fast-fail
     Mock Resolve-Cosign { "cosign" }
+    # The resolved cosign is now probed for executability before any verify
+    # failure is read as a bad signature; these tests are about the verify
+    # branches, so hold the probe true.
+    Mock Test-CosignRuns { $true }
     Mock Get-Optional   { $true }        # bundle + sig + cert all "published/fetched"
     Mock Ok {}; Mock Warn {}
   }
@@ -215,5 +219,71 @@ Describe "Confirm-ManifestSignature: offline-bundle -> sig/cert fallback behavio
     Mock Invoke-CosignVerifyBlob { $false }
     { Confirm-ManifestSignature -Manifest 'm' -RepoRel 'r' -TmpDir $TestDrive -AllowUnverified $false } |
       Should -Throw -ExpectedMessage "*Couldn't confirm the installer download is authentic*"
+  }
+}
+
+Describe "cosign bootstrap on Windows-on-ARM (client#734)" {
+  # Sigstore has never published a Windows arm64 cosign — `cosign-windows-amd64.exe`
+  # is the only Windows asset at any release. Asking for the arm64 name 404s, so a
+  # Windows-on-ARM install failed closed reading like a network blip, permanently.
+  BeforeAll { $script:BOOTSRC2 = Get-Content -Raw "$PSScriptRoot/../install.ps1" }
+
+  It "requests the amd64 cosign asset unconditionally — never a per-arch name" {
+    $fn = (($script:BOOTSRC2 -split "function Resolve-Cosign")[1] -split "`nfunction ")[0]
+    $fn | Should -Match 'cosign-windows-amd64\.exe'
+    # The interpolated form is the bug: it builds a URL for an asset that does not exist.
+    $fn | Should -Not -Match 'cosign-windows-\$arch\.exe'
+  }
+
+  It "still refuses an architecture it does not recognise" {
+    $fn = (($script:BOOTSRC2 -split "function Resolve-Cosign")[1] -split "`nfunction ")[0]
+    $fn | Should -Match 'default\s*\{\s*return \$null\s*\}'
+  }
+
+  It "keeps checksum-verifying the bootstrapped cosign (the trust chain is unchanged)" {
+    $fn = (($script:BOOTSRC2 -split "function Resolve-Cosign")[1] -split "`nfunction ")[0]
+    $fn | Should -Match 'Bootstrapped cosign failed its own checksum'
+  }
+
+  It "Test-CosignRuns presets a nonzero sentinel so a binary that never starts can't read as success" {
+    $fn = (($script:BOOTSRC2 -split "function Test-CosignRuns")[1] -split "`nfunction ")[0]
+    $fn | Should -Match '\$global:LASTEXITCODE = 255'
+    $fn | Should -Match 'return \(\$LASTEXITCODE -eq 0\)'
+  }
+}
+
+Describe "A cosign that won't execute is not a failed signature (client#734)" {
+  BeforeEach {
+    $env:TRACEBLOC_CA_BUNDLE = $null; $env:CURL_CA_BUNDLE = $null
+    Mock Resolve-Cosign { "cosign" }
+    Mock Get-Optional   { $true }
+    Mock Ok {}; Mock Warn {}
+  }
+
+  It "fails closed, and says the download is NOT implicated" {
+    Mock Test-CosignRuns { $false }
+    { Confirm-ManifestSignature -Manifest 'm' -RepoRel 'r' -TmpDir $TestDrive -AllowUnverified $false } |
+      Should -Throw -ExpectedMessage "*NOT a failed verification*"
+  }
+
+  It "names the real cause and a remedy that works on Windows-on-ARM" {
+    Mock Test-CosignRuns { $false }
+    { Confirm-ManifestSignature -Manifest 'm' -RepoRel 'r' -TmpDir $TestDrive -AllowUnverified $false } |
+      Should -Throw -ExpectedMessage "*winget install sigstore.cosign*"
+  }
+
+  It "never reaches the verify when cosign can't run" {
+    Mock Test-CosignRuns { $false }
+    Mock Invoke-CosignVerifyBlob { $true }
+    { Confirm-ManifestSignature -Manifest 'm' -RepoRel 'r' -TmpDir $TestDrive -AllowUnverified $false } |
+      Should -Throw
+    Should -Invoke Invoke-CosignVerifyBlob -Times 0 -Exactly
+  }
+
+  It "honours TRACEBLOC_ALLOW_UNVERIFIED, loudly, like the other unverified path" {
+    Mock Test-CosignRuns { $false }
+    { Confirm-ManifestSignature -Manifest 'm' -RepoRel 'r' -TmpDir $TestDrive -AllowUnverified $true } |
+      Should -Not -Throw
+    Should -Invoke Warn -Times 2 -Exactly
   }
 }


### PR DESCRIPTION
Closes #734. Unblocks the `cli` port in tracebloc/backend#2078.

## The bug

`Resolve-Cosign` built `cosign-windows-$arch.exe`. On Windows-on-ARM that asks for `cosign-windows-arm64.exe` — **an asset sigstore has never published**:

```
v2.4.1 (pinned) → cosign-windows-amd64.exe   (only Windows asset)
v3.1.3 (latest) → cosign-windows-amd64.exe   (only Windows asset)
```

404 → `Resolve-Cosign` returns `$null` → fail closed. The *direction* is right; the *reason* is accidental. The user sees a cosign download failure that reads as a transient network problem, and no amount of retrying can conjure the asset.

## Why now

backend#2078 proposes porting this exact function into `cli/scripts/install.ps1`, which today skips signature verification altogether. Copying it as-is would carry the broken arch map into a second installer — and the CLI is the **more** exposed one, because its release matrix really does build `windows/arm64`. So ARM users get a native binary and nothing able to verify it. Fixing it here means that port is a copy of one correct function.

## Why amd64-under-emulation is the right answer, not a compromise

cosign verifies a signature over **bytes**. The instruction set it was compiled for cannot change the verdict, and the artifact handed to it is still the native arm64 binary. The bootstrapped cosign is checksum-verified against sigstore's own published list before use, exactly as on amd64 — **the trust chain is byte-for-byte identical**.

The alternative — fail closed with a `winget install sigstore.cosign` hint — routes the user to do the same thing by hand, because winget's cosign is also amd64-only. Same end state, more friction, and one more opportunity to reach for `TRACEBLOC_ALLOW_UNVERIFIED=1`, which is the outcome we least want.

## Second half: a verifier that won't start is not a bad signature

`Invoke-CosignVerifyBlob` already fails closed on a binary that cannot execute — but reported it **identically to a signature that did not verify**. On an older Windows 10 on ARM without x64 emulation, that tells a user their download may be tampered with when the truth is "the verifier won't start on this machine."

Those warrant opposite reactions, and only one of them is a security event. A `cosign version` probe after resolution separates them:

- still fails closed
- says plainly that this is **not** a failed verification
- names x64 emulation as the likely cause and gives a remedy that works
- honours `TRACEBLOC_ALLOW_UNVERIFIED` loudly, like the sibling path

## Test plan

`make check` green · **Pester 680 passed, 0 failed** across the suite.

Both halves mutation-real:

```
--- restore  $asset = "cosign-windows-$arch.exe" ---
[-] requests the amd64 cosign asset unconditionally — never a per-arch name

--- drop the Test-CosignRuns probe ---
[-] fails closed, and says the download is NOT implicated
[-] names the real cause and a remedy that works on Windows-on-ARM
[-] never reaches the verify when cosign can't run
[-] honours TRACEBLOC_ALLOW_UNVERIFIED, loudly, like the other unverified path
```

Also pinned: the unknown-architecture refusal still stands, and the bootstrapped cosign is still checksum-verified — so the fix cannot be mistaken for loosening the trust chain.

## Reviewer note

**CI cannot exercise the ARM path** — GitHub's Windows runners are x64, so no test here will ever run on the hardware this fixes. The arch-map coverage is deliberately source-level for that reason, and the comment inside `Resolve-Cosign` is load-bearing: it is the only thing that will stop someone "correcting" `amd64` back to `$arch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the installer’s cosign bootstrap and manifest signature gate (supply-chain trust root); behavior is more permissive on ARM when amd64 cosign runs under emulation, but trust chain and fail-closed defaults remain.
> 
> **Overview**
> Fixes **Windows-on-ARM** installs that failed because `Resolve-Cosign` requested `cosign-windows-arm64.exe`, which Sigstore never ships—only `cosign-windows-amd64.exe` exists. Both AMD64 and ARM64 now bootstrap that amd64 asset; checksum verification of the bootstrapped binary is unchanged.
> 
> Adds **`Test-CosignRuns`** (`cosign version` with the same `LASTEXITCODE` sentinel as verify) and runs it in **`Confirm-ManifestSignature`** before any `verify-blob`. If cosign cannot execute (AV quarantine, or ARM without x64 emulation), the installer still **fails closed** but explains this is **not** a failed signature and does **not** suggest `winget install sigstore.cosign` (same amd64 build). `TRACEBLOC_ALLOW_UNVERIFIED` still allows checksum-only proceed with warnings.
> 
> Pester coverage locks the amd64 asset name, executability probe, error wording, and no-verify path when cosign won’t run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 648deecfe89be3a6ca0d86ab592256be5da08a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->