### PR TITLE
feat(rbac): let jobs-manager read daemonsets for the heartbeat version inventory

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.45
-appVersion: "1.9.45"
+version: 1.9.46
+appVersion: "1.9.46"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.46
-appVersion: "1.9.46"
+version: 1.9.47
+appVersion: "1.9.47"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -216,6 +216,16 @@ nvidia-device-plugin-daemonset
 {{- end }}
 
 {{/*
+  Name of the jobs-manager Role/RoleBinding pair in the NODE-AGENTS namespace.
+  Distinct from tracebloc.rbacName so the two pairs cannot collide when
+  `nodeAgents.namespace.name` points back at the release namespace — the same
+  reasoning as tracebloc.imageRefreshNodeAgentsName above.
+*/}}
+{{- define "tracebloc.rbacNodeAgentsName" -}}
+{{ .Release.Name }}-jobs-manager-node-agents
+{{- end }}
+
+{{/*
   Name of the requests-proxy Deployment. ONE definition, because #569 gave it a
   second consumer: image-refresh reconciles it by name with `kubectl set image`,
   so a rename that reached only the Deployment would leave the CronJob patching

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -216,10 +216,9 @@ nvidia-device-plugin-daemonset
 {{- end }}
 
 {{/*
-  Name of the jobs-manager Role/RoleBinding pair in the NODE-AGENTS namespace.
-  Distinct from tracebloc.rbacName so the two pairs cannot collide when
-  `nodeAgents.namespace.name` points back at the release namespace — the same
-  reasoning as tracebloc.imageRefreshNodeAgentsName above.
+  jobs-manager Role/RoleBinding pair in the node-agents namespace. Distinct from
+  tracebloc.rbacName so the pairs cannot collide when that namespace IS the
+  release namespace.
 */}}
 {{- define "tracebloc.rbacNodeAgentsName" -}}
 {{ .Release.Name }}-jobs-manager-node-agents

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -421,8 +421,17 @@ spec:
         # the heartbeat version inventory. It is the one chart workload outside
         # the release namespace, so without this the inventory searches the
         # wrong namespace and reports resource-monitor as "not deployed".
+        #
+        # EMPTY when resourceMonitor is off, and that empty value is load-
+        # bearing rather than a no-op: the runtime reads unset as "older chart,
+        # use the built-in default" and set-but-empty as "there is no
+        # node-agents namespace". With resourceMonitor off the namespace and its
+        # RBAC are not rendered at all, so leaving this populated would have
+        # jobs-manager list a namespace that does not exist, with no Role to
+        # authorize it — a 403 every heartbeat, forever, about a workload the
+        # operator deliberately turned off (review, PR #750).
         - name: NODE_AGENTS_NAMESPACE
-          value: {{ .Values.nodeAgents.namespace.name | quote }}
+          value: {{ if ne .Values.resourceMonitor false }}{{ dig "namespace" "name" "" (.Values.nodeAgents | default dict) | quote }}{{ else }}""{{ end }}
         # backend#664 (Utilization Ladder L0): with NEITHER env.RESOURCE_REQUESTS
         # nor env.RESOURCE_LIMITS set, BOTH vars are omitted and jobs-manager
         # sizes the envelope from node allocatable (75% with cpu=2/memory=8Gi

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -417,6 +417,12 @@ spec:
           value: {{ printf "%s/" (dig "imageRegistry" "docker.io" (.Values.global | default dict) | default "docker.io") | quote }}
         - name: CLIENT_ENV
           value: {{ include "tracebloc.clientEnv" . | quote }}
+        # client-runtime#152: where the resource-monitor DaemonSet lives, for
+        # the heartbeat version inventory. It is the one chart workload outside
+        # the release namespace, so without this the inventory searches the
+        # wrong namespace and reports resource-monitor as "not deployed".
+        - name: NODE_AGENTS_NAMESPACE
+          value: {{ .Values.nodeAgents.namespace.name | quote }}
         # backend#664 (Utilization Ladder L0): with NEITHER env.RESOURCE_REQUESTS
         # nor env.RESOURCE_LIMITS set, BOTH vars are omitted and jobs-manager
         # sizes the envelope from node allocatable (75% with cpu=2/memory=8Gi

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -417,19 +417,12 @@ spec:
           value: {{ printf "%s/" (dig "imageRegistry" "docker.io" (.Values.global | default dict) | default "docker.io") | quote }}
         - name: CLIENT_ENV
           value: {{ include "tracebloc.clientEnv" . | quote }}
-        # client-runtime#152: where the resource-monitor DaemonSet lives, for
-        # the heartbeat version inventory. It is the one chart workload outside
-        # the release namespace, so without this the inventory searches the
-        # wrong namespace and reports resource-monitor as "not deployed".
-        #
-        # EMPTY when resourceMonitor is off, and that empty value is load-
-        # bearing rather than a no-op: the runtime reads unset as "older chart,
-        # use the built-in default" and set-but-empty as "there is no
-        # node-agents namespace". With resourceMonitor off the namespace and its
-        # RBAC are not rendered at all, so leaving this populated would have
-        # jobs-manager list a namespace that does not exist, with no Role to
-        # authorize it — a 403 every heartbeat, forever, about a workload the
-        # operator deliberately turned off (review, PR #750).
+        # Where the resource-monitor DaemonSet lives, for the heartbeat version
+        # inventory. EMPTY when resourceMonitor is off, and that empty value is
+        # load-bearing: the runtime reads unset as "use the built-in default"
+        # and set-but-empty as "no node-agents namespace", so leaving it
+        # populated would list a namespace that isn't rendered — a 403 every
+        # heartbeat for a workload the operator turned off.
         - name: NODE_AGENTS_NAMESPACE
           value: {{ if ne .Values.resourceMonitor false }}{{ dig "namespace" "name" "" (.Values.nodeAgents | default dict) | quote }}{{ else }}""{{ end }}
         # backend#664 (Utilization Ladder L0): with NEITHER env.RESOURCE_REQUESTS

--- a/client/templates/rbac.yaml
+++ b/client/templates/rbac.yaml
@@ -27,8 +27,17 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "events"]
     verbs: ["get", "list", "watch"]
+  # client-runtime#152: jobs-manager reports a version inventory on the
+  # heartbeat, assembled from the configured images on the chart's own
+  # workloads. `deployments` covers jobs-manager, pods-monitor,
+  # requests-proxy, mysql-client and egress-proxy; `daemonsets` is needed
+  # for resource-monitor, the one workload that is not a Deployment.
+  # Read-only, and scoped to the release namespace in the Role branch.
+  # Without daemonsets the list 403s and resource-monitor is reported as
+  # null forever — the runtime degrades rather than failing, so the symptom
+  # is a permanently blank field, not an error anyone would chase.
   - apiGroups: ["apps"]
-    resources: ["deployments"]
+    resources: ["deployments", "daemonsets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["metrics.k8s.io"]
     resources: ["pods"]
@@ -126,8 +135,17 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "events"]
     verbs: ["get", "list", "watch"]
+  # client-runtime#152: jobs-manager reports a version inventory on the
+  # heartbeat, assembled from the configured images on the chart's own
+  # workloads. `deployments` covers jobs-manager, pods-monitor,
+  # requests-proxy, mysql-client and egress-proxy; `daemonsets` is needed
+  # for resource-monitor, the one workload that is not a Deployment.
+  # Read-only, and scoped to the release namespace in the Role branch.
+  # Without daemonsets the list 403s and resource-monitor is reported as
+  # null forever — the runtime degrades rather than failing, so the symptom
+  # is a permanently blank field, not an error anyone would chase.
   - apiGroups: ["apps"]
-    resources: ["deployments"]
+    resources: ["deployments", "daemonsets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["metrics.k8s.io"]
     resources: ["pods"]

--- a/client/templates/rbac.yaml
+++ b/client/templates/rbac.yaml
@@ -27,15 +27,8 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "events"]
     verbs: ["get", "list", "watch"]
-  # client-runtime#152: jobs-manager reports a version inventory on the
-  # heartbeat, assembled from the configured images on the chart's own
-  # workloads. `deployments` covers jobs-manager, pods-monitor,
-  # requests-proxy, mysql-client and egress-proxy; `daemonsets` is needed
-  # for resource-monitor, the one workload that is not a Deployment.
-  # Read-only, and scoped to the release namespace in the Role branch.
-  # Without daemonsets the list 403s and resource-monitor is reported as
-  # null forever — the runtime degrades rather than failing, so the symptom
-  # is a permanently blank field, not an error anyone would chase.
+  # Read-only, for the heartbeat version inventory: `deployments` covers every
+  # chart workload except resource-monitor, which needs `daemonsets`.
   - apiGroups: ["apps"]
     resources: ["deployments", "daemonsets"]
     verbs: ["get", "list", "watch"]
@@ -135,15 +128,8 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "events"]
     verbs: ["get", "list", "watch"]
-  # client-runtime#152: jobs-manager reports a version inventory on the
-  # heartbeat, assembled from the configured images on the chart's own
-  # workloads. `deployments` covers jobs-manager, pods-monitor,
-  # requests-proxy, mysql-client and egress-proxy; `daemonsets` is needed
-  # for resource-monitor, the one workload that is not a Deployment.
-  # Read-only, and scoped to the release namespace in the Role branch.
-  # Without daemonsets the list 403s and resource-monitor is reported as
-  # null forever — the runtime degrades rather than failing, so the symptom
-  # is a permanently blank field, not an error anyone would chase.
+  # Read-only, for the heartbeat version inventory: `deployments` covers every
+  # chart workload except resource-monitor, which needs `daemonsets`.
   - apiGroups: ["apps"]
     resources: ["deployments", "daemonsets"]
     verbs: ["get", "list", "watch"]
@@ -197,24 +183,10 @@ roleRef:
 {{- if and (ne .Values.resourceMonitor false) $nodeAgentsNs (ne $nodeAgentsNs .Release.Namespace) }}
 ---
 {{/*
-  jobs-manager in the NODE-AGENTS namespace (client-runtime#152).
-
-  The heartbeat version inventory reads the configured image off each of the
-  chart's workloads. Five of them are Deployments in the release namespace and
-  are covered by the Role/ClusterRole above — but resource-monitor is a
-  DaemonSet in `nodeAgents.namespace.name`, deliberately split out so it can run
-  under PSA `privileged` without widening the release namespace.
-
-  A grant in the release namespace therefore does not reach it: the list call
-  succeeds with zero items and the inventory reports resource-monitor as null,
-  which reads as "not deployed". The ClusterRole branch already covers it
-  cluster-wide, so this pair exists for `clusterScope: false` edges (including
-  OpenShift). Same second-Role split image-refresh already uses for this exact
-  namespace boundary (image-refresh-rbac.yaml).
-
-  Read-only, and rendered only when there IS a DaemonSet to read: with
-  resourceMonitor off, or with the node-agents namespace pointing back at the
-  release namespace (already granted above), this is pure unused surface.
+  jobs-manager reads the resource-monitor DaemonSet for the heartbeat version
+  inventory, and that DaemonSet lives in nodeAgents.namespace, not the release
+  namespace — so the Role above cannot reach it. The ClusterRole branch already
+  covers it; this pair is for clusterScope: false. Mirrors image-refresh-rbac.
 */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -236,10 +208,8 @@ metadata:
   labels:
     {{- include "tracebloc.labels" . | nindent 4 }}
 subjects:
-  # The SUBJECT keeps tracebloc.serviceAccountName: there is only ONE
-  # jobs-manager ServiceAccount and it lives in the release namespace. Only the
-  # Role and RoleBinding are renamed, to avoid colliding with the
-  # release-namespace pair.
+  # One ServiceAccount, in the release namespace; only the Role/RoleBinding
+  # names differ, so the two pairs cannot collide.
   - kind: ServiceAccount
     name: {{ include "tracebloc.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}

--- a/client/templates/rbac.yaml
+++ b/client/templates/rbac.yaml
@@ -192,3 +192,59 @@ roleRef:
   name: {{ include "tracebloc.rbacName" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+
+{{- $nodeAgentsNs := dig "namespace" "name" "" (.Values.nodeAgents | default dict) }}
+{{- if and (ne .Values.resourceMonitor false) $nodeAgentsNs (ne $nodeAgentsNs .Release.Namespace) }}
+---
+{{/*
+  jobs-manager in the NODE-AGENTS namespace (client-runtime#152).
+
+  The heartbeat version inventory reads the configured image off each of the
+  chart's workloads. Five of them are Deployments in the release namespace and
+  are covered by the Role/ClusterRole above — but resource-monitor is a
+  DaemonSet in `nodeAgents.namespace.name`, deliberately split out so it can run
+  under PSA `privileged` without widening the release namespace.
+
+  A grant in the release namespace therefore does not reach it: the list call
+  succeeds with zero items and the inventory reports resource-monitor as null,
+  which reads as "not deployed". The ClusterRole branch already covers it
+  cluster-wide, so this pair exists for `clusterScope: false` edges (including
+  OpenShift). Same second-Role split image-refresh already uses for this exact
+  namespace boundary (image-refresh-rbac.yaml).
+
+  Read-only, and rendered only when there IS a DaemonSet to read: with
+  resourceMonitor off, or with the node-agents namespace pointing back at the
+  release namespace (already granted above), this is pure unused surface.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tracebloc.rbacNodeAgentsName" . }}
+  namespace: {{ $nodeAgentsNs }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tracebloc.rbacNodeAgentsName" . }}
+  namespace: {{ $nodeAgentsNs }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+subjects:
+  # The SUBJECT keeps tracebloc.serviceAccountName: there is only ONE
+  # jobs-manager ServiceAccount and it lives in the release namespace. Only the
+  # Role and RoleBinding are renamed, to avoid colliding with the
+  # release-namespace pair.
+  - kind: ServiceAccount
+    name: {{ include "tracebloc.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "tracebloc.rbacNodeAgentsName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -831,3 +831,34 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].name
           value: pods-monitor-container
+
+  # client-runtime#152: the heartbeat version inventory needs to know where the
+  # resource-monitor DaemonSet lives — the one chart workload outside the
+  # release namespace.
+  - it: passes the node-agents namespace to the api container (client-runtime#152)
+    set:
+      nodeAgents:
+        namespace:
+          name: tracebloc-node-agents
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_AGENTS_NAMESPACE
+            value: "tracebloc-node-agents"
+
+  # The empty value is load-bearing, not a no-op: the runtime reads UNSET as
+  # "older chart, use the built-in default" and SET-BUT-EMPTY as "there is no
+  # node-agents namespace". With resourceMonitor off the namespace and its RBAC
+  # are not rendered, so a populated value would have jobs-manager list a
+  # namespace that does not exist with no Role to authorize it — a 403 every
+  # heartbeat, forever, for a workload the operator turned off (review PR #750).
+  - it: empties the node-agents namespace when resourceMonitor is off (client-runtime#152)
+    set:
+      resourceMonitor: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_AGENTS_NAMESPACE
+            value: ""

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -832,10 +832,9 @@ tests:
           path: spec.template.spec.containers[1].name
           value: pods-monitor-container
 
-  # client-runtime#152: the heartbeat version inventory needs to know where the
-  # resource-monitor DaemonSet lives — the one chart workload outside the
-  # release namespace.
-  - it: passes the node-agents namespace to the api container (client-runtime#152)
+  # The heartbeat version inventory needs to know where the resource-monitor
+  # DaemonSet lives — the one chart workload outside the release namespace.
+  - it: passes the node-agents namespace to the api container
     set:
       nodeAgents:
         namespace:
@@ -847,13 +846,9 @@ tests:
             name: NODE_AGENTS_NAMESPACE
             value: "tracebloc-node-agents"
 
-  # The empty value is load-bearing, not a no-op: the runtime reads UNSET as
-  # "older chart, use the built-in default" and SET-BUT-EMPTY as "there is no
-  # node-agents namespace". With resourceMonitor off the namespace and its RBAC
-  # are not rendered, so a populated value would have jobs-manager list a
-  # namespace that does not exist with no Role to authorize it — a 403 every
-  # heartbeat, forever, for a workload the operator turned off (review PR #750).
-  - it: empties the node-agents namespace when resourceMonitor is off (client-runtime#152)
+  # The empty value is load-bearing: the runtime reads unset as "use the
+  # built-in default" and set-but-empty as "no node-agents namespace".
+  - it: empties the node-agents namespace when resourceMonitor is off
     set:
       resourceMonitor: false
     asserts:

--- a/client/tests/rbac_test.yaml
+++ b/client/tests/rbac_test.yaml
@@ -106,6 +106,59 @@ tests:
             resources: ["deployments", "daemonsets"]
             verbs: ["get", "list", "watch"]
 
+  # client-runtime#152 / review PR #750: resource-monitor is a DaemonSet in
+  # nodeAgents.namespace, NOT the release namespace. A release-namespace grant
+  # does not reach it — the list succeeds with zero items and the inventory
+  # reports "not deployed". clusterScope: false edges need a second Role there.
+  - it: a clusterScope=false edge gets a node-agents Role for the DaemonSet (client-runtime#152)
+    set:
+      clusterScope: false
+      nodeAgents:
+        namespace:
+          name: tracebloc-node-agents
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-node-agents
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["apps"]
+            resources: ["daemonsets"]
+            verbs: ["get", "list", "watch"]
+
+  - it: the node-agents RoleBinding binds the release-namespace ServiceAccount (client-runtime#152)
+    set:
+      clusterScope: false
+      nodeAgents:
+        namespace:
+          name: tracebloc-node-agents
+    documentIndex: 4
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.namespace
+          value: tracebloc-node-agents
+      - equal:
+          path: subjects[0].namespace
+          value: NAMESPACE
+
+  - it: no node-agents pair when that namespace IS the release namespace (client-runtime#152)
+    set:
+      clusterScope: false
+      nodeAgents:
+        namespace:
+          name: NAMESPACE
+    asserts:
+      # The release-namespace Role already grants daemonsets there, so a second
+      # pair would be unused surface — and would collide on name.
+      - hasDocuments:
+          count: 3
+
   # backend#1876: the GPU->CPU pending fallback needs list nodes. `nodes` is
   # cluster-scoped, so it must be in the ClusterRole and CANNOT be in the
   # namespaced Role — assert both.

--- a/client/tests/rbac_test.yaml
+++ b/client/tests/rbac_test.yaml
@@ -77,6 +77,35 @@ tests:
             resources: ["pods", "pods/log", "events"]
             verbs: ["get", "list", "watch"]
 
+  # client-runtime#152: the heartbeat version inventory reads the chart's own
+  # workloads. resource-monitor is a DaemonSet, so a deployments-only grant
+  # reports it as null forever — and because the runtime degrades rather than
+  # failing, the symptom is a blank field nobody would chase. Assert BOTH
+  # branches: an edge on clusterScope: false must get it too.
+  - it: ClusterRole grants read on deployments and daemonsets for the version inventory (client-runtime#152)
+    set:
+      clusterScope: true
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["apps"]
+            resources: ["deployments", "daemonsets"]
+            verbs: ["get", "list", "watch"]
+
+  - it: namespaced Role grants read on deployments and daemonsets too (client-runtime#152)
+    set:
+      clusterScope: false
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["apps"]
+            resources: ["deployments", "daemonsets"]
+            verbs: ["get", "list", "watch"]
+
   # backend#1876: the GPU->CPU pending fallback needs list nodes. `nodes` is
   # cluster-scoped, so it must be in the ClusterRole and CANNOT be in the
   # namespaced Role — assert both.

--- a/client/tests/rbac_test.yaml
+++ b/client/tests/rbac_test.yaml
@@ -77,12 +77,8 @@ tests:
             resources: ["pods", "pods/log", "events"]
             verbs: ["get", "list", "watch"]
 
-  # client-runtime#152: the heartbeat version inventory reads the chart's own
-  # workloads. resource-monitor is a DaemonSet, so a deployments-only grant
-  # reports it as null forever — and because the runtime degrades rather than
-  # failing, the symptom is a blank field nobody would chase. Assert BOTH
-  # branches: an edge on clusterScope: false must get it too.
-  - it: ClusterRole grants read on deployments and daemonsets for the version inventory (client-runtime#152)
+  # Assert both branches — a clusterScope: false edge needs the grant too.
+  - it: ClusterRole grants read on deployments and daemonsets for the version inventory
     set:
       clusterScope: true
     documentIndex: 1
@@ -94,7 +90,7 @@ tests:
             resources: ["deployments", "daemonsets"]
             verbs: ["get", "list", "watch"]
 
-  - it: namespaced Role grants read on deployments and daemonsets too (client-runtime#152)
+  - it: namespaced Role grants read on deployments and daemonsets too
     set:
       clusterScope: false
     documentIndex: 1
@@ -106,11 +102,9 @@ tests:
             resources: ["deployments", "daemonsets"]
             verbs: ["get", "list", "watch"]
 
-  # client-runtime#152 / review PR #750: resource-monitor is a DaemonSet in
-  # nodeAgents.namespace, NOT the release namespace. A release-namespace grant
-  # does not reach it — the list succeeds with zero items and the inventory
-  # reports "not deployed". clusterScope: false edges need a second Role there.
-  - it: a clusterScope=false edge gets a node-agents Role for the DaemonSet (client-runtime#152)
+  # resource-monitor is a DaemonSet in nodeAgents.namespace, not the release
+  # namespace, so a release-namespace grant does not reach it.
+  - it: a clusterScope=false edge gets a node-agents Role for the DaemonSet
     set:
       clusterScope: false
       nodeAgents:
@@ -130,7 +124,7 @@ tests:
             resources: ["daemonsets"]
             verbs: ["get", "list", "watch"]
 
-  - it: the node-agents RoleBinding binds the release-namespace ServiceAccount (client-runtime#152)
+  - it: the node-agents RoleBinding binds the release-namespace ServiceAccount
     set:
       clusterScope: false
       nodeAgents:
@@ -147,15 +141,14 @@ tests:
           path: subjects[0].namespace
           value: NAMESPACE
 
-  - it: no node-agents pair when that namespace IS the release namespace (client-runtime#152)
+  - it: no node-agents pair when that namespace IS the release namespace
     set:
       clusterScope: false
       nodeAgents:
         namespace:
           name: NAMESPACE
     asserts:
-      # The release-namespace Role already grants daemonsets there, so a second
-      # pair would be unused surface — and would collide on name.
+      # Already granted by the Role above, and a second pair would collide on name.
       - hasDocuments:
           count: 3
 


### PR DESCRIPTION
Companion to **tracebloc/client-runtime#348** (client-runtime#152). Refs client-runtime#152.

## Why

client-runtime#152 adds a version inventory to the edge-device heartbeat, assembled from the configured images on the chart's own workloads. The jobs-manager Role already grants read on `deployments`, which covers jobs-manager, pods-monitor, requests-proxy, mysql-client and egress-proxy.

**resource-monitor is a DaemonSet** — the one workload that isn't a Deployment — and `daemonsets` was granted nowhere in this Role.

Without the grant the list 403s. The runtime degrades rather than failing (it lists the two kinds separately for exactly this reason), so the symptom isn't an error anyone would chase: resource-monitor is reported as `null` forever, which reads as "not deployed".

## What

`apps: ["deployments"]` → `apps: ["deployments", "daemonsets"]`, read-only (`get, list, watch`), in **both** RBAC branches — an edge on `clusterScope: false` needs it just as much. Namespace-scoped in the Role branch.

Two helm unit tests assert both branches. The two rule lists are maintained separately in this template and have drifted before, so the assertion is per-branch rather than shared.

## Verification

- `helm lint ./client` — clean
- `helm unittest ./client` — **469 passed, 31 suites** (467 + the 2 new)
- `scripts/chart-version-guard.sh` — `client chart content changed and client/Chart.yaml 'version:' was bumped. ✓`

## Note on the version bump

Bumped 1.9.45 → 1.9.46. [#749](https://github.com/tracebloc/client/pull/749) (docs, also open) bumps to the same version — whichever merges second needs a trivial bump to 1.9.47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds namespace-scoped RBAC and a load-bearing env contract for heartbeat inventory; misconfiguration could cause 403s or silent null resource-monitor reporting, but grants are read-only and gated on layout flags.
> 
> **Overview**
> Enables jobs-manager to include **resource-monitor** in the edge heartbeat version inventory (companion to client-runtime changes). The main jobs-manager **ClusterRole/Role** now grants read-only access to **`daemonsets`** as well as **`deployments`**.
> 
> Because resource-monitor is a **DaemonSet in `nodeAgents.namespace`**, split-namespace installs (`clusterScope: false`) get an extra **Role/RoleBinding** in that namespace (via `tracebloc.rbacNodeAgentsName`), mirroring image-refresh RBAC; the pair is skipped when the node-agents namespace is the release namespace to avoid name collisions.
> 
> The jobs-manager **api** container receives **`NODE_AGENTS_NAMESPACE`** (the configured namespace when resource monitor is on, **empty** when `resourceMonitor: false` so the runtime does not list a disabled workload). Chart version **1.9.47**; helm unit tests cover RBAC branches and the env wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf85a23678608d045cdd4bc2692ab4d1e58df739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->