### PR TITLE
docs(chart): record that Recreate + --atomic rolls back a degraded jobs-manager (backend#1922)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.58
-appVersion: "1.9.58"
+version: 1.9.59
+appVersion: "1.9.59"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -202,15 +202,23 @@ spec:
         # `kubectl rollout status` printed "successfully rolled out" while the
         # pod was crash-looping (4 restarts in 72s, 2026-08-11 / backend#1723).
         #
-        # Why a PORT probe is the right signal here, and not GET /healthz:
+        # Why a PORT probe is the shipped signal here, and not GET /healthz:
         # jobs-manager opens 8080 only at the END of a successful start — it
         # authenticates against the backend first and exits(1) on failure
         # (jobs_manager.py: auth at main() then run_server_in_thread ~140 lines
         # later), and create_app() runs the ingestion_runs migration against
         # MySQL on the way up. So "8080 accepts a connection" already implies
-        # backend auth succeeded and MySQL was reachable. `/healthz` is an
-        # unconditional `200 {"status":"ok"}` and would add no information over
-        # the TCP connect — the evidence is in reaching the port at all.
+        # backend auth succeeded and MySQL was reachable — enough to catch the
+        # crash-loop false-green this probe was added for.
+        #
+        # (`/healthz` is NOT the unconditional 200 an earlier version of this
+        # comment described — client-runtime#327 made it a real readiness report:
+        # authz_mount + schema + metadata_db, 503 when any is broken. Pointing
+        # readiness at httpGet /healthz is the deferred second half of
+        # backend#1779 and a genuine operational call — readiness would then
+        # depend on MySQL, so `helm --wait` blocks during a DB outage.
+        # backend#1922 considered that switch and declined it; the tcpSocket
+        # probe stays. See the rollback note below.)
         #
         # Gated on INGESTION_HTTP_DISABLED because the runtime gates the server
         # on it, with the same truthiness: `not os.getenv(...)` treats ANY
@@ -229,8 +237,11 @@ spec:
           # initialDelaySeconds covers the slow start without any consequence
           # if it is not enough: this container retries backend auth and then
           # runs a MySQL migration before it listens, and while readiness fails
-          # the pod is merely NotReady. Nothing kills it. That is the whole
-          # point — see the note below.
+          # OUTSIDE a rollout the pod is merely NotReady — pulled from the
+          # Service, not killed. (During a rollout there IS a further
+          # consequence: Recreate + `helm upgrade --atomic` rolls the release
+          # back. That is a recorded, accepted decision — see the rollback
+          # note below.)
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 3
@@ -255,6 +266,25 @@ spec:
         # (An earlier revision of this PR did add a startupProbe with a 150s
         # budget, which had exactly that bug — it was caught in review. Do not
         # reintroduce one without also changing jobs_manager.py's decision.)
+        #
+        # ROLLBACK ON THE DEGRADED PATH — recorded decision, backend#1922.
+        # Readiness-only (above) keeps a degraded pod alive OUTSIDE a rollout.
+        # A rollout is different: `strategy: Recreate` (top of this spec) deletes
+        # the old pod before the new one starts, and the auto-upgrade CronJob
+        # runs `helm upgrade --atomic` (see auto-upgrade-cronjob.yaml). If the
+        # new pod never becomes Ready — e.g. the ingestion server failed to bind
+        # 8080 though SB polling and training would still have worked — `--wait`
+        # times out and `--atomic` rolls back to the last good release. So on
+        # that path the deploy is reverted (an outage for the --timeout window),
+        # NOT a degraded-but-serving jobs-manager left running the new image.
+        #
+        # backend#1922 weighed making the degraded state serve instead (bind
+        # 8080 unconditionally and answer 503, or wire readiness to /healthz) and
+        # chose to ACCEPT the rollback: --atomic self-heals to a revision known
+        # to work, the safer default for an unattended customer edge than
+        # shipping a half-broken image. Revisiting that trade is a
+        # jobs_manager.py change (bind behaviour) or an httpGet /healthz switch,
+        # not a chart tweak.
         {{- end }}
         volumeMounts:
           - name: shared-volume


### PR DESCRIPTION
## What

Comment-only change to `client/templates/jobs-manager-deployment.yaml`. Records the **Option B** decision from backend#1922: the jobs-manager readiness design **accepts** that a degraded pod is rolled back during a rollout, rather than changing runtime behaviour to keep it serving.

## Why

backend#1922 (Bugbot finding, staging hop round 4) traced a real cross-repo mechanism: when the ingestion HTTP server fails to bind 8080 at startup, jobs-manager deliberately keeps running (SB polling + training continue), but `readinessProbe: tcpSocket: 8080` then never passes. With `strategy: Recreate` + the auto-upgrade CronJob's `helm upgrade --atomic`, the old pod is already gone and the never-Ready new pod makes `--wait` time out → `--atomic` rolls back to the last good release.

The existing comment argued the opposite — *"Nothing kills it"* — and also justified preferring `tcpSocket` over `/healthz` on the grounds that *"/healthz is an unconditional 200"*. Both statements are now misleading:

- `Recreate` + `--atomic` **does** effectively end the degraded pod during a rollout (revert to prior revision, outage for the `--timeout` window).
- client-runtime#327 made `/healthz` a real readiness report (`authz_mount` + `schema` + `metadata_db`, 503 when any is broken), so the "unconditional 200" rationale no longer holds.

This PR corrects both and adds a **ROLLBACK ON THE DEGRADED PATH** note recording that backend#1922 weighed making the degraded state serve (bind 8080 unconditionally + 503, or wire readiness to `/healthz`) and chose to accept the rollback as the safer default for an unattended edge. No probe or strategy change.

## Scope / decision

This is the documentation half of the decision. If we ever revisit the trade, it becomes a `jobs_manager.py` bind-behaviour change (client-runtime) or an `httpGet /healthz` switch — deliberately **not** a chart tweak, which is why nothing operational changes here. Related: the deferred second half of backend#1779.

## Verification

- `helm template ... --show-only templates/jobs-manager-deployment.yaml` renders unchanged (comments only; probe/strategy identical).

Draft pending the decision being confirmed on backend#1922.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and a chart version bump only; rendered probes and strategy are identical.
> 
> **Overview**
> Comment-only update on the jobs-manager readiness probe, plus a chart bump to **1.9.59**. Probe settings and rollout strategy are unchanged.
> 
> Corrects two stale claims: `/healthz` is no longer an unconditional 200 (client-runtime#327), and a failed readiness check *does* kill the new pod during a rollout because `Recreate` plus auto-upgrade `helm upgrade --atomic` times out and rolls back.
> 
> Adds a **ROLLBACK ON THE DEGRADED PATH** note (backend#1922): keep `tcpSocket` on 8080 and accept rollback rather than serving a half-broken image. Revisiting that is a runtime bind change or an `httpGet /healthz` switch, not a chart tweak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40fefecfbbd90df4c8b7238e03d204d8ed6cfd56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->