### PR TITLE
fix(chart): a declared CPU-only install must emit an explicit empty GPU_LIMITS (backend#2216)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.48
-appVersion: "1.9.48"
+version: 1.9.49
+appVersion: "1.9.49"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -465,19 +465,37 @@ spec:
         - name: RESOURCE_LIMITS
           value: {{ if hasKey .Values.env "RESOURCE_LIMITS" }}{{ .Values.env.RESOURCE_LIMITS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         {{- end }}
-        # #343: only stamp the GPU vars when a GPU is actually configured. A
-        # CPU-only install writes GPU_LIMITS: "" (empty), and a chart-direct
-        # install may omit the key entirely — in both cases emitting the var
-        # (or its "nvidia.com/gpu=1" default) surfaces a phantom GPU in the
-        # CLI resources view. GPU_REQUESTS is gated on the SAME condition so a
-        # CPU-only install emits NEITHER var, and a GPU install emits BOTH
-        # (a lone GPU request with no matching limit is rejected by the API
-        # server). Render only for a non-empty GPU_LIMITS value.
-        {{- if (default "" .Values.env.GPU_LIMITS) }}
+        # #343: never stamp a PHANTOM GPU. Emitting the "nvidia.com/gpu=1"
+        # default on a CPU-only install surfaced a GPU that was not there in
+        # the CLI resources view. GPU_REQUESTS and GPU_LIMITS share one gate so
+        # an install emits BOTH or NEITHER (a lone GPU request with no matching
+        # limit is rejected by the API server).
+        #
+        # THE GATE IS `hasKey`, NOT NON-EMPTINESS (backend#2216). #343 keyed on
+        # a non-empty GPU_LIMITS, which collapsed two different situations into
+        # one silence:
+        #
+        #   * the operator DECLARED CPU-only     -> `GPU_LIMITS: ""` is present
+        #   * nobody said anything (chart-direct) -> the key is absent
+        #
+        # jobs-manager reads those differently by design: an explicit empty
+        # means "no GPU on this cluster" (`_gpu_available_from_env`,
+        # client-runtime#80) while absence preserves the legacy assume-a-GPU
+        # default. Omitting the var in BOTH cases threw the declaration away, so
+        # a declared CPU-only edge looked identical to a GPU one — every job
+        # requested `nvidia.com/gpu`, wedged Pending, and waited out the 600s
+        # scale-from-zero grace before being respun on CPU, once per experiment
+        # (the cost recorded on client-runtime#355).
+        #
+        # So: key present -> emit it, empty value included. Key absent -> emit
+        # neither, which is still "can't tell" and still the legacy default.
+        # The phantom GPU stays fixed either way, because what caused it was
+        # the "nvidia.com/gpu=1" DEFAULT, and an explicit empty is not that.
+        {{- if hasKey .Values.env "GPU_LIMITS" }}
         - name: GPU_REQUESTS
-          value: {{ if hasKey .Values.env "GPU_REQUESTS" }}{{ .Values.env.GPU_REQUESTS | quote }}{{ else }}"nvidia.com/gpu=1"{{ end }}
+          value: {{ if hasKey .Values.env "GPU_REQUESTS" }}{{ .Values.env.GPU_REQUESTS | quote }}{{ else if (default "" .Values.env.GPU_LIMITS) }}"nvidia.com/gpu=1"{{ else }}""{{ end }}
         - name: GPU_LIMITS
-          value: {{ .Values.env.GPU_LIMITS | quote }}
+          value: {{ .Values.env.GPU_LIMITS | default "" | quote }}
         {{- end }}
         - name: RUNTIME_CLASS_NAME
           value: {{ if hasKey .Values.env "RUNTIME_CLASS_NAME" }}{{ .Values.env.RUNTIME_CLASS_NAME | quote }}{{ else }}""{{ end }}
@@ -572,14 +590,15 @@ spec:
           value: {{ if hasKey .Values.env "RESOURCE_LIMITS" }}{{ .Values.env.RESOURCE_LIMITS | quote }}{{ else }}"cpu=2,memory=8Gi"{{ end }}
         {{- end }}
         # #343: only stamp the GPU vars when a GPU is actually configured (see
-        # the api container above) — GPU_REQUESTS and GPU_LIMITS share one gate
+        # the api container above) — GPU_REQUESTS and GPU_LIMITS share one gate,
+        # `hasKey` since backend#2216 (see the api container for why)
         # so a CPU-only install emits neither (no phantom GPU in the CLI view)
         # and a GPU install emits both (request == limit).
-        {{- if (default "" .Values.env.GPU_LIMITS) }}
+        {{- if hasKey .Values.env "GPU_LIMITS" }}
         - name: GPU_REQUESTS
-          value: {{ if hasKey .Values.env "GPU_REQUESTS" }}{{ .Values.env.GPU_REQUESTS | quote }}{{ else }}"nvidia.com/gpu=1"{{ end }}
+          value: {{ if hasKey .Values.env "GPU_REQUESTS" }}{{ .Values.env.GPU_REQUESTS | quote }}{{ else if (default "" .Values.env.GPU_LIMITS) }}"nvidia.com/gpu=1"{{ else }}""{{ end }}
         - name: GPU_LIMITS
-          value: {{ .Values.env.GPU_LIMITS | quote }}
+          value: {{ .Values.env.GPU_LIMITS | default "" | quote }}
         {{- end }}
         - name: RUNTIME_CLASS_NAME
           value: {{ if hasKey .Values.env "RUNTIME_CLASS_NAME" }}{{ .Values.env.RUNTIME_CLASS_NAME | quote }}{{ else }}""{{ end }}

--- a/client/tests/gpu_env_declaration_test.yaml
+++ b/client/tests/gpu_env_declaration_test.yaml
@@ -1,0 +1,115 @@
+suite: GPU env declaration reaches jobs-manager (backend#2216)
+# THREE SITUATIONS, NOT TWO. jobs-manager's `_gpu_available_from_env`
+# (client-runtime#80) distinguishes an EXPLICIT EMPTY GPU_LIMITS ("no GPU on
+# this cluster") from an ABSENT one ("nobody said; assume a GPU, the legacy
+# default"). client#343 gated both vars on a NON-EMPTY GPU_LIMITS, which
+# collapsed the first case into the second: a declared CPU-only edge emitted
+# nothing and therefore looked exactly like a GPU install.
+#
+# The cost of that collapse, measured on client-runtime#355: every job on such
+# an edge requested `nvidia.com/gpu`, wedged Pending, and waited out the 600s
+# scale-from-zero grace before being respun on CPU -- once per experiment.
+#
+# The gate this file pins existed unguarded from #343 until now: no chart test
+# asserted the GPU env vars at all, in either direction.
+templates:
+  - templates/jobs-manager-deployment.yaml
+set:
+  clientId: "test-id"
+  clientPassword: "test"
+tests:
+  - it: a GPU install emits both vars with the configured value
+    set:
+      env:
+        GPU_LIMITS: "nvidia.com/gpu=2"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GPU_LIMITS
+            value: "nvidia.com/gpu=2"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GPU_REQUESTS
+            value: "nvidia.com/gpu=1"
+
+  - it: a DECLARED CPU-only install emits an explicit empty, not silence
+    # THE FIX. `GPU_LIMITS: ""` is the operator saying "no GPU here". Emitting
+    # nothing threw that declaration away and jobs-manager fell back to
+    # assuming a GPU.
+    set:
+      env:
+        GPU_LIMITS: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GPU_LIMITS
+            value: ""
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GPU_REQUESTS
+            value: ""
+
+  - it: a declared CPU-only install never emits the phantom GPU default
+    # WHY #343 EXISTED, still pinned. The phantom GPU in the CLI resources view
+    # came from the "nvidia.com/gpu=1" DEFAULT, not from the var being present,
+    # so an explicit empty does not bring it back.
+    set:
+      env:
+        GPU_LIMITS: ""
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GPU_REQUESTS
+            value: "nvidia.com/gpu=1"
+
+  - it: an absent key still emits NEITHER var — "can't tell" is not "no GPU"
+    # The other half of the distinction, and the reason the gate is `hasKey`
+    # rather than unconditional. A chart-direct install that never mentions GPU
+    # must keep the legacy assume-a-GPU default, which absence is what encodes.
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GPU_LIMITS
+            value: ""
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GPU_REQUESTS
+            value: ""
+
+  - it: both vars travel together on the pods-monitor container too
+    # A lone GPU request with no matching limit is rejected by the API server,
+    # and the second container carries its own copy of the gate — so the two
+    # sites are asserted separately rather than assumed to agree.
+    set:
+      env:
+        GPU_LIMITS: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: GPU_LIMITS
+            value: ""
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: GPU_REQUESTS
+            value: ""
+
+  - it: an explicit GPU_REQUESTS still wins over both defaults
+    set:
+      env:
+        GPU_LIMITS: "nvidia.com/gpu=4"
+        GPU_REQUESTS: "nvidia.com/gpu=4"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GPU_REQUESTS
+            value: "nvidia.com/gpu=4"


### PR DESCRIPTION
Closes part of tracebloc/backend#2216 — the upstream half. Found by @shujaatTracebloc reviewing tracebloc/client-runtime#355.

## Three situations, not two

jobs-manager's `_gpu_available_from_env` (client-runtime#80) reads three states, deliberately:

| values | meaning to jobs-manager |
|---|---|
| `GPU_LIMITS: "nvidia.com/gpu=2"` | GPU install |
| `GPU_LIMITS: ""` **(explicit empty)** | **no GPU on this cluster** |
| key absent | nobody said — assume a GPU (legacy default) |

`client#343` gated both GPU vars on a **non-empty** `GPU_LIMITS`, which collapsed rows 2 and 3 into one silence. An operator who wrote `GPU_LIMITS: ""` emitted nothing, so their edge was indistinguishable from a GPU install.

## What that cost

Measured on client-runtime#355, on a CPU-only **multi-node** edge:

1. `_gpu_available` came back `True` — the declaration had been thrown away;
2. `_configure_resources` took the GPU branch and every job requested `nvidia.com/gpu`;
3. the pod wedged **Pending**; `check_pending_jobs` took the `elastic_no_gpu_node` fall-through;
4. it waited out the **600s** scale-from-zero grace before being respun on CPU — **once per experiment**.

That is backend#1874's Pending-then-respin cycle, and worse than the ~206s tax backend#2089 removed.

## The change

The gate becomes `hasKey`: **key present → emit it, empty value included. Key absent → emit neither.**

`#343`'s actual defect stays fixed. The phantom GPU in the CLI resources view came from the `"nvidia.com/gpu=1"` **default**, not from the var being present — and that default now applies only when `GPU_LIMITS` is non-empty. An explicit empty renders as an explicit empty.

Both containers carry their own copy of the gate, so both are changed, and both are asserted **separately** rather than assumed to agree — a lone GPU request with no matching limit is rejected by the API server.

## This gate had no test at all

From `#343` until now, nothing asserted the GPU env vars in either direction — which is how one silence standing for two meanings survived. Six tests added, covering all three situations plus the phantom-GPU regression `#343` was opened for.

Mutation-proved:

| mutation | reddens |
|---|---|
| restore `#343`'s non-empty gate (the exact defect) | 2 |
| emit the phantom default on a declared-empty install | 3 |
| emit unconditionally (loses the can't-tell case) | 1 |

488 chart tests pass; `helm lint` clean. Chart bumped 1.9.48 → 1.9.49.

## Sequencing

**Ahead of client-runtime#355.** With the declaration restored, a CPU-only multi-node edge takes the CPU branch outright and does not need that PR's spawn-time gate at all — which is exactly why @shujaatTracebloc asked for this to land before/with it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 98f1547d3db0ce972fbf184da6e6a6e3e39e6736. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->