### PR TITLE
docs(bugbot): encode the three shapes of a vacuous test (backend#2265)

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -105,6 +105,50 @@ for *what the operator sees and can act on*, not code elegance.
   (`scripts/gen-manifest.sh`). `make drift` fails in the required `Source-of-truth drift`
   check, and a stale manifest breaks `install.sh`'s verified fetch.
 
+- **A test whose fixture cannot reach the code it names.** Ask which line of production
+  code changes the assertion's outcome; if none does, the test is decoration however well
+  it reads. Three PRs on 2026-08-20 (#762, #763, `tracebloc/release-train#94`) shipped
+  **eleven** of these, every one reviewed and green, so treat it as the default suspicion
+  on a new guard test. Three shapes, ascending in subtlety:
+  - **Unreachable fixture** — the input never takes the path. A one-liner test that
+    *indents* the function when the opener rule is anchored at column 0; an attribution
+    test whose dispatch-only fixture returns before attribution runs.
+  - **Redundant mechanisms** — two code paths give the same observable for that input, so
+    removing either changes nothing. A fixture with ONE Dockerfile cannot distinguish "the
+    fallback demanded everything" from "the comment attributed that one file": both count 1.
+    Add the second element.
+  - **Inert mutation** — the *mutation* fails to express the defect. For a root Dockerfile
+    `rel` and the basename are the same string, so mutating one of two redundant match arms
+    leaves the other matching. An anchor-resolution check **cannot** catch this — the
+    anchor resolves perfectly and the log is indistinguishable from real coverage. Only a
+    surviving mutation reveals it.
+
+- **A surviving mutation treated as a nuisance.** It is a defect in the test, or in the
+  mutation — never something to annotate and move past. The converse matters too: a green
+  mutation log is evidence only if the run also asserts the mutation *applied*
+  (backend#1729 rule 5), because an unresolvable anchor and real coverage look the same.
+
+- **A derived vocabulary that cannot fail closed.** Deriving beats restating (backend#1729
+  rule 1), but a derivation that silently falls through returns the *wrong* vocabulary and
+  then agrees with itself. `_brand_rgbs` in `scripts/tests/check-style.bats` fell back to
+  the hex list when rule 1's RGB arm was deleted, so the test asserting "every RGB triple
+  is caught" passed with the RGB half **gone**. Require both halves: fail closed on a
+  missing marker, and assert the token shape.
+
+- **A pipe into an early-closing reader under errexit + pipefail.** `producer | head -n N`,
+  `| grep -q`, `| grep -m N`: the reader closes, the producer takes SIGPIPE, pipefail makes
+  the pipeline 141 and errexit kills the script. Size-dependent, which is why it survives
+  review — measured, 50 lines exit 0 and 20k exit 141 (client#656, client#678). The house
+  idiom is a here-string or capture-then-slice.
+  `scripts/tests/pipefail-early-close.sh` enforces this in CI, **including inside
+  `scripts/lib/*.sh`** (see the corollary below). Converting an instance is not always the
+  fix: `scripts/lib/diagnose.sh:95-101` keeps its `df -h | head -20` on purpose, because
+  `run_diagnose` opens with `set +e` so the 141 cannot fire, *and* `head` streams — capturing
+  df in full would block the whole bundle on an unresponsive NFS mount. The guard reads
+  `set +e` and does not flag it, so no marker is needed there; `# pipefail-guard: allow`
+  exists for a case the guard cannot reason about, and is currently unused in the tree.
+  Flag a new marker that does not state why.
+
 - **A `Chart.yaml` `version` bump without the matching `appVersion`** — the
   `app.kubernetes.io/version` label depends on it.
 
@@ -112,6 +156,10 @@ for *what the operator sees and can act on*, not code elegance.
 
 - **`scripts/lib/*.sh` have no `set -euo pipefail` by design.** They are only ever
   `source`d by `scripts/install-k8s.sh`, which sets it at line 44 *before* sourcing.
+  Corollary, and the reason this is a non-issue rather than a free pass: those libs still
+  **run** under both options, so every errexit/pipefail rule — including the early-close
+  gate above — applies to them in full. A guard that only asks "does this file set the
+  options" reads the entire lib tree as safe; that was the bug #763 fixed.
 - `scripts/check-style.sh`, `scripts/tests/check-drift.sh`, `scripts/tests/distro-prereqs.sh`
   and `scripts/tests/path-persist.sh` deliberately use `set -uo pipefail` **without `-e`**
   so they can inspect a failing check's exit code instead of aborting.
@@ -146,5 +194,10 @@ ticket detail in a finding. A bare `tracebloc/backend#NNNN` reference is fine.
 Every Bugbot review thread gets a reply, then gets resolved:
 - **Fixed**: say what changed and in which commit.
 - **False positive**: say why, with evidence (file/line, measured behavior).
+- **Never resolve on "the reported case now passes."** Re-test the surrounding shape space
+  first — a fix for one spelling routinely leaves its sibling broken (flow vs block form
+  recurred four times in `tracebloc/release-train#94` alone). A resolved thread reads as
+  "handled" to the next person, so closing one over a still-broken shape is worse than
+  leaving it open.
 Unresolved cursor threads HOLD release-train promotions (soft gate) — an
 unaddressed finding blocks the fleet, not just this PR.


### PR DESCRIPTION
Fixes tracebloc/backend#2265

## Why

Three PRs merged on 2026-08-20 — #762, #763 and `tracebloc/release-train#94` — shipped **eleven** tests that asserted the right property and proved nothing. Every one was written deliberately, reviewed, and green. That is the most frequent finding across those PRs by a wide margin — more than every production defect in them combined — and `.cursor/BUGBOT.md` said nothing about it.

The repo convention is that a finding recurring across PRs becomes a rule here.

## What's added

**Three shapes, ascending in subtlety** — only the first is widely understood:

1. **Unreachable fixture** — the input never takes the path. A one-liner test that *indents* the function when the opener rule is anchored at column 0.
2. **Redundant mechanisms** — two code paths give the same observable for that input. A fixture with one Dockerfile cannot distinguish "the fallback demanded everything" from "the comment attributed that one file": both count 1.
3. **Inert mutation** — the *mutation* fails to express the defect. For a root Dockerfile, `rel` and the basename are the same string, so mutating one of two redundant arms leaves the other matching.

Shape 3 is the one worth internalising: **an anchor-resolution check cannot detect it.** The anchor resolves perfectly and the log is indistinguishable from real coverage. Only a surviving mutation reveals it.

Plus:

- a surviving mutation is a defect in the test, never a nuisance to annotate — and a green mutation log is evidence only if the run asserts the mutation *applied*
- a derived vocabulary must fail closed (the `_brand_rgbs` case: deleting rule 1's whole RGB arm left its test green, because the extractor fell through to the hex list)
- the early-close hazard now has a CI gate, with `diagnose.sh` as the worked example of an instance that is correct **as** a pipe
- a corollary on the `scripts/lib/*.sh` non-issue: they set no options but they *run* under both, so errexit/pipefail rules apply in full
- never resolve a thread on "the reported case now passes"

## Relationship to backend#1729

#1729 already requires mutation-proving, deriving the input domain, and never testing a copy of the rule. **All three were followed in these PRs and the tests were still vacuous eleven times.** The existing rules say to mutation-test; they don't say what a *surviving* mutation means, or that a fixture can be too thin for the property to be observable. That's the gap.

## Verification

Docs-only, but every factual claim was checked against the tree — which caught two errors in my own draft before commit:

- I wrote that `diagnose.sh` carries a `# pipefail-guard: allow` marker. It doesn't — I removed it once the guard learned to read `set +e`. Reworded to describe what the file actually does.
- I referenced `make mutation-markers`, which is a **release-train** target, not a client one. Replaced with a repo-neutral phrasing.

Writing a rule about prose that contradicts code, and nearly shipping exactly that, is not lost on me.

`check-style.sh`, `gen-manifest --check`, `check-drift.sh` and the early-close gate all clean. No customer or internal detail (public repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change to the Bugbot review guide; no runtime, security, or installer behavior is modified.
> 
> **Overview**
> Updates `.cursor/BUGBOT.md` so reviewers treat **vacuous guard tests** as the default suspicion: fixtures that never hit the named path, inputs that cannot distinguish two mechanisms, and mutations that do not actually express the defect.
> 
> Also tells Bugbot to flag surviving mutations as test defects (not nuisances), derived vocabularies that fail open, and unexplained `# pipefail-guard: allow` markers. Clarifies that sourced `scripts/lib/*.sh` still run under `errexit`/`pipefail`, and that a finding must not be resolved just because the reported case now passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d2196e57ce6b05261a64d89bcf8863df23bfb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->