### PR TITLE
test(installer): the PowerShell sanitiser's SS3 + floor behaviour had no test

### DIFF
--- a/scripts/tests/install-k8s.Tests.ps1
+++ b/scripts/tests/install-k8s.Tests.ps1
@@ -2546,6 +2546,72 @@ Describe "ConvertTo-SanitizedInput" {
   It "empty in, empty out" {
     ConvertTo-SanitizedInput -Value "" | Should -Be ""
   }
+
+  # ── SS3 (ESC O <final>) and the floor ───────────────────────────────────
+  # These shipped in #736 with NO committed PowerShell test: the four cases
+  # above are all CSI, so the whole SS3 half and the entire floor were
+  # unverified here while the bash and Go copies had cases. That asymmetry is
+  # how SS3 came to be missing from all three implementations at once
+  # (tracebloc/cli#516) — the rule is hand-copied into three languages and only
+  # one shape was ever tested.
+  #
+  # The cases mirror the bats corpus in install-client-helm.bats one-for-one, on
+  # purpose: until backend#2084 lands a shared fixture, matching case lists are
+  # the only thing making the three implementations comparable by reading.
+
+  It "strips SS3 escapes around real content" {
+    $esc = [char]27
+    ConvertTo-SanitizedInput -Value "na${esc}ODme" | Should -Be "name"
+  }
+
+  It "SS3-only input yields empty, so the caller re-prompts" {
+    $esc = [char]27
+    # Arrow keys pressed at the prompt. Empty is the contract: callers treat it
+    # as "no answer" and re-prompt or auto-name, rather than naming a machine
+    # after escape residue.
+    ConvertTo-SanitizedInput -Value "${esc}OD${esc}OD${esc}OA" | Should -Be ""
+    ConvertTo-SanitizedInput -Value "${esc}OH${esc}OF"         | Should -Be ""   # Home/End
+    ConvertTo-SanitizedInput -Value "${esc}OP${esc}OQ"         | Should -Be ""   # F1/F2
+  }
+
+  It "handles SS3 and CSI mixed in one value" {
+    $esc = [char]27
+    ConvertTo-SanitizedInput -Value "a${esc}ODb${esc}[Dc" | Should -Be "abc"
+  }
+
+  It "a bare O is not an escape" {
+    # The regression guard for the obvious wrong fix: matching "O<letter>"
+    # without requiring the ESC would eat two characters out of any name
+    # starting with O.
+    ConvertTo-SanitizedInput -Value "OPTIMUS-01" | Should -Be "OPTIMUS-01"
+  }
+
+  It "truncated SS3 (ESC with no final byte) yields empty" {
+    $esc = [char]27
+    ConvertTo-SanitizedInput -Value "${esc}O" | Should -Be ""
+  }
+
+  It "an unknown escape family with nothing else is refused" {
+    # ESC N is SS2 — deliberately NOT in the strip list. This is the floor
+    # doing its job on the family nobody has reported yet, which is the only
+    # part of this that generalises past the escapes we happen to know.
+    $esc = [char]27
+    ConvertTo-SanitizedInput -Value "${esc}NB${esc}NC" | Should -Be ""
+  }
+
+  It "an unknown escape family beside real content keeps the content" {
+    $esc = [char]27
+    ConvertTo-SanitizedInput -Value "box${esc}NC" | Should -Be "boxNC"
+  }
+
+  It "the floor counts non-Latin letters as real content" {
+    # \p{L} not [A-Za-z]: keep-vs-reject must not depend on the script a name
+    # is written in. An ASCII name and a Japanese one behave the same here
+    # (Bugbot, #736) — the pair is the assertion, either alone proves nothing.
+    $esc = [char]27
+    ConvertTo-SanitizedInput -Value "${esc}NC日本"  | Should -Be "NC日本"
+    ConvertTo-SanitizedInput -Value "${esc}NChello" | Should -Be "NChello"
+  }
 }
 
 Describe "Get-ProvisioningPreset" {


### PR DESCRIPTION
Refs tracebloc/backend#2084 — its carved-out sub-task, **not** the ticket itself.

## The gap

client#736 extended `ConvertTo-SanitizedInput` with the SS3 family (`ESC O <final>`) and the unknown-family floor, and shipped both with **zero PowerShell coverage**. The four cases in that `Describe` block are all CSI — so on Windows the entire SS3 half and the whole floor were unverified, while the bash and Go copies each had cases.

That asymmetry is the mechanism behind the bug #736 was fixing. The rule is hand-copied into three languages; only one shape was ever tested in one of them; SS3 went missing from **all three at once** (tracebloc/cli#516) — exactly as the CSI gap had before it (cli#364 / client#362). A rule covered in two of three implementations is a rule that drifts in the third.

## What's here

Eight `It` blocks, mirroring the bats corpus in `install-client-helm.bats` case-for-case:

- SS3 around real content → stripped
- SS3-only (arrows, Home/End, F1/F2) → empty, so the caller re-prompts
- SS3 + CSI mixed in one value
- a bare `O` is not an escape (`OPTIMUS-01` survives)
- truncated `ESC O` with no final byte → empty
- an unknown family (`ESC N`, SS2 — deliberately not in the strip list) alone → refused
- the same family beside content → content kept
- the floor counts non-Latin letters as content

The non-Latin case is asserted **as a pair** with the ASCII one. Either alone proves nothing: the point is that keep-vs-reject must not depend on the script a name is written in (Bugbot, #736), and only the two together say that.

## Mutation-proven

Each anchor confirmed to apply, against the 12 cases in the block:

| mutation | reddens |
|---|---|
| drop SS3 from the strip (the cli#516 bug itself) | 2 |
| remove the floor entirely | 2 |
| floor uses `[A-Za-z]` instead of `\p{L}` | 1 |
| match `O<final>` without requiring ESC (the obvious wrong fix) | 4 |

Full Pester suite: **671 passed, 0 failed, 13 skipped.** `gen-manifest.sh --check` passes (test-only change, no lib touched).

## What this deliberately does not do

backend#2084's structural half — one canonical corpus file that all three suites derive from, plus a cross-repo drift check — is untouched. Splitting it out was the point: **a fixture wired into two of the three implementations is the same defect wearing a different hat**, and the corpus genuinely spans two repos, so it needs a vendoring + fail-closed drift mechanism (`scripts/tests/check-drift.sh` is the shape) rather than being tacked onto a test PR.

Until that lands, matching case lists across the three suites are the only thing making them comparable by reading — hence mirroring the bats corpus one-for-one rather than inventing a different set here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code touched; risk is limited to CI/test maintenance.
> 
> **Overview**
> Adds **eight Pester cases** to the `ConvertTo-SanitizedInput` `Describe` in `install-k8s.Tests.ps1`, filling a gap where only CSI-shaped inputs were tested after #736.
> 
> The new tests align with the bats corpus in `install-client-helm.bats`: SS3 stripping and SS3-only → empty (re-prompt contract), mixed SS3/CSI, `OPTIMUS-01` surviving (no bare-`O` false match), truncated `ESC O`, unknown escape family (SS2) refused vs content preserved, and **non-Latin + ASCII pairs** for the floor’s `\p{L}` rule.
> 
> **No changes** to `ConvertTo-SanitizedInput` or other libs—test-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f8b5c6ea6c05bb0d7fb71a23333c45c42b6aa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->