### PR TITLE
test(style): prove the style gate fires — 25 cases, every rule both ways (backend#1924)

### DIFF
--- a/scripts/check-style.sh
+++ b/scripts/check-style.sh
@@ -9,7 +9,7 @@
 #  so until 2026-08-19 a violation here printed red and merged anyway.
 #  Exit 0 = clean, 1 = violations found, 2 = the guard itself errored (fail-closed).
 #
-#  Three mechanical checks (semantic calls — role misuse, judgement-y wording —
+#  Four mechanical checks (semantic calls — role misuse, judgement-y wording —
 #  stay with CODEOWNERS review + STYLE.md; a grep can't police those). Emoji are
 #  intentionally NOT policed — they're welcome (see STYLE.md):
 #    1. No hardcoded brand colour outside the colour engine (scripts/lib/common.sh).
@@ -17,6 +17,12 @@
 #       Internal identifiers (the DNS-1123 sanitisers) and comments are exempt.
 #    3. No bare 'curl' — every fetch carries the minimum TLS version. INTERIM,
 #       see the note on the check itself.
+#    4. No capital-T 'Tracebloc' in user-facing text — the product name is
+#       lowercase. Comments and PascalCase identifiers are exempt.
+#
+#  This count is asserted by scripts/tests/check-style.bats: it said "Three" while
+#  four rules were live (backend#1924). A gate whose own description undercounts
+#  it is how a rule gets dropped without anyone noticing.
 #
 #  A line may opt out of ANY check with a trailing  # style-guard: allow  marker.
 # =============================================================================

--- a/scripts/tests/check-style.bats
+++ b/scripts/tests/check-style.bats
@@ -60,9 +60,21 @@ fixture() { printf '%s\n' "$@" > "$FIXTURE"; }
 # ── rule 1: hardcoded brand colour ───────────────────────────────────────────
 
 # Pull the tone vocabulary out of the script instead of restating it.
+# BOTH extractors FAIL CLOSED on a missing marker, and both callers assert the
+# token SHAPE (Bugbot + Asad on #762). `${re##*38;2;(}` is a no-op when the
+# marker is absent, so deleting rule 1's entire RGB arm made _brand_rgbs fall
+# through and return the HEX vocabulary instead. Those hexes were then planted as
+# `printf '\033[38;2;#?(01a5cc m'` — which still contains a brand hex, so the
+# surviving hex rule fired, the count floor was met, and the test asserting "the
+# RGB half is caught" passed with the RGB half GONE. Reproduced before fixing.
+#
+# Non-emptiness was never the contract. The contract is "this is the RGB
+# vocabulary", so the marker must be present and every token must look like a
+# triple. A guard on the extractor alone would still let a stray hex through.
 _brand_hexes() {
   local line re
   line="$(grep -m1 '^brand=' "$CS")"
+  case "$line" in *'#?('*) ;; *) return 1 ;; esac
   re="${line#brand=\'}"; re="${re%\'}"
   re="${re#*\#?(}"
   printf '%s' "${re%%)*}" | tr '|' ' '
@@ -70,6 +82,7 @@ _brand_hexes() {
 _brand_rgbs() {
   local line re
   line="$(grep -m1 '^brand=' "$CS")"
+  case "$line" in *'38;2;('*) ;; *) return 1 ;; esac
   re="${line#brand=\'}"; re="${re%\'}"
   re="${re##*38;2;(}"
   printf '%s' "${re%%)*}" | tr '|' ' '
@@ -77,9 +90,12 @@ _brand_rgbs() {
 
 @test "rule 1: EVERY brand hex the script declares is caught (vocabulary derived, not restated)" {
   local hexes count=0
-  hexes="$(_brand_hexes)"
-  [ -n "$hexes" ] || return 1          # fail closed: an unparsed vocabulary is a finding
+  hexes="$(_brand_hexes)" || return 1  # fail closed: no `#?(` marker is a finding
+  [ -n "$hexes" ] || return 1
   for h in $hexes; do
+    # Shape first: only a 6-digit hex may stand in for a hex token. Without this
+    # a leaked RGB fragment would satisfy the loop just as well.
+    [[ "$h" =~ ^[0-9a-fA-F]{6}$ ]] || return 1
     fixture "  local c=\"#${h}\""
     run run_style
     [ "$status" -eq 1 ] || return 1
@@ -91,9 +107,14 @@ _brand_rgbs() {
 
 @test "rule 1: EVERY brand RGB triple the script declares is caught" {
   local rgbs count=0
-  rgbs="$(_brand_rgbs)"
+  rgbs="$(_brand_rgbs)" || return 1    # fail closed: no `38;2;(` marker is a finding
   [ -n "$rgbs" ] || return 1
   for t in $rgbs; do
+    # THE ASSERTION THAT MAKES THIS REAL: a token must actually be a triple.
+    # Deleting the RGB arm used to leak the hex vocabulary in here, and a planted
+    # `38;2;#?(01a5cc` still tripped the surviving HEX rule — so the test passed
+    # while proving nothing about RGB.
+    [[ "$t" =~ ^[0-9]{1,3}\;[0-9]{1,3}\;[0-9]{1,3}$ ]] || return 1
     fixture "  printf '\\033[38;2;${t}m'"
     run run_style
     [ "$status" -eq 1 ] || return 1

--- a/scripts/tests/check-style.bats
+++ b/scripts/tests/check-style.bats
@@ -1,0 +1,310 @@
+#!/usr/bin/env bats
+# check-style.sh — the prose/terminology gate (backend#1924, backend#1729 sweep 6).
+#
+# WHY THIS SUITE EXISTS
+# ---------------------
+# Sweep 6 measured that of the 24 shell scripts under scripts/ (excluding
+# scripts/tests/ itself), exactly two were referenced by no bats suite.
+# gen-manifest.sh was the other, and it got client#707. This is the residual.
+#
+# The stake is lower than gen-manifest's on purpose — an inert style guard costs
+# drifting wording, not unverified code running privileged steps — but the reason
+# to cover it is the same: an uncovered gate is a gate nobody can prove fires,
+# and this one now sits inside the REQUIRED "Source-of-truth drift" check, so a
+# rule that silently stopped matching would read as "clean" forever.
+#
+# SHAPE (from client#707): every rule is tested BOTH ways — it fires on a
+# violation AND passes on the clean equivalent. One-sided tests are the trap
+# here: a rule whose regex stopped matching anything passes every
+# "clean input is clean" assertion while enforcing nothing.
+#
+# The brand-colour vocabulary is DERIVED from the script's own `brand=` regex
+# rather than restated (backend#1729 rule 1/6). A hand-copied list of tones would
+# agree with itself while a newly added tone went untested — the exact vocabulary
+# gap mutation coverage cannot see.
+
+setup() {
+  REPO="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  # A copy, always: these tests plant violations and corrupt the tree, and must
+  # never touch the working tree (same rule as gen-manifest.bats).
+  WORK="$(mktemp -d "${BATS_TMPDIR:-/tmp}/style.XXXXXX")"
+  cp -R "$REPO/scripts" "$WORK/scripts"
+  CS="$WORK/scripts/check-style.sh"
+  # The planted-violation file. NOT under scripts/tests/ — the scanner excludes
+  # that directory, so a fixture there would prove nothing (and every "it fires"
+  # test would pass for the wrong reason).
+  FIXTURE="$WORK/scripts/lib/zz-style-fixture.sh"
+}
+
+teardown() {
+  [ -n "${WORK:-}" ] && [ -d "$WORK" ] && rm -rf "$WORK"
+  return 0
+}
+
+# The real script, run the way CI runs it.
+run_style() { ( cd "$WORK" && bash scripts/check-style.sh ) }
+
+# Plant lines in a scanned .sh file.
+fixture() { printf '%s\n' "$@" > "$FIXTURE"; }
+
+# ── the clean baseline ───────────────────────────────────────────────────────
+# If this ever fails, every "fires on a violation" test below is meaningless:
+# they would be measuring the working tree's own violations, not the plant.
+
+@test "the working tree is clean (baseline — the rest of this suite depends on it)" {
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+  [[ "$output" == *"ok: style + terminology clean"* ]] || return 1
+}
+
+# ── rule 1: hardcoded brand colour ───────────────────────────────────────────
+
+# Pull the tone vocabulary out of the script instead of restating it.
+_brand_hexes() {
+  local line re
+  line="$(grep -m1 '^brand=' "$CS")"
+  re="${line#brand=\'}"; re="${re%\'}"
+  re="${re#*\#?(}"
+  printf '%s' "${re%%)*}" | tr '|' ' '
+}
+_brand_rgbs() {
+  local line re
+  line="$(grep -m1 '^brand=' "$CS")"
+  re="${line#brand=\'}"; re="${re%\'}"
+  re="${re##*38;2;(}"
+  printf '%s' "${re%%)*}" | tr '|' ' '
+}
+
+@test "rule 1: EVERY brand hex the script declares is caught (vocabulary derived, not restated)" {
+  local hexes count=0
+  hexes="$(_brand_hexes)"
+  [ -n "$hexes" ] || return 1          # fail closed: an unparsed vocabulary is a finding
+  for h in $hexes; do
+    fixture "  local c=\"#${h}\""
+    run run_style
+    [ "$status" -eq 1 ] || return 1
+    [[ "$output" == *"hardcoded brand colour"* ]] || return 1
+    count=$((count + 1))
+  done
+  [ "$count" -ge 6 ] || return 1       # the declared palette, not a subset
+}
+
+@test "rule 1: EVERY brand RGB triple the script declares is caught" {
+  local rgbs count=0
+  rgbs="$(_brand_rgbs)"
+  [ -n "$rgbs" ] || return 1
+  for t in $rgbs; do
+    fixture "  printf '\\033[38;2;${t}m'"
+    run run_style
+    [ "$status" -eq 1 ] || return 1
+    [[ "$output" == *"hardcoded brand colour"* ]] || return 1
+    count=$((count + 1))
+  done
+  [ "$count" -ge 5 ] || return 1
+}
+
+@test "rule 1: caught case-insensitively (#01A5CC is the same violation as #01a5cc)" {
+  fixture '  local c="#01A5CC"'
+  run run_style
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"hardcoded brand colour"* ]] || return 1
+}
+
+@test "rule 1: a NON-brand colour is clean (the rule discriminates, it is not 'any hex')" {
+  fixture '  local c="#123456"'
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+@test "rule 1: the colour engine itself is exempt (it is where the tones legitimately live)" {
+  # Same violation text, placed in common.sh — the one file the report filters out.
+  printf '\n  local c="#01a5cc"\n' >> "$WORK/scripts/lib/common.sh"
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+# ── rule 2: banned term 'workspace' ──────────────────────────────────────────
+
+@test "rule 2: 'workspace' in user-facing text is caught" {
+  fixture '  echo "your workspace is ready"'
+  run run_style
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"banned term 'workspace'"* ]] || return 1
+}
+
+@test "rule 2: the approved wording is clean" {
+  fixture '  echo "your secure environment is ready"'
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+@test "rule 2: comments and the DNS-1123 sanitiser identifiers are exempt" {
+  fixture \
+    '# a comment mentioning workspace is fine' \
+    '  _sanitize_workspace_name "$1"' \
+    '  ConvertTo-WorkspaceName "$1"' \
+    '  local workspace_name="x"'
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+# ── rule 3: bare curl (the TLS floor) ────────────────────────────────────────
+
+@test "rule 3: a bare curl call is caught" {
+  fixture '  curl -fsSL "$url" -o "$out"'
+  run run_style
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"bare 'curl'"* ]] || return 1
+}
+
+@test "rule 3: curl_secure is NOT a bare curl (\\bcurl\\b must not match the wrapper)" {
+  # The whole point of the rule is to push call sites onto the wrapper; flagging
+  # the wrapper would make the rule unsatisfiable.
+  fixture \
+    '  curl_secure "$url" -o "$out"' \
+    '  local curl_pid=$!' \
+    '  nocurl=1'
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+@test "rule 3: the documented exemptions are clean (TLS named, comment, presence test, install one-liner)" {
+  fixture \
+    '  curl --tlsv1.2 -fsSL "$url"' \
+    '# curl in a comment is fine' \
+    '  has curl || return 1' \
+    '  command -v curl >/dev/null' \
+    '  echo "  curl -fsSL https://tracebloc.io/i.sh | sh"'
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+# ── rule 4: capital-T 'Tracebloc' ────────────────────────────────────────────
+# Note this is the FOURTH rule; the header comment called it "Three mechanical
+# checks" until backend#1924, which is why it is worth a test of its own.
+
+@test "rule 4: capital-T 'Tracebloc' in user-facing text is caught" {
+  fixture '  echo "Welcome to Tracebloc"'
+  run run_style
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"capital-T 'Tracebloc'"* ]] || return 1
+}
+
+@test "rule 4: lowercase product name is clean" {
+  fixture '  echo "Welcome to tracebloc"'
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+@test "rule 4: PascalCase identifiers and comments are exempt" {
+  # Two DIFFERENT exemptions live here and must be driven separately, or one of
+  # them is untested: `Tracebloc[A-Z]` spares a name with a following capital,
+  # `[-]Tracebloc` spares a cmdlet name with a leading dash. Found by mutation —
+  # a fixture of only `Get-TraceblocClientEnv` satisfies BOTH, so deleting the
+  # dash filter changed nothing and the test stayed green.
+  fixture \
+    '# Tracebloc in a comment is fine' \
+    '  $key = "TraceblocInstallerResume"'
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+@test "rule 4: a cmdlet name with NO following capital is exempt via the leading dash alone" {
+  # `Get-Tracebloc` — the one input that only `[-]Tracebloc` can spare.
+  fixture '  Get-Tracebloc "$1"'
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+# ── the opt-out marker ───────────────────────────────────────────────────────
+# The header promises it works on ANY check. Tested per rule, because the marker
+# is applied in one shared place (scan) and a regression would silently un-exempt
+# every deliberate edge in the tree at once.
+
+@test "the '# style-guard: allow' marker opts a line out of EVERY rule" {
+  fixture \
+    '  local c="#01a5cc"   # style-guard: allow' \
+    '  echo "your workspace"   # style-guard: allow' \
+    '  curl -fsSL "$url"   # style-guard: allow' \
+    '  echo "Tracebloc"   # style-guard: allow'
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+@test "the marker is not required to be spaced exactly (#style-guard:allow also opts out)" {
+  fixture '  echo "your workspace"   #style-guard:allow'
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+# ── scope: what the scanner does and does not read ───────────────────────────
+
+@test "scope: violations in scripts/tests/ are not scanned (fixtures must not self-trip the gate)" {
+  printf '  echo "your workspace"\n' > "$WORK/scripts/tests/zz-scope-fixture.sh"
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+@test "scope: .ps1 files ARE scanned (the gate is cross-platform, not bash-only)" {
+  printf '  Write-Host "your workspace"\n' > "$WORK/scripts/zz-fixture.ps1"
+  run run_style
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *"banned term 'workspace'"* ]] || return 1
+}
+
+@test "scope: non-script files are not scanned" {
+  printf 'your workspace\n' > "$WORK/scripts/zz-fixture.md"
+  run run_style
+  [ "$status" -eq 0 ] || return 1
+}
+
+# ── fail-closed ──────────────────────────────────────────────────────────────
+# The script's own comment: "a mis-run guard (wrong dir, missing tree) must never
+# look like a pass". Exit 2 is reserved for that, and is distinct from exit 1.
+
+@test "fail-closed: no scripts/ tree -> exit 2, not a clean 0" {
+  local lone="$WORK/lone"
+  mkdir -p "$lone/scripts"
+  cp "$CS" "$lone/scripts/check-style.sh"
+  rm -rf "$lone/scripts"          # the script is gone with it; run the copy by path
+  mkdir -p "$lone/bin"
+  cp "$CS" "$lone/bin/check-style.sh"
+  run bash "$lone/bin/check-style.sh"
+  [ "$status" -eq 2 ] || return 1
+  [[ "$output" == *"refusing to report clean"* ]] || return 1
+}
+
+@test "fail-closed: a grep internal error -> exit 2, not a clean 0" {
+  # The `rc >= 2` branch in scan(). Driven by putting a grep that exits 2 on PATH,
+  # so the REAL branch runs — rather than editing the script, which would test a
+  # copy of the rule instead of the rule (backend#1729 rule 9).
+  local stub="$WORK/stub"
+  mkdir -p "$stub"
+  printf '#!/usr/bin/env bash\nexit 2\n' > "$stub/grep"
+  chmod +x "$stub/grep"
+  run env PATH="$stub:$PATH" bash -c "cd '$WORK' && bash scripts/check-style.sh"
+  [ "$status" -eq 2 ] || return 1
+}
+
+@test "exit codes are distinct: 1 means violations, 2 means the guard could not tell" {
+  fixture '  echo "your workspace"'
+  run run_style
+  [ "$status" -eq 1 ] || return 1        # a real violation is 1, never 2
+  [[ "$output" != *"failing closed"* ]] || return 1
+}
+
+# ── the header's own claim ───────────────────────────────────────────────────
+
+@test "the header's rule count matches the rules actually implemented" {
+  # backend#1924 found this stale: the header said "Three mechanical checks"
+  # while four `report` calls were live. A gate whose own description undercounts
+  # it is how a rule gets dropped without anyone noticing.
+  local implemented declared
+  implemented="$(grep -c '^report ' "$CS")"
+  declared="$(grep -oE '^#  (Three|Four|Five|Six) mechanical checks' "$CS" | awk '{print $2}')"
+  case "$declared" in
+    Three) declared=3 ;; Four) declared=4 ;; Five) declared=5 ;; Six) declared=6 ;;
+    *) return 1 ;;                       # unparsed header is a finding, not a pass
+  esac
+  [ "$implemented" -eq "$declared" ] || return 1
+}


### PR DESCRIPTION
Fixes tracebloc/backend#1924

## Why

Sweep 6 (backend#1729) measured that of the 24 shell scripts under `scripts/`, exactly two were referenced by no bats suite. `gen-manifest.sh` got #707; `check-style.sh` is the residual.

The stake is deliberately lower than the manifest generator's — an inert style guard costs drifting wording, not unverified code running privileged steps — but the reason to cover it is the same, and it got sharper on 2026-08-19: this gate now runs inside the **required** `Source-of-truth drift` check. An uncovered gate is a gate nobody can prove fires, and a rule that silently stopped matching would read as "clean" forever.

## Shape

From #707: **every rule is tested both ways** — fires on a violation, passes on the clean equivalent. One-sided tests are the trap here. A rule whose regex stopped matching anything satisfies every "clean input is clean" assertion while enforcing nothing.

25 cases covering:

- all four rules (brand colour, `workspace`, bare `curl`, capital-T `Tracebloc`) and **each documented exemption** — the colour engine, the DNS-1123 sanitiser identifiers, comments, `--tlsv1.2` lines, `has curl` / `command -v curl`, the `curl … | sh` one-liner, and both PascalCase forms
- the shared `# style-guard: allow` opt-out, on every rule
- scanner scope: `.ps1` **is** scanned (the gate is cross-platform), `scripts/tests/` is **not** (or fixtures would self-trip it), non-scripts are not
- both fail-closed exits: a missing tree and a grep internal error must be **exit 2**, never a clean 0, and exit 1 (violations) stays distinct from exit 2 (could not tell)

Two deliberate choices worth review:

**The brand palette is derived, not restated** (#1729 rule 1/6) — parsed out of the script's own `brand=` regex, so a newly added tone is tested automatically. Deriving *alone* would be self-consistent and blind, though: mutating a tone out of the palette also mutates what the test reads. A floor on the count closes that, and mutation MS2 proves it.

**The grep-error path is driven by putting a `grep` that exits 2 on `PATH`**, so the real `rc >= 2` branch runs — rather than editing the script, which would test a copy of the rule instead of the rule (#1729 rule 9).

## Mutation proof

21 mutations, each reddening its own guard; restored control 25/25.

| Mutation | Result |
|---|---|
| rule 1 report disabled | RED |
| a tone removed from the declared palette (self-consistency trap) | RED |
| `-i` dropped (case-insensitivity lost) | RED |
| colour-engine exemption removed | RED |
| rule 2: sanitiser-identifier exemption removed | RED |
| rule 2: comment exemption removed | RED |
| rule 3: `\bcurl\b` weakened / `--tlsv1.2`, `has curl`, `curl \| sh` exemptions removed | RED (×4) |
| rule 4: `Tracebloc[A-Z]` exemption removed | RED |
| rule 4: `[-]Tracebloc` exemption removed | RED |
| `# style-guard: allow` ignored | RED |
| `--exclude-dir=tests` dropped | RED |
| `--include=*.ps1` dropped | RED |
| fail-closed tree check disarmed | RED |
| grep-error threshold raised (internal error read as clean) | RED |
| header rule count made stale again | RED |

**One mutation found a real hole in this suite before it shipped.** Rule 4 has two separate exemptions, and a fixture of only `Get-TraceblocClientEnv` satisfies *both* — so deleting the `[-]Tracebloc` filter changed nothing and the test stayed green. Split out a case that only the leading-dash filter can spare (`Get-Tracebloc`, no following capital); both now redden independently. That is the value of asserting the mutation actually applied rather than trusting a green log.

## One stale claim fixed

The header read **"Three mechanical checks"** while four `report` calls were live — rule 4 arrived later and the count stayed behind. A gate whose own description undercounts it is how a rule gets dropped unnoticed, so the count is now asserted by the suite rather than trusted.

## Verification

- `bats scripts/tests/check-style.bats` → **25/25**
- `bats scripts/tests/bats-hygiene.bats` → 0 offenders (the new suite satisfies the org's `|| return 1` convention)
- `check-style.sh` on the real tree → clean; `bash -n`, `shellcheck -S error`, `gen-manifest --check`, `check-facts --check`, `check-drift.sh` → all clean

`Makefile`'s bats count is derived from `grep '^@test'`, so nothing needed hand-updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only plus comment/header fixes on the style guard; no runtime installer or CI behavior change beyond documenting four rules.
> 
> **Overview**
> Adds **`scripts/tests/check-style.bats`** (25 cases) so the required **`check-style.sh`** gate in `make drift` is proven to fire and pass on clean input—each of the four rules is tested **both ways**, plus documented exemptions, `# style-guard: allow`, scanner scope (`.ps1` vs `scripts/tests/`), and fail-closed exits **1 vs 2**.
> 
> Brand-colour coverage **parses the script’s `brand=` regex** instead of duplicating the palette; a test also checks the header’s **“Four mechanical checks”** claim matches the number of `report` calls.
> 
> **`check-style.sh`** header is corrected from “Three” to **Four** mechanical checks and notes that the bats suite asserts that count (backend#1924).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8e272dca1dfdfa70580b9399a96688565931276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->