### PR TITLE
sec(chart): drop the unused watch verb from the resource-monitor ClusterRole

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.50
-appVersion: "1.9.50"
+version: 1.9.51
+appVersion: "1.9.51"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/resource-monitor-rbac.yaml
+++ b/client/templates/resource-monitor-rbac.yaml
@@ -54,14 +54,27 @@ metadata:
   of every pod in the cluster -- including other tenants' training pods, which
   run customer code and print customer data. That is a real exfiltration path
   for a node-telemetry agent that never reads a log. backend#950.
+
+  `watch` is removed for the same reason, on both rules: every call above is a
+  point read or a one-shot list. The image never opens a watch -- no `Watch()`,
+  no `watch.stream`, no `watch=True`, and it shells out to nothing (its CMD is
+  `python /app/resource_monitor.py`; there is no kubectl in the image). A
+  cluster-wide `watch` on pods is a live streaming feed of every pod object in
+  the cluster, so an agent that only samples its own node's metrics should not
+  hold one. backend#950 follow-up.
+
+  VERBS ARE PINNED BY TEST, not just resources. `watch` survived the #950 trim
+  because resource_monitor_test.yaml asserted only `resources` -- the rule was
+  narrowed on one axis while the other kept an unused grant. Both axes are
+  asserted now.
 */}}
 rules:
   - apiGroups: [""]
     resources: ["pods", "nodes", "nodes/status"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
   - apiGroups: ["metrics.k8s.io"]
     resources: ["pods", "nodes"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/client/tests/resource_monitor_test.yaml
+++ b/client/tests/resource_monitor_test.yaml
@@ -112,6 +112,32 @@ tests:
           path: rules[1].resources
           value: ["pods", "nodes"]
 
+  # VERBS, not just resources. `watch` survived the #950 trim precisely because
+  # this suite pinned one axis and left the other open: the rule was narrowed to
+  # the right resources while keeping a verb the image never uses. Every call the
+  # image makes is a point read or a one-shot list (read_namespaced_pod,
+  # read_node, read_node_status, list_pod_for_all_namespaces,
+  # get_cluster_custom_object, list_namespaced_custom_object) — no Watch(), no
+  # watch.stream, no kubectl. A cluster-wide watch on pods is a live feed of
+  # every pod object in the cluster, which a per-node telemetry agent has no use
+  # for. Assert both rules so it cannot come back silently.
+  - it: ClusterRole grants get and list only — never watch
+    template: templates/resource-monitor-rbac.yaml
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: rules[0].verbs
+          value: ["get", "list"]
+      - equal:
+          path: rules[1].verbs
+          value: ["get", "list"]
+      - notContains:
+          path: rules[0].verbs
+          content: watch
+      - notContains:
+          path: rules[1].verbs
+          content: watch
+
   - it: ClusterRoleBinding subject points at the release-scoped SA
     template: templates/resource-monitor-rbac.yaml
     documentIndex: 2


### PR DESCRIPTION
The last code item on backend#950. Refs backend#950.

## Why

#731 narrowed this rule to the resources the image actually reads, but left `watch` on both rules. Nothing watches.

Every Kubernetes call in the resource-monitor image is a point read or a one-shot list:

| apiGroup | calls | verbs needed |
|---|---|---|
| `""` | `read_namespaced_pod`, `read_node`, `read_node_status`, `list_pod_for_all_namespaces` | get, list |
| `metrics.k8s.io` | `get_cluster_custom_object`, `list_namespaced_custom_object` ×2 | get, list |

No `Watch()`, no `watch.stream`, no `watch=True` anywhere in `Node-deploy/`, and the image shells out to nothing — its CMD is `python /app/resource_monitor.py` and no kubectl is installed. The template's own comment already enumerated exactly this surface and never mentioned `watch`.

Worth removing rather than shrugging at: this is a **cluster-scoped** role, so `watch` on pods is a live streaming feed of every pod object in the cluster — other tenants' training pods included — held by an agent that only samples its own node's metrics. Same argument that removed `pods/log` under #950, one verb over.

## Why it survived, and the fix for that

`resource_monitor_test.yaml` pinned `resources` and left `verbs` unasserted. The rule got narrowed on one axis while the other kept an unused grant — which is exactly how you end up doing a security trim twice.

Both axes are asserted now. The new test was checked **against the unfixed template**: re-adding `watch` fails it with `- watch / +- watch` on both rules, so it isn't vacuous.

```
$ helm unittest ./client -f 'tests/resource_monitor_test.yaml'   # with watch restored
 FAIL  Resource-monitor DaemonSet
    - ClusterRole grants get and list only — never watch
Tests:  1 failed, 12 passed, 13 total
```

## Verification

- `helm unittest ./client` — **492 passed, 33 suites** (was 488)
- `helm lint ./client` — clean
- `scripts/chart-version-guard.sh` — bump present ✓
- Rendered output confirms both rules are `["get", "list"]`

Chart 1.9.50 → 1.9.51.

## Note on closing backend#950

This clears the last **code** item. What remains there is operational and not mine to do: rotating the exposed resource-monitor credential (the finding-1 token was in Datadog-scraped logs, so the fix stops future exposure but doesn't un-expose it), flipping `POD_TOKEN_REQUIRE_BOUND_CLAIMS=1` once pre-#950 tokens have drained, and FR on staging. The chart-rollout bullet there is stale — develop is on 1.9.50, well past the 1.9.45 it names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster-scoped RBAC for a node telemetry ServiceAccount. The change only drops unused `watch` (least privilege), so blast radius is a failed rollout if the image actually watched, which tests and comments say it does not.
> 
> **Overview**
> Tightens the resource-monitor **ClusterRole** so both core and `metrics.k8s.io` rules grant only `get`/`list`. Unused cluster-wide `watch` on pods/nodes is dropped (backend#950 follow-up): the agent only does point reads and one-shot lists, and a live watch would stream every pod object in the cluster.
> 
> Helm unittest now asserts verbs on both rules (`get`/`list` only, no `watch`) so an unused grant cannot return silently. Chart version **1.9.50 → 1.9.51**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c638a8ad0a0e0da29cf7eb8effbf2e1bb606d0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->