### PR TITLE
fix(ci): installer-tests needs helm too, or 14 assertions fail closed (client#751)

### DIFF
--- a/.github/workflows/installer-tests.yaml
+++ b/.github/workflows/installer-tests.yaml
@@ -106,6 +106,22 @@ jobs:
           echo "::error::could not install bats in 3 bounded attempts - runner-to-mirror connectivity, not this PR. Re-run this job."
           exit 1
 
+      # scripts/tests/chart-pull-secret.bats renders the REAL chart, so this job
+      # needs helm too. Without it `require_tool helm` fail-closes under CI=true
+      # and every `scripts/**` PR reds here instead of skipping -- the mirror
+      # image of the client#751 finding, where the suite ran with no helm and
+      # self-skipped green. standard-checks.yml already sets helm up; this job
+      # runs the same suite and was missed (Bugbot on the develop -> staging
+      # promotion, client#760).
+      #
+      # Same sha-pinned action and same v3.15.4 pin as standard-checks.yml,
+      # helm-ci.yaml and drift-checks.yaml: the bats file's own version gate keys
+      # off this pin, and an unpinned helm silently changes which assertions run.
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: v3.15.4
+
       - name: Run bats
         run: bats scripts/tests/*.bats
 


### PR DESCRIPTION
Bugbot flagged this High on the `develop -> staging` promotion (client#760): `installer-tests.yaml` runs `bats scripts/tests/*.bats` with no Helm setup.

`chart-pull-secret.bats` renders the real chart, so `require_tool helm` turns a missing helm into a **failure** when `CI=true` — deliberately, because in a required gate a skip is indistinguishable from a pass (client#751). Helm was added to `standard-checks.yml`'s `Unit tests` job when that fail-close landed, but this workflow runs the same suite and was missed.

Measured both directions on this branch:

| condition | result |
|---|---|
| helm absent, `CI=true` | **14 of 14 not ok**, each printing the `::error::` that names `standard-checks.yml 'Set up Helm'` |
| helm present, `CI=true` | full suite **1204 tests, all ok** |

Same sha-pinned `azure/setup-helm` and same `v3.15.4` pin as the five other workflows here — the bats file's own version gate keys off that pin, and an unpinned helm silently changes which assertions run.

`actionlint` clean.

Rolls up under client#751 rather than a new ticket (Bugbot drive-by on already-tracked work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; no runtime installer or chart behavior.
> 
> **Overview**
> The **`unit-bash`** job in **`installer-tests.yaml`** now installs **Helm** before **`bats scripts/tests/*.bats`**, matching **`standard-checks.yml`**.
> 
> **`chart-pull-secret.bats`** renders the real chart, so with **`CI=true`** a missing **`helm`** makes **`require_tool helm`** **fail** instead of skip—**14 assertions** were red on **`scripts/**`** PRs while the other workflow already had Helm (client#751 / client#760).
> 
> Uses the same sha-pinned **`azure/setup-helm`** action and **`v3.15.4`** version as **`standard-checks.yml`**, **`helm-ci.yaml`**, and **`drift-checks.yaml`** so the bats version gate stays aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16eaf9ab3917422ec31ee56efa6057b1228bf851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->