### PR TITLE
docs(bugbot): changing half of a paired construct is a new bug, not a partial fix

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -149,6 +149,32 @@ for *what the operator sees and can act on*, not code elegance.
   exists for a case the guard cannot reason about, and is currently unused in the tree.
   Flag a new marker that does not state why.
 
+- **Half of a paired construct changed.** Openers and closers, arms of one `if`, a
+  neutralisation and the boundary it destroys, a writer and its reader — when a rule lives
+  in two places that must move together, changing one is not a partial fix, it is a *new*
+  bug, and often in the opposite direction from the one being fixed. Three in one day on
+  2026-08-20/21, all on constructs whose halves sat within twenty lines of each other:
+    - client#777: `||` neutralised to `\001` for the `grep` arms via `grep[^|\001]*`, but
+      `\001` was not added to the `head` terminator class — so `producer | head||die`, which
+      `develop` flagged, was silently dropped. Fail-open.
+    - client#764: the Helm comment stripper taught the chomping opener `{{- /*` but not the
+      matching closer `*/ -}}`, so a block that used both never terminated and the stripper
+      ate 23 lines of the file. Fail-**closed**, in a required drift gate.
+    - client#777 again: the fix for the first one shipped a second change (a one-character
+      stand-in) whose mutation survived — inert, and reverted.
+  Two habits close it, and both are cheap. **Grep for the sibling** before committing: if
+  you edited a terminator class, an opener, or one arm of a matcher, find the other. And for
+  a scanner or matcher, **diff the whole-tree output against the base** — if the base flags
+  something you no longer do, that is a regression the unit tests will not show you, because
+  they only cover the case you were already thinking about.
+
+- **A fixture set that only exercises the form the author had in mind.** The corollary to
+  the above, and the reason it kept getting through: the `k3s-components-agreement` suite
+  added in client#764 had nine cases and none used the `*/ -}}` closer, so the suite shipped
+  in the *same commit* as the bug it could not see. When the thing under test accepts
+  several spellings of one construct, enumerate the spellings from the real input — here,
+  from the template the guard actually reads — not from the example in your head.
+
 - **A `Chart.yaml` `version` bump without the matching `appVersion`** — the
   `app.kubernetes.io/version` label depends on it.
 


### PR DESCRIPTION
Follows client#776, which encoded the three shapes of a vacuous test. This encodes a different pattern, found the hard way in the hours since.

## The rule

**Changing half of a paired construct is a new bug, not a partial fix** — and often in the *opposite* direction from the one being fixed.

Three instances in one day, all caught by reviewers rather than by me, all on constructs whose halves sat within twenty lines of each other:

| PR | what | direction |
|---|---|---|
| client#777 | `\|\|` neutralised to `\001` for the grep arms via `grep[^\|\001]*`, but `\001` never added to the `head` terminator class — `producer \| head\|\|die` silently dropped, though `develop` flagged it | **fail-open** |
| client#764 | Helm comment stripper taught the chomping opener `{{- /*` but not the closer `*/ -}}`; a block using both never terminated and the stripper ate 23 of 165 lines | **fail-closed**, in a required drift gate |
| client#777 | the fix for the first shipped a second change (a one-char stand-in) whose mutation **survived** — inert, reverted |  |

Once is bad luck. Three times between two PRs is a pattern, and the org convention is explicit that a recurring finding becomes a rule here rather than being re-argued in comments.

## The two habits it prescribes

Both cheap, both would have caught all three:

1. **Grep for the sibling before committing.** Edited a terminator class, an opener, one arm of a matcher? Find the other half.
2. **For any scanner or matcher, diff the whole-tree output against the base.** If the base flags something you no longer do, that is a regression *no unit test will show you* — the tests only cover the case you were already thinking about. This is the one that matters: I ran it after Arturo's finding and it took seconds.

## The corollary — why it kept getting through

**A fixture set that only exercises the form the author had in mind.**

The `k3s-components-agreement` suite added in client#764 had nine cases, and **none used the `*/ -}}` closer**. So the suite shipped in the *same commit* as a bug none of its fixtures could see. When the thing under test accepts several spellings of one construct, enumerate the spellings from the real input — here, from the template the guard actually reads — not from the example in your head.

That is adjacent to client#776's "unreachable fixture" shape but distinct: there the fixture couldn't reach the code path; here it reaches it, in only one of its several legal spellings.

## Verification

Docs-only. Every factual claim re-checked against the tree before committing — the line references, the 23-of-165 measurement, and the nine-cases-at-the-time count (that suite is at 11 now, and the text is careful to say what it was at that commit).

`check-style.sh`, `gen-manifest.sh --check` and the early-close gate all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change to the Bugbot review guide; no runtime, security, or CI behavior is modified.
> 
> **Overview**
> Adds two **Always flag** rules to `.cursor/BUGBOT.md` so reviewers treat a one-sided edit of a paired construct as a *new* bug, not a partial fix.
> 
> The first rule covers openers/closers, matcher arms, and writer/reader pairs, with three recent examples (fail-open `head||die` drop, fail-closed Helm comment strip, inert mutation). It prescribes grepping the sibling and diffing whole-tree scanner output against the base.
> 
> The corollary flags fixture suites that only cover the spelling the author had in mind, citing `k3s-components-agreement` shipping without a `*/ -}}` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b8f413a0d9fc6de8494adade1f1ff3a057db045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->