### PR TITLE
fix(shell-gate): `||` is not a pipe, and `|&` is (backend#2264)

### DIFF
--- a/scripts/tests/pipefail-early-close.awk
+++ b/scripts/tests/pipefail-early-close.awk
@@ -165,10 +165,18 @@ FNR == 1 {
   # `|&` is bash's pipe-both-streams and is a pipe like any other, so the bar is
   # allowed one optional `&`. It is NOT the `|&` of the terminator class below,
   # which is about what may FOLLOW `head`.
+  #
+  # \001 IS IN THE HEAD TERMINATOR CLASS for the same reason it is in the grep
+  # arms' `[^|\001]*`: the stand-in has to read as a BOUNDARY, not as ordinary
+  # text. `producer | head||die` leaves `head` followed by \001, and without it
+  # in the class the pipe is missed -- a FALSE NEGATIVE this fix introduced and
+  # `develop` did not have (Arturo, client#777). The neutralisation and the
+  # boundary are one change; doing half of it moves the bug rather than fixing
+  # it, which is exactly what happened here twice.
   # The terminator class matters: `head` can be followed by a CLOSING delimiter,
   # not just whitespace or end-of-line. `x="$(cmd | head)"` ends at `)` and then
   # `"`, and requiring space-or-EOL missed exactly that shape (Bugbot #763).
-  if (probe ~ /\|&?[[:space:]]*head([[:space:]]|$|[)"'\''`;|&])/ \
+  if (probe ~ /\|&?[[:space:]]*head([[:space:]]|$|[)"'\''`;|&\001])/ \
       || probe ~ /\|&?[[:space:]]*grep[^|\001]*[[:space:]]-[a-zA-Z]*q/ \
       || probe ~ /\|&?[[:space:]]*grep[^|\001]*[[:space:]]-[a-zA-Z]*m[[:space:]]*[0-9]/) {
     sub(/^[[:space:]]+/, "", line)

--- a/scripts/tests/pipefail-early-close.awk
+++ b/scripts/tests/pipefail-early-close.awk
@@ -115,16 +115,32 @@ FNR == 1 {
 
   if (!(e_on && p_on)) next
 
+  # `||` IS NOT A PIPE, and must be neutralised before the hazard test below.
+  # Otherwise the SECOND bar of a `||` reads as a pipeline, and the scanner
+  # flags the very form this file recommends:
+  #     out=$(producer) || true
+  #     grep -q needle <<<"$out"        # fine
+  #     cmd || grep -q needle <<<"$out" # was reported as an offender
+  # Found while converting the fleet for backend#2264 -- the gate rejected the
+  # output of its own remediation, which is how a gate teaches people to
+  # disable it. \001 cannot occur in a shell source line, so it is a safe
+  # stand-in; the ORIGINAL line is still what gets printed.
+  probe = line
+  gsub(/\|\|/, "\001\001", probe)
+
   # The hazard: a pipe into a reader that closes early.
   #   `| head`        — closes after N lines
   #   `| grep -q`     — closes on the first match
   #   `| grep -m N`   — closes after N matches
+  # `|&` is bash's pipe-both-streams and is a pipe like any other, so the bar is
+  # allowed one optional `&`. It is NOT the `|&` of the terminator class below,
+  # which is about what may FOLLOW `head`.
   # The terminator class matters: `head` can be followed by a CLOSING delimiter,
   # not just whitespace or end-of-line. `x="$(cmd | head)"` ends at `)` and then
   # `"`, and requiring space-or-EOL missed exactly that shape (Bugbot #763).
-  if (line ~ /\|[[:space:]]*head([[:space:]]|$|[)"'\''`;|&])/ \
-      || line ~ /\|[[:space:]]*grep[^|]*[[:space:]]-[a-zA-Z]*q/ \
-      || line ~ /\|[[:space:]]*grep[^|]*[[:space:]]-[a-zA-Z]*m[[:space:]]*[0-9]/) {
+  if (probe ~ /\|&?[[:space:]]*head([[:space:]]|$|[)"'\''`;|&])/ \
+      || probe ~ /\|&?[[:space:]]*grep[^|]*[[:space:]]-[a-zA-Z]*q/ \
+      || probe ~ /\|&?[[:space:]]*grep[^|]*[[:space:]]-[a-zA-Z]*m[[:space:]]*[0-9]/) {
     sub(/^[[:space:]]+/, "", line)
     print curfile ":" FNR ": " line
   }

--- a/scripts/tests/pipefail-early-close.awk
+++ b/scripts/tests/pipefail-early-close.awk
@@ -39,6 +39,24 @@
 # `hazardous` (from pipefail-early-close.sh) seeds files that inherit both
 # options from a sourcing script; those start with the state already on.
 #
+# KNOWN LIMITATION -- a `set` line inside a MULTI-LINE QUOTED STRING is read as
+# this file's options rather than as fixture data. tracebloc/.github's
+# house-rules-selftest.sh passes whole scripts as quoted arguments:
+#
+#     expect "a bare curl fires both rules" \
+#     '#!/bin/bash
+#     set -euo pipefail
+#     curl -fsSL "$url" -o out' curl-timeout,curl-tls
+#
+# so the scanner sees errexit enabled in a file whose real options are
+# `set -uo pipefail`, and reports a line that carries no hazard. Counting quotes
+# to find such regions was tried and REJECTED: apostrophes in prose ("the file's
+# options") desynchronise the count within a few lines of the top of that very
+# file, and a desynchronised count HIDES real offenders -- strictly worse than
+# reporting a false one. Use `# pipefail-guard: allow` on the affected line until
+# the scanner can lex shell properly (backend#2264). The behaviour is PINNED by a
+# test, so changing it is deliberate rather than silent.
+#
 # Usage:  awk -v hazardous="<paths>" -f pipefail-early-close.awk FILE...
 # Output: one `path:line: code` per offender.
 

--- a/scripts/tests/pipefail-early-close.awk
+++ b/scripts/tests/pipefail-early-close.awk
@@ -143,6 +143,18 @@ FNR == 1 {
   # output of its own remediation, which is how a gate teaches people to
   # disable it. \001 cannot occur in a shell source line, so it is a safe
   # stand-in; the ORIGINAL line is still what gets printed.
+  #
+  # THE STAND-IN IS ALSO A BOUNDARY, and the `[^|\001]*` class below is what
+  # makes it one. The `|` characters of a `||` are not just noise -- they are
+  # what STOPS `grep[^|]*` from spanning further down the line. Replacing them
+  # with a character the class permitted let a plain `| grep` reach the `-q` of
+  # a LATER `|| grep -q`:
+  #     producer | grep needle && cmd || grep -q x <<<"$y"
+  # flagged again -- the same false positive, one level deeper (Bugbot,
+  # client#777). Neutralising the pipe is only half the job; the boundary has to
+  # survive. Adding \001 to the class is the fix, and it is the ONLY fix here:
+  # shrinking the stand-in to one character was tried, and its mutation survived,
+  # so it changed nothing and was reverted.
   probe = line
   gsub(/\|\|/, "\001\001", probe)
 
@@ -157,8 +169,8 @@ FNR == 1 {
   # not just whitespace or end-of-line. `x="$(cmd | head)"` ends at `)` and then
   # `"`, and requiring space-or-EOL missed exactly that shape (Bugbot #763).
   if (probe ~ /\|&?[[:space:]]*head([[:space:]]|$|[)"'\''`;|&])/ \
-      || probe ~ /\|&?[[:space:]]*grep[^|]*[[:space:]]-[a-zA-Z]*q/ \
-      || probe ~ /\|&?[[:space:]]*grep[^|]*[[:space:]]-[a-zA-Z]*m[[:space:]]*[0-9]/) {
+      || probe ~ /\|&?[[:space:]]*grep[^|\001]*[[:space:]]-[a-zA-Z]*q/ \
+      || probe ~ /\|&?[[:space:]]*grep[^|\001]*[[:space:]]-[a-zA-Z]*m[[:space:]]*[0-9]/) {
     sub(/^[[:space:]]+/, "", line)
     print curfile ":" FNR ": " line
   }

--- a/scripts/tests/pipefail-early-close.bats
+++ b/scripts/tests/pipefail-early-close.bats
@@ -430,3 +430,35 @@ hazardous() {
   run scan "$f"
   [ -n "$output" ] || return 1
 }
+
+# Arturo, client#777: the head arm needed the SAME boundary treatment as the
+# grep arms. Neutralising `||` left `head` followed by \001, which the
+# terminator class did not list — so `producer | head||die` was silently
+# dropped. develop caught it; the first version of this fix did not. Doing half
+# the boundary work moves the bug rather than fixing it.
+@test "a pipe into head glued to '||' is still flagged (no space before the bars)" {
+  local f; f="$(hazardous glued.sh '  producer | head||die')"
+  run scan "$f"
+  [ -n "$output" ] || return 1
+  [[ "$output" == *"glued.sh:3"* ]] || return 1
+}
+
+@test "the same for '|&' glued to '||'" {
+  local f; f="$(hazardous gluedamp.sh '  noisy |& head||die')"
+  run scan "$f"
+  [ -n "$output" ] || return 1
+}
+
+# The discrimination: `|| true` must STILL spare the glued form, or the fix
+# above would just be "flag everything with head in it".
+@test "but 'head||true' stays spared — the status is still discarded" {
+  local f; f="$(hazardous gluedtrue.sh '  producer | head||true')"
+  run scan "$f"
+  [ -z "$output" ] || return 1
+}
+
+@test "and 'head|| :' likewise" {
+  local f; f="$(hazardous gluedcolon.sh '  producer | head|| :')"
+  run scan "$f"
+  [ -z "$output" ] || return 1
+}

--- a/scripts/tests/pipefail-early-close.bats
+++ b/scripts/tests/pipefail-early-close.bats
@@ -377,3 +377,31 @@ hazardous() {
   run scan "$f"
   [ -n "$output" ] || return 1
 }
+
+# ── a pinned KNOWN LIMITATION, not an endorsement ────────────────────────────
+# A `set` line inside a multi-line quoted string is fixture data, but the
+# scanner reads it as the file's own options. This test asserts the CURRENT
+# behaviour so that a future fix reddens it deliberately rather than changing
+# the gate's verdicts silently. Counting quotes to detect such regions was
+# tried and rejected: apostrophes in prose desynchronise the count, and a
+# desynchronised count HIDES real offenders (backend#2264).
+@test "KNOWN LIMITATION: a 'set -e' inside a quoted fixture is read as the file's own" {
+  local f="$WORK/fixture.sh"
+  { printf '#!/usr/bin/env bash\nset -uo pipefail\n'          # the REAL options: no errexit
+    printf "expect 'a fixture script' \\\\\n"
+    printf "'#!/bin/bash\nset -euo pipefail\ncurl x' rulename\n"
+    printf '  n=$(producer | head -1)\n'; } > "$f"
+  run scan "$f"
+  # Documented wrong answer: flagged, though the file never enables errexit.
+  [ -n "$output" ] || return 1
+}
+
+@test "and the allow marker is the documented workaround for exactly that case" {
+  local f="$WORK/fixture-allowed.sh"
+  { printf '#!/usr/bin/env bash\nset -uo pipefail\n'
+    printf "expect 'a fixture script' \\\\\n"
+    printf "'#!/bin/bash\nset -euo pipefail\ncurl x' rulename\n"
+    printf '  n=$(producer | head -1)   # pipefail-guard: allow\n'; } > "$f"
+  run scan "$f"
+  [ -z "$output" ] || return 1
+}

--- a/scripts/tests/pipefail-early-close.bats
+++ b/scripts/tests/pipefail-early-close.bats
@@ -405,3 +405,28 @@ hazardous() {
   run scan "$f"
   [ -z "$output" ] || return 1
 }
+
+# Bugbot, client#777: neutralising `||` must not remove the BOUNDARY the grep
+# arms rely on. `grep[^|]*` used the `|` of a `||` as its stop; replacing those
+# bars with something the class permits let a plain `| grep` span the whole line
+# and reach the `-q` of a later `|| grep -q`.
+@test "a plain '| grep' does NOT borrow the -q of a later '|| grep -q'" {
+  local f; f="$(hazardous span.sh '  producer | grep needle && cmd || grep -q x <<<"$y"')"
+  run scan "$f"
+  [ -z "$output" ] || return 1
+}
+
+@test "nor the -m of a later '|| grep -m1'" {
+  local f; f="$(hazardous spanm.sh '  producer | grep needle && cmd || grep -m1 x <<<"$y"')"
+  run scan "$f"
+  [ -z "$output" ] || return 1
+}
+
+# The discrimination: on a line of that exact shape, a REAL early-close is still
+# caught. Without this, widening the stand-in until everything is spared would
+# pass the two above.
+@test "but a real '| grep -q' on such a line IS still flagged" {
+  local f; f="$(hazardous spanreal.sh '  producer | grep -q needle && cmd || fallback')"
+  run scan "$f"
+  [ -n "$output" ] || return 1
+}

--- a/scripts/tests/pipefail-early-close.bats
+++ b/scripts/tests/pipefail-early-close.bats
@@ -323,3 +323,57 @@ hazardous() {
   [[ "$output" == *"a-bad.sh"* ]] || return 1
   [[ "$output" != *"b-good.sh"* ]] || return 1
 }
+
+# ── `||` is not a pipe ───────────────────────────────────────────────────────
+# The gate flagged the output of its own remediation: converting the fleet for
+# backend#2264 produced `cmd || grep -q x <<<"$y"`, and the SECOND bar of the
+# `||` was read as a pipeline. A gate that rejects the form it recommends is
+# how a gate teaches people to switch it off.
+
+@test "it does NOT flag '|| grep -q' — the second bar of || is not a pipe" {
+  local f; f="$(hazardous orgrep.sh '  helm template . >/dev/null || grep -q needle <<<"$out"')"
+  run scan "$f"
+  [ -z "$output" ] || return 1
+}
+
+@test "it does NOT flag '|| head' either" {
+  local f; f="$(hazardous orhead.sh '  check_it || head -5 <<<"$captured" >&2')"
+  run scan "$f"
+  [ -z "$output" ] || return 1
+}
+
+@test "it does NOT flag '|| grep -m1'" {
+  local f; f="$(hazardous orgrepm.sh '  probe || grep -m1 needle <<<"$out"')"
+  run scan "$f"
+  [ -z "$output" ] || return 1
+}
+
+# The discrimination that makes the three above meaningful: a REAL pipe on a
+# line that ALSO contains `||` must still be caught. Without this, deleting the
+# hazard test entirely would pass all three.
+@test "a real pipe is still flagged on a line that also contains '||'" {
+  local f; f="$(hazardous mixed.sh '  x=$(producer | head -1) || warn "no first line"')"
+  run scan "$f"
+  [ -n "$output" ] || return 1
+  [[ "$output" == *"mixed.sh:3"* ]] || return 1
+}
+
+@test "and '|| true' still spares a real pipe (the pre-existing rule is intact)" {
+  local f; f="$(hazardous ortrue2.sh '  x=$(producer | head -1) || true')"
+  run scan "$f"
+  [ -z "$output" ] || return 1
+}
+
+# `|&` is bash's pipe-both-streams. It is a pipe, so the hazard applies; the
+# scanner used to miss it because the bar had to be followed by space-or-name.
+@test "it FLAGS '|& head' — pipe-both-streams is still a pipe" {
+  local f; f="$(hazardous amppipe.sh '  noisy_producer |& head -1')"
+  run scan "$f"
+  [ -n "$output" ] || return 1
+}
+
+@test "it FLAGS '|& grep -q' too" {
+  local f; f="$(hazardous amppipeq.sh '  noisy_producer |& grep -q needle')"
+  run scan "$f"
+  [ -n "$output" ] || return 1
+}


### PR DESCRIPTION
Part of tracebloc/backend#2264.

## The gate rejected the output of its own remediation

Converting the fleet for #2264 produces exactly this line:

```bash
cmd || grep -q needle <<<"$out"
```

There is no pipe in it. But the hazard regex matched the **second bar of the `||`**, so the scanner reported the very form this repo documents as the house idiom. It would have blocked every cleanup PR in the #2264 wave — and a gate that rejects its own fix is how a gate teaches people to switch it off.

Found by running the gate against my own converted `cli` scripts, not by reading it.

## Fix

Neutralise `||` into `\001\001` on a **probe copy** before the hazard test. `\001` cannot occur in a shell source line, and the original line is still what gets printed, so offender output is byte-identical.

**Second, smaller gap** found while writing that test: `|&` — bash's pipe-both-streams — *is* a pipe and carries the identical hazard, but the bar had to be followed by space-or-name, so `noisy |& head -1` was missed entirely. The bar now takes an optional `&`. A gate that misses a real pipe form is the "advice, not a gate" failure from the house rules, so I fixed it here rather than filing it.

## Mutation-proof

Baseline 33 green. Each mutation asserted its anchor matched **exactly one line** before running — an inert mutation and real coverage are indistinguishable in a log otherwise.

| mutation | reddens |
|---|---|
| remove the `\|\|` neutralisation | **3** — tests 27, 28, 29 |
| hazard test reads `line`, not `probe` | 1 — test 28 |
| drop `\|&` from the head arm | 1 — test 32 |
| drop `\|&` from the grep -q arm | 1 — test 33 |

Every mutation is caught by the test that *names* the property, not by one shared failure that any mutation would trip.

The load-bearing test is **"a real pipe is still flagged on a line that also contains `||`"**. Without it, the three new spare-cases would all pass if the hazard test were deleted outright — three tests asserting the right property and proving nothing. That's the shape client#776 is about, so it would have been a poor look to ship it here.

## Verification

- the gate reports **zero** over the whole tree
- `check-style.sh` clean, `gen-manifest.sh --check` up to date
- 23 other bats suites run, **0 failures** (the remainder are unaffected — this touches only the scanner and its own test file)

## Sequencing note

This wants to land **before** the remaining #2264 conversion PRs, or the gate will be wrong about them once it's armed. It does not block them from merging today, since the gate is not yet a required check anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Linter-only regex and test changes; no runtime, auth, or data-path code. Residual risk is false positives/negatives in the style gate, which the new tests pin.
> 
> **Overview**
> Stops the pipefail early-close scanner from flagging the house remediation idiom (`cmd || grep -q …`) by treating `||` as **not** a pipeline, while still catching real `|` / `|&` hazards on the same line.
> 
> The matcher now runs on a probe copy where `||` is replaced with a `\001` stand-in that also acts as a regex boundary, so a later `|| grep -q` cannot be borrowed by a plain `| grep`, and glued forms like `head||die` stay flagged. `|&` (pipe both streams) is now recognized as a pipe.
> 
> Also documents and pins a known false positive: `set` inside a multi-line quoted fixture is read as the file’s own options; `# pipefail-guard: allow` remains the workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0a9d3fabef1f43188d0e79eb79d49c3a2004d20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->