### PR TITLE
feat(2036): add-to-kanban authenticates as the App

### DIFF
--- a/.github/workflows/add-to-kanban.yml
+++ b/.github/workflows/add-to-kanban.yml
@@ -10,7 +10,24 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
+      # Board writes authenticate as the tracebloc-release-train App (backend#2036),
+      # not a human's PAT. `owner:` yields an ORG-scoped installation token; a
+      # repo-scoped one cannot write the org project. No fallback to the PAT: a
+      # fallback would let a broken App path keep working silently.
+      #
+      # This workflow also fires on DEPENDABOT PRs, which GitHub gates on a separate
+      # secret scope -- both app secrets are set there too, or Dependabot PRs would
+      # stop reaching the board with `Input required and not supplied`.
+      - name: Mint an installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_TRAIN_APP_ID }}
+          private-key: ${{ secrets.RELEASE_TRAIN_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/tracebloc/projects/2
-          github-token: ${{ secrets.PROJECTS_KANBAN_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
+


### PR DESCRIPTION
Refs backend#2036 — the last board writer to move off `PROJECTS_KANBAN_TOKEN`.

`add-to-kanban.yml` is a per-repo **copy**, not a reusable, so this is one PR per repo. The content is byte-identical across every repo that carries it, and the guard compares it that way.

## The change

Mint a `tracebloc-release-train` installation token and use it instead of the PAT.

`owner:` makes the token **org-scoped** — a repo-scoped one cannot write the org project at all.

**No fallback to the PAT**, consistent with the rest of this migration: a fallback would let a broken App path keep working silently, which is the failure class backend#1680 exists to remove.

## Dependabot

This workflow also fires on Dependabot PRs, and GitHub gates those on a **separate secret scope**. Both app secrets are set in the Dependabot scope as well as Actions — without that, Dependabot PRs would stop reaching the board with `Input required and not supplied: github-token`. That is the exact failure `PROJECTS_KANBAN_TOKEN` already had to be dual-scoped to avoid.

## Ordering

`caller-drift` compares each repo's copy against `.github`'s as the source of truth, so a fleet-wide change to a copy has an unavoidable drift window. Every other repo merges **before** `.github`, which keeps the window on `develop` rather than on `main`. `.github` is the last PR in the sweep.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI credentials for org kanban writes; misconfigured App secrets or Dependabot-scoped secrets would stop issues/PRs from landing on the board until fixed.
> 
> **Overview**
> **Kanban automation** now authenticates to the org project with a **minted `tracebloc-release-train` GitHub App installation token** instead of the human **`PROJECTS_KANBAN_TOKEN` PAT**, completing the board-writer migration for this per-repo workflow copy (backend#2036).
> 
> A new step runs **`actions/create-github-app-token`** with **`owner: ${{ github.repository_owner }}`** so the token is **org-scoped** (required to write the org kanban). **`add-to-project`** receives **`steps.app-token.outputs.token`**. There is **no PAT fallback** so a broken App path fails visibly rather than silently continuing on the old token.
> 
> Inline comments document that **Dependabot-triggered runs** need the same app secrets in GitHub’s **Dependabot secret scope**, not only Actions—otherwise those PRs would fail with missing **`github-token`** input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ed938c44647aa59fd8bc185e97e32e8a30e4187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->