### PR TITLE
docs(#248): the §8.2 egress lockdown needs an enforcing CNI — say which, and gate on it

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.45
-appVersion: "1.9.45"
+version: 1.9.46
+appVersion: "1.9.46"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -273,6 +273,13 @@ networkPolicy:
     # enforcing egress). The retry tolerates standard-mode CNIs that enforce only after a
     # brief per-pod reconcile. A test hook never affects install/upgrade. Set "" to
     # disable (e.g. air-gapped clusters).
+    #
+    # FALSE-PASS CAVEAT (SECURITY §8.2): the check reads a refused TCP connect
+    # (curl exit 7) as "egress is blocked" — and a host with NOTHING LISTENING on
+    # :443 refuses identically, so it passes without testing anything. This host
+    # MUST genuinely accept TCP :443 when egress is open. 1.1.1.1 does. Before
+    # trusting a custom value, confirm it is reachable with the lockdown OFF; if
+    # that probe also fails to connect, the host is wrong, not the CNI.
     enforcementProbeHost: "1.1.1.1"
     # Max seconds the enforcement check waits for egress to become blocked before it
     # gives up and FAILS. Covers the standard-mode CNI reconciliation window (AWS VPC CNI

--- a/docs/SEAL-CHECK.md
+++ b/docs/SEAL-CHECK.md
@@ -92,7 +92,7 @@ these):
 
 | `seal-check-name` | Template | Verifies | Renders when | Explicit off-switch |
 |---|---|---|---|---|
-| `egress-enforcement` | `egress-enforcement-check.yaml` | The CNI actually blocks a training-labelled pod's direct egress to `enforcementProbeHost:443` — i.e. the §8.2 lockdown is *enforced*, not just declared | `networkPolicy.training.enabled` and `allowExternalHttps=false` and `enforcementProbeHost` non-empty | `networkPolicy.training.enforcementProbeHost: ""` |
+| `egress-enforcement` | `egress-enforcement-check.yaml` | The CNI actually blocks a training-labelled pod's direct egress to `enforcementProbeHost:443` — i.e. the §8.2 lockdown is *enforced*, not just declared. **Probe host must accept TCP :443** — see [Probe-host false pass](#probe-host-false-pass) | `networkPolicy.training.enabled` and `allowExternalHttps=false` and `enforcementProbeHost` non-empty | `networkPolicy.training.enforcementProbeHost: ""` |
 | `backend-reachability` | `egress-reachability-check.yaml` | A normal (non-training) pod completes an HTTPS round trip to the tracebloc backend API — the required-egress complement (no backend egress ⇒ experiments sit Pending) | `egressReachabilityCheck.enabled` (default on) | `egressReachabilityCheck.enabled: false` |
 | `storage-assertions` | `storage-assertions-check.yaml` | Release storage matches the declared storage model (below) | `sealCheck.storageAssertions.enabled` (default on) | `sealCheck.storageAssertions.enabled: false` |
 
@@ -236,6 +236,72 @@ still to be recorded here (pass/fail, k3s/k3d versions, date) and folded into
 the RFC-0003 §8.3 matrix. The **substrate** enforcement it builds on is already
 verified — see the Status note at the top of this section (the single record
 of that run).
+
+## Runbook: flip the §8.2 egress lockdown on a real fleet
+
+The runbook above verifies the *substrate* locally. This is the production
+procedure for turning the lockdown on for a customer fleet. Every step is
+reversible and none of it migrates data.
+
+**Gate 0 — pre-flight, before touching the release.** A DNS-only egress
+NetworkPolicy in a throwaway namespace must block `https://1.1.1.1`. The exact
+commands are in [SECURITY.md §6.2](SECURITY.md#egress-preflight-probe). If the
+probe connects, this fleet's CNI does not enforce egress and the rest of this
+runbook is theatre — the policy will render and block nothing. Fix the CNI
+first (SECURITY.md §5.1; on EKS that usually means the `vpc-cni` **managed
+add-on** with `enableNetworkPolicy=true`, not a self-managed DaemonSet).
+
+```bash
+RELEASE=<release> NS=<namespace>
+
+# 1. Gateway deployed and routing (prerequisite — SECURITY.md §8.2 steps 1-2).
+helm get values "$RELEASE" -n "$NS" | grep -A2 egressProxy   # routeWorkloads: true
+
+# 2. DRAIN: wait for in-flight training to finish. The policy change applies to
+#    RUNNING pods, so a mid-run pod still egressing directly fails at the flip.
+kubectl -n "$NS" get jobs -l tracebloc.io/workload=training    # expect: none active
+
+# 3. FLIP.
+helm upgrade "$RELEASE" tracebloc/client -n "$NS" --reset-then-reuse-values \
+  --set networkPolicy.training.allowExternalHttps=false
+
+# 4. VERIFY — the egress-enforcement check renders only now.
+helm test "$RELEASE" -n "$NS" --logs \
+  --filter name="$RELEASE"-egress-enforcement-check
+
+# 5. Run one real training experiment end to end through the gateway.
+```
+
+**Interpreting step 4** — same three outcomes as the local runbook:
+`OK  egress lockdown verified …` → sealed for **G2** on this fleet (record the
+run). `WARNING  EGRESS LOCKDOWN NOT ENFORCED` → the CNI is not enforcing;
+**roll back**. `WARNING  … INCONCLUSIVE` → the probe host did not resolve;
+unverified is never reported sealed, so this fails too.
+
+**Rollback** (from any step, including a failed step 4 or a bad experiment in
+step 5):
+
+```bash
+helm upgrade "$RELEASE" tracebloc/client -n "$NS" --reset-then-reuse-values \
+  --set networkPolicy.training.allowExternalHttps=true
+```
+
+The external-443 rule returns within a CNI reconcile. Leave the gateway
+deployed and routing — it is inert with respect to the policy, and keeping it
+means the next attempt starts at step 2. Use `--reset-then-reuse-values`
+(Helm ≥ 3.14): a plain `--reuse-values` re-applies the stored `false` from the
+previous upgrade and silently defeats the rollback.
+
+### Probe-host false pass
+
+`enforcementProbeHost` must be a host that genuinely **accepts** TCP `:443`
+when egress is open. The check reads a refused connect (curl exit 7) as
+"blocked" — and a host with nothing listening on `:443` refuses identically,
+so a wrong probe host **passes without testing anything**. The `1.1.1.1`
+default accepts. Before trusting a custom value, confirm it is reachable with
+the lockdown OFF; if that probe also fails to connect, the host is wrong, not
+the CNI. A DNS failure (exit 6) is reported INCONCLUSIVE and fails — it is
+never treated as a pass.
 
 ## CI coverage — what runs where
 

--- a/docs/SEAL-CHECK.md
+++ b/docs/SEAL-CHECK.md
@@ -259,7 +259,10 @@ helm get values "$RELEASE" -n "$NS" | grep -A2 egressProxy   # routeWorkloads: t
 
 # 2. DRAIN: wait for in-flight training to finish. The policy change applies to
 #    RUNNING pods, so a mid-run pod still egressing directly fails at the flip.
-kubectl -n "$NS" get jobs -l tracebloc.io/workload=training    # expect: none active
+#    PODS, not Jobs: tracebloc.io/workload=training is set on the pod template
+#    only (never on the Job object), so `get jobs -l ...` returns nothing even
+#    mid-run — a false all-clear.
+kubectl -n "$NS" get pods -l tracebloc.io/workload=training    # expect: none running
 
 # 3. FLIP.
 helm upgrade "$RELEASE" tracebloc/client -n "$NS" --reset-then-reuse-values \

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -195,6 +195,8 @@ spec:
 - In-cluster egress to MySQL (3306), the requests-proxy (8888), and the egress gateway (3128)
 - Outbound HTTPS/443 to the public internet — **only while `networkPolicy.training.allowExternalHttps: true` (the current default).** Set it to `false` and this rule is dropped, so training pods reach external services only through the in-cluster egress gateway (see §8.2).
 
+**Enforcement prerequisite:** every bullet above is a *request* to the CNI, not a guarantee. It holds only on a CNI that enforces **egress** NetworkPolicy — Calico, Cilium, OpenShift OVN-Kubernetes, Azure CNI created with a network policy, or the **EKS VPC CNI managed add-on with `enableNetworkPolicy=true`**. See [§5.1](#enforcing-cnis) for the full list and the EKS caveat, and §6.2 for how to verify it on a given cluster. On a non-enforcing CNI the policy object exists and blocks nothing.
+
 **Configuration:** `networkPolicy.training.enabled: true` (the default). Egress lockdown: `networkPolicy.training.allowExternalHttps` + `egressProxy.*` (see §8.2).
 
 ### 4.3 Kubernetes API access (G3)
@@ -312,7 +314,7 @@ NetworkPolicy and Pod Security Admission behave differently depending on the cus
 | Platform | Default CNI | Enforces NetworkPolicy? | Operator action |
 |---|---|---|---|
 | **AKS** | Azure CNI | Only with `--network-policy azure` or Calico add-on **enabled at cluster-create time** | Create the cluster with one of these options |
-| **EKS** | AWS VPC CNI | **No** — VPC CNI alone does not enforce NetworkPolicy | Install Calico add-on or Cilium; or leave `networkPolicy.training.enabled: false` and accept the residual risk |
+| **EKS** | AWS VPC CNI | **Not by default.** VPC CNI enforces only as the **managed add-on with `enableNetworkPolicy=true`** (v1.14+). A self-managed VPC CNI DaemonSet does **not** — the flag alone is insufficient without the control-plane PolicyEndpoint controller the managed add-on installs | Set `enableNetworkPolicy=true` on the `vpc-cni` managed add-on, or install Calico / Cilium; or leave `networkPolicy.training.enabled: false` and accept the residual risk |
 | **Bare-metal** | depends on install | Calico / Cilium / kube-router: yes. Flannel alone: no | If Flannel-only, install a NetworkPolicy engine or disable the toggle |
 | **OpenShift** | OVN-Kubernetes | Yes (default) | No action — selector defaults differ, see below |
 
@@ -329,7 +331,20 @@ networkPolicy:
       - "172.30.0.0/16"   # OpenShift default service CIDR
 ```
 
+<a id="enforcing-cnis"></a>**Which CNIs enforce *egress* NetworkPolicy** — the concrete list the §4.2 and §8.2 layers require:
+
+- **Calico** (any distribution, including the EKS add-on)
+- **Cilium**
+- **OpenShift OVN-Kubernetes** (default on OCP)
+- **Azure CNI** with `--network-policy azure` or `calico`, set **at cluster-create time**
+- **AWS VPC CNI** — **only** as the **managed EKS add-on with `enableNetworkPolicy=true`** (v1.14+). The bare DaemonSet env flag on a self-managed VPC CNI install is **not** enough: enforcement needs the control-plane PolicyEndpoint controller that the managed add-on brings. In the add-on's default `standard` mode a brand-new pod is allowed all traffic until its per-pod policy is programmed (a few-second reconcile) — real training pods start far slower than that window, and the `egress-enforcement` seal check retries across it.
+- **k3s / kube-router, Antrea, Weave** — enforce, but verify per §6.2 rather than assuming.
+
+Anything else — notably **Flannel alone** and a **self-managed AWS VPC CNI** — does not enforce.
+
 **Silent-no-enforcement risk:** If `networkPolicy.training.enabled: true` on a cluster whose CNI does not enforce, the policy is created but ignored. Customers must verify their CNI enforces NetworkPolicy before relying on this layer. We default the EKS `ci/eks-values.yaml` to `enabled: false` for this reason.
+
+> Verified 2026-06 on `tb-client-dev-templates` (EKS, **self-managed** VPC CNI, NetworkPolicy disabled): a DNS-only egress NetworkPolicy did **not** block `https://example.com` — the probe returned `200`. On such a fleet, flipping `allowExternalHttps=false` is **cosmetic**: the rule renders and nothing enforces it.
 
 ### 5.2 Pod Security Admission
 
@@ -380,6 +395,39 @@ timeout 5 bash -c 'cat < /dev/tcp/8.8.8.8/80'        && echo FAIL || echo OK   #
 ```
 
 If any assertion reads the wrong way, the CNI is not enforcing — investigate before relying on §4.2.
+
+<a id="egress-preflight-probe"></a>**Egress pre-flight probe (required gate before the §8.2 lockdown).** The check above proves the *allowed* rules behave; it does **not** prove the CNI can **block** egress, which is the whole point of the lockdown. Run this in a throwaway namespace on **every fleet** before flipping `allowExternalHttps=false`:
+
+```bash
+NS=np-preflight
+kubectl create namespace "$NS"
+
+# A DNS-only egress policy over everything in the namespace.
+kubectl -n "$NS" apply -f - <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dns-only-egress
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - {port: 53, protocol: UDP}
+        - {port: 53, protocol: TCP}
+EOF
+
+# Give the CNI a moment to program the per-pod policy (AWS VPC CNI in its
+# default "standard" mode allows a new pod all traffic until it reconciles),
+# then probe. -k so a cert error is not misread as a block.
+kubectl -n "$NS" run probe --rm -i --restart=Never   --image=curlimages/curl:8.20.0 --   sh -c 'sleep 15; curl --noproxy "*" -k -sS -m 5 -o /dev/null -w "%{http_code}\n" https://1.1.1.1; echo "exit=$?"'
+
+kubectl delete namespace "$NS"
+```
+
+**It MUST fail to connect** (`exit=7` connection refused or `exit=28` timeout). If it prints an HTTP code — `200`, or any TLS-layer error meaning the TCP connect succeeded — **the CNI is not enforcing egress**: fix the CNI first (§5.1), because flipping the lockdown on this fleet would be cosmetic.
+
+Note the failure modes this probe shares with the `egress-enforcement` seal check: `exit=6` is a DNS failure (**inconclusive**, not a pass), and a connection refused against a host that simply *has nothing listening on :443* is a **false pass** — see §8.2.
 
 ### 6.3 Apply PSA labels on existing namespaces
 
@@ -498,9 +546,25 @@ By default the NetworkPolicy still allows outbound HTTPS/443 so training pods ca
 **Mechanism (chart 1.7.0, client-runtime#102):** an in-cluster **egress gateway** (`egressProxy` — a squid forward proxy) permits HTTPS CONNECT only to an FQDN allowlist (backend + App Insights) and chains to a corporate proxy via `cache_peer`. With routing on, jobs-manager injects `HTTPS_PROXY=egress-proxy-service:3128` into each training pod (and drops the raw `HTTP_PROXY_HOST`), so backend + App-Insights traffic flows through the gateway; Service Bus already goes via the requests-proxy. The pod then needs no direct internet, and the external-443 rule can be dropped.
 
 **Rollout (per fleet, progressive — each step reversible):**
+
+**Gate 0 — CNI enforcement pre-flight (required, before anything else).** Run the [§6.2 egress pre-flight probe](#egress-preflight-probe) on this fleet. It must fail to connect. If it returns `200`, this fleet's CNI does **not** enforce egress and steps 1–3 buy nothing: the rule renders, nothing blocks, and the fleet reads as locked down when it is not. Fix the CNI first (§5.1 — on EKS, that usually means moving to the `vpc-cni` managed add-on with `enableNetworkPolicy=true`). Do not proceed on a fleet that fails this gate.
+
 1. Upgrade to ≥ 1.7.0 — the gateway deploys, inert (`egressProxy.routeWorkloads: false`).
 2. Set `egressProxy.routeWorkloads: true`; verify a training run completes via the gateway.
-3. Set `networkPolicy.training.allowExternalHttps: false` to drop the external-443 rule, and verify **G2** (a training pod cannot reach an arbitrary external host). Requires a NetworkPolicy-enforcing CNI (§4.2).
+3. **Drain first.** Wait for in-flight experiments to finish (`kubectl -n <ns> get jobs -l tracebloc.io/workload=training`). Step 4 changes the policy for *running* pods too, so a training pod mid-run that still reaches the internet directly — one whose image or user code has not picked up `HTTPS_PROXY` — fails at the moment of the flip rather than at submit time.
+4. Set `networkPolicy.training.allowExternalHttps: false` to drop the external-443 rule.
+5. **Verify, do not assume.** The `egress-enforcement` seal check renders exactly when the lockdown is on:
+
+   ```bash
+   helm test <release> -n <ns> --logs --filter name=<release>-egress-enforcement-check
+   ```
+
+   `OK  egress lockdown verified …` → **G2** holds on this fleet. `WARNING  EGRESS LOCKDOWN NOT ENFORCED` or `INCONCLUSIVE` → treat the fleet as **unsealed** and roll back (below). See [SEAL-CHECK.md](SEAL-CHECK.md) for the contract.
+6. Run one real training experiment end to end through the gateway before declaring the fleet done.
+
+**Rollback (any step, at any time):** set `networkPolicy.training.allowExternalHttps: true` and upgrade — the external-443 rule returns within a CNI reconcile and training pods reach the internet directly again. Nothing persists, no data migrates, and the gateway can stay deployed and routing. Use `--reset-then-reuse-values` (Helm ≥ 3.14) rather than `--reuse-values`, which would re-apply the stored `false`.
+
+**Probe-host caveat (false pass).** Both the pre-flight probe and the `egress-enforcement` check read a refused TCP connect (curl exit 7) as "egress is blocked". A probe host that has **nothing listening on :443** refuses the same way, so it **passes without testing anything**. `enforcementProbeHost` must be a host that genuinely *accepts* TCP :443 when egress is open — the `1.1.1.1` default does. Before trusting a custom value, confirm it is reachable with the lockdown OFF; if that probe *also* fails to connect, the host is wrong, not the CNI. A DNS failure (exit 6) is reported INCONCLUSIVE and fails the check rather than passing it.
 
 **Residual:** the pod still holds `BACKEND_TOKEN` (it authenticates to the backend through the gateway). Scoping / short-TTL of that token is tracked under §8.1.
 
@@ -614,6 +678,7 @@ Cross-reference for reviewers and contributors.
 
 - **2026-04** — Initial version. Documents the training-pod sandbox as shipped in client chart ≥ 1.0.4 and client-runtime images built from `develop` at that date. Reflects the narrow threat model (trusted platform, untrusted external data scientist submissions).
 - **2026-08** — Documented the MySQL database identity model (§4.1.1) and the `edgeuser` root-equivalence retirement (§8.10) — RFC-0003 D10 close-out, backend#1528.
+- **2026-08** — Sharpened the §8.2 egress-lockdown guidance (tracebloc/client#248): named the enforcing CNIs concretely in §5.1 (including the EKS `vpc-cni` managed add-on `enableNetworkPolicy=true` prerequisite), added the §6.2 egress pre-flight probe as a required gate before the flip, and gave §8.2 a drain → flip → verify → rollback rollout with the probe-host false-pass caveat. Fleet runbook in [SEAL-CHECK.md](SEAL-CHECK.md).
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -551,7 +551,7 @@ By default the NetworkPolicy still allows outbound HTTPS/443 so training pods ca
 
 1. Upgrade to ≥ 1.7.0 — the gateway deploys, inert (`egressProxy.routeWorkloads: false`).
 2. Set `egressProxy.routeWorkloads: true`; verify a training run completes via the gateway.
-3. **Drain first.** Wait for in-flight experiments to finish (`kubectl -n <ns> get jobs -l tracebloc.io/workload=training`). Step 4 changes the policy for *running* pods too, so a training pod mid-run that still reaches the internet directly — one whose image or user code has not picked up `HTTPS_PROXY` — fails at the moment of the flip rather than at submit time.
+3. **Drain first.** Wait for in-flight experiments to finish (`kubectl -n <ns> get pods -l tracebloc.io/workload=training`). Step 4 changes the policy for *running* pods too, so a training pod mid-run that still reaches the internet directly — one whose image or user code has not picked up `HTTPS_PROXY` — fails at the moment of the flip rather than at submit time. Select **pods, not Jobs**: jobs-manager sets `tracebloc.io/workload: training` on the pod template only (`job.yaml`, `jobs_manager._prepare_job_config`), never on the Job object — which is all the NetworkPolicy needs, since its `podSelector` matches the pod. `get jobs -l …` therefore returns nothing even mid-run, which reads as a false all-clear.
 4. Set `networkPolicy.training.allowExternalHttps: false` to drop the external-443 rule.
 5. **Verify, do not assume.** The `egress-enforcement` seal check renders exactly when the lockdown is on:
 


### PR DESCRIPTION
Closes #248 — all three folded follow-ups (#248, #257, #258).

## Why

The §8.2 training-pod egress lockdown only blocks anything on a CNI that enforces **egress** NetworkPolicy. Verified 2026-06 on `tb-client-dev-templates` (EKS, **self-managed** VPC CNI, NetworkPolicy disabled): a DNS-only egress policy did **not** block `https://example.com` — the probe returned `200`.

On such a fleet, flipping `allowExternalHttps=false` is cosmetic: the rule renders and nothing enforces it. The docs didn't say which CNIs actually enforce, and the rollout had no gate that would have caught it.

## What changed

**`docs/SECURITY.md`**
- **§5.1** — a concrete enforcing-CNI list, and an EKS row that distinguishes the `vpc-cni` **managed add-on** with `enableNetworkPolicy=true` (enforces, v1.14+) from a **self-managed DaemonSet** (does not — the flag alone is insufficient without the control-plane PolicyEndpoint controller). Records the dev-EKS finding.
- **§4.2** — the policy bullets are a *request* to the CNI, not a guarantee; the prerequisite is now linked from where the rules are stated.
- **§6.2** — an **egress pre-flight probe**: DNS-only policy in a throwaway namespace, the connect MUST fail. This is the gate the old rollout lacked.
- **§8.2** — rollout is now **Gate 0 pre-flight → drain → flip → `helm test` the egress-enforcement check → real experiment**, with an explicit rollback. Drain is called out because the policy change applies to **running** pods too.

**`docs/SEAL-CHECK.md`**
- A per-fleet **production flip/rollback runbook** alongside the existing local k3d one, on `--reset-then-reuse-values` — a plain `--reuse-values` re-applies the stored `false` and silently defeats the rollback.
- The **probe-host false pass** (folded #257): the check reads a refused connect (curl exit 7) as "blocked", and a host with *nothing listening on :443* refuses identically — so a wrong `enforcementProbeHost` passes without testing anything.

**`client/values.yaml`** — the same false-pass caveat where the operator actually sets the host.

## Scope

Docs plus one values comment. No template renders differently.

`Chart.yaml` 1.9.45 → 1.9.46: `values.yaml` is packaged chart content, so `chart-version-guard` requires the bump (same as #717, a values-comment-only change).

## Verification

- `helm lint ./client` — clean
- `helm unittest ./client` — **467 passed, 31 suites**
- `scripts/chart-version-guard.sh` — `client chart content changed and client/Chart.yaml 'version:' was bumped. ✓`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and operator comments only—no Helm template or security behavior changes. Misconfiguration risk is reduced by clearer gates; chart version bump is packaging-only.
> 
> **Overview**
> Closes the gap where flipping `allowExternalHttps=false` could look “locked down” on fleets whose CNI never enforces egress NetworkPolicy (e.g. verified self-managed EKS VPC CNI).
> 
> **`docs/SECURITY.md`** names which CNIs actually enforce egress (including EKS **managed** `vpc-cni` with `enableNetworkPolicy=true` vs self-managed DaemonSet), links §4.2 policy bullets to that prerequisite, adds a **§6.2 egress pre-flight probe** (DNS-only policy must block `https://1.1.1.1`), and expands **§8.2** to **Gate 0 → drain running training pods → flip → `helm test` egress-enforcement → real experiment**, with rollback via `--reset-then-reuse-values` and the **probe-host false pass** (refused TCP on :443 is not proof of enforcement).
> 
> **`docs/SEAL-CHECK.md`** adds a production flip/rollback runbook and documents the same probe-host caveat in the suite table.
> 
> **`client/values.yaml`** mirrors the false-pass warning on `enforcementProbeHost`; **`Chart.yaml`** bumps **1.9.45 → 1.9.46** for packaged values (chart-version-guard).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a049e6d7e966146fd92015eed56d06c8ee306723. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->