### PR TITLE
feat(telemetry): the chart wires jobs-manager to the Collector's token (backend#2274)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,7 @@ lint-warnings:
 #
 # `|`-separated because each guard is a multi-word command. One entry per guard,
 # and this is the only place they are written down.
-DRIFT_GUARDS := scripts/gen-manifest.sh --check|scripts/check-facts.sh --check|bash scripts/check-style.sh|bash scripts/tests/check-drift.sh|bash scripts/tests/env-vocabulary-agreement.sh|bash scripts/tests/telemetry-vocabulary-agreement.sh|bash scripts/tests/k3s-components-agreement.sh|bash scripts/tests/collector-class-a-agreement.sh|bash scripts/tests/openshift-scc-coverage.sh|bash scripts/tests/collector-offsets-persisted.sh|bash scripts/tests/node-agents-tenancy.sh
+DRIFT_GUARDS := scripts/gen-manifest.sh --check|scripts/check-facts.sh --check|bash scripts/check-style.sh|bash scripts/tests/check-drift.sh|bash scripts/tests/env-vocabulary-agreement.sh|bash scripts/tests/telemetry-vocabulary-agreement.sh|bash scripts/tests/k3s-components-agreement.sh|bash scripts/tests/collector-class-a-agreement.sh|bash scripts/tests/openshift-scc-coverage.sh|bash scripts/tests/collector-offsets-persisted.sh|bash scripts/tests/node-agents-tenancy.sh|bash scripts/tests/telemetry-token-agreement.sh
 
 # EXPORTED, not interpolated. The recipe reads $$DRIFT_GUARDS from the
 # environment; it used to do `guards='$(DRIFT_GUARDS)'`, which Make expands

--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.58
-appVersion: "1.9.58"
+version: 1.9.59
+appVersion: "1.9.59"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -270,6 +270,34 @@ spec:
             readOnly: true
         env:
         {{- include "tracebloc.proxyEnv" . | nindent 8 }}
+        {{- /*
+          The edge Collector's token Secret (backend#2274). jobs-manager holds NO
+          default for these: the chart declares the name, namespace and key and
+          passes them here, so the two sides cannot disagree. The Collector mounts
+          that Secret `optional: true` on purpose — a missing token must buffer,
+          not CrashLoopBackOff on every node — which means a wrong name, namespace
+          or key all look exactly like "not deployed yet". A default on the reader
+          side that drifted from this block would manufacture that silence.
+
+          THIS CONTAINER ONLY. `pods-monitor-container` below has a
+          byte-identical `env:` opening, and it does not run jobs_manager.py — the
+          Secret writer lives in the jobs-manager image. Wired to the wrong one,
+          every variable would be set on a process that never reads them and the
+          Collector would still get no token.
+
+          Absent when the Collector is off, and the reader treats that as "nothing
+          to do" without making a single API call.
+        */}}
+        {{- $tcEnv := default (dict) .Values.telemetryCollector }}
+        {{- if $tcEnv.enabled }}
+        {{- $tokEnv := default (dict) $tcEnv.tokenSecret }}
+        - name: TELEMETRY_TOKEN_SECRET_NAMESPACE
+          value: {{ .Values.nodeAgents.namespace.name | quote }}
+        - name: TELEMETRY_TOKEN_SECRET_NAME
+          value: {{ $tokEnv.name | default "tracebloc-telemetry-token" | quote }}
+        - name: TELEMETRY_TOKEN_SECRET_KEY
+          value: {{ $tokEnv.key | default "token" | quote }}
+        {{- end }}
         - name: CLIENT_ID
           valueFrom:
             secretKeyRef:

--- a/client/templates/telemetry-token-rbac.yaml
+++ b/client/templates/telemetry-token-rbac.yaml
@@ -1,0 +1,76 @@
+{{- $tcTok := default (dict) .Values.telemetryCollector -}}
+{{- if $tcTok.enabled }}
+{{- $tokSecret := default (dict) $tcTok.tokenSecret -}}
+{{- $tokName := $tokSecret.name | default "tracebloc-telemetry-token" -}}
+{{- /*
+  Lets jobs-manager write and REFRESH the edge Collector's ingest token
+  (backend#2274). The Collector reads its credential through `bearertokenauth`'s
+  `filename` from a projected Secret; jobs-manager is what puts it there, using
+  the same DRF token it already sends as `Authorization: Token <token>`.
+
+  GATED ON THE COLLECTOR ALONE, deliberately not on `nodeAgents.namespace`
+  differing from the release namespace. The sibling node-agents Roles carry that
+  second condition because the release-namespace grant already covers them when
+  the two coincide. This one is not covered either way: jobs-manager's cluster-wide
+  rule in rbac.yaml grants `secrets: [create, get]` and NOT `patch`, in ANY
+  namespace — so without this Role the create succeeds and every refresh 403s
+  wherever the Collector runs. The Role name is release-scoped, so it cannot
+  collide with anything when the namespaces do coincide.
+
+  WHY `patch` MATTERS ENOUGH TO ADD A ROLE FOR. `bearertokenauth` watches the
+  projected file, so a rotated token is picked up with no Collector restart — but
+  only if something updates the Secret. Without `patch`, the Collector works until
+  the first token rotation and then 401s on every export, buffering to disk until
+  the cap. That failure needs no code change to appear; it arrives on its own.
+
+  TWO RULES, because `resourceNames` IS NOT HONOURED FOR `create`: the API server
+  cannot match a name that does not exist yet. So `create` is namespace-scoped and
+  `get`/`patch` are pinned to this one Secret — which is the tighter half, and the
+  one that would otherwise let jobs-manager rewrite any Secret in the namespace.
+  Same shape and same reason as image-refresh-rbac.yaml's collection-verb split.
+*/}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tracebloc.telemetryCollectorName" . }}-token
+  namespace: {{ .Values.nodeAgents.namespace.name }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: telemetry-collector
+rules:
+  # `create` cannot be name-scoped (see above). Namespace-scoped, create-only.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  # The refresh path, pinned to the one Secret this feature owns.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ $tokName | quote }}]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tracebloc.telemetryCollectorName" . }}-token
+  namespace: {{ .Values.nodeAgents.namespace.name }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tracebloc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: telemetry-collector
+subjects:
+  # jobs-manager's ServiceAccount, which lives in the RELEASE namespace — the
+  # Role and RoleBinding are the only things in the node-agents namespace.
+  - kind: ServiceAccount
+    name: {{ include "tracebloc.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "tracebloc.telemetryCollectorName" . }}-token
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/client/tests/telemetry_collector_test.yaml
+++ b/client/tests/telemetry_collector_test.yaml
@@ -4,6 +4,8 @@ templates:
   - templates/telemetry-collector-daemonset.yaml
   - templates/telemetry-collector-rbac.yaml
   - templates/telemetry-collector-scc.yaml
+  - templates/telemetry-token-rbac.yaml
+  - templates/jobs-manager-deployment.yaml
   - templates/auto-upgrade-rbac.yaml
   - templates/image-refresh-rbac.yaml
   # Not a Collector template, but the Collector is now a second tenant of the
@@ -680,3 +682,96 @@ tests:
       - equal:
           path: seLinuxContext.type
           value: RunAsAny
+
+  # ── the token Secret's RBAC and the writer's env (backend#2274) ─────────────
+  - it: grants jobs-manager create AND patch on the token Secret
+    set:
+      telemetryCollector.enabled: true
+    template: templates/telemetry-token-rbac.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: kind
+          value: Role
+      # TWO rules, and the split is forced by Kubernetes: `resourceNames` is not
+      # honoured for `create` (the API server cannot match a name that does not
+      # exist yet), so `create` is namespace-scoped while `get`/`patch` are pinned
+      # to the one Secret. Collapsing them either way is wrong in one direction —
+      # too broad, or a create that 403s.
+      - lengthEqual:
+          path: rules
+          count: 2
+      - contains:
+          path: rules[0].verbs
+          content: create
+      - contains:
+          path: rules[1].verbs
+          content: patch
+      # `patch` is the whole reason this Role exists: the cluster-wide rule in
+      # rbac.yaml grants create+get and NOT patch, so without it the Collector
+      # works until the first token rotation and then 401s on every export.
+      - contains:
+          path: rules[1].resourceNames
+          content: tracebloc-telemetry-token
+
+  - it: renders no token RBAC when the Collector is off
+    template: templates/telemetry-token-rbac.yaml
+    asserts:
+      # The negative half, so the positive above cannot pass for free.
+      - hasDocuments:
+          count: 0
+
+  - it: survives an explicit null telemetryCollector
+    set:
+      telemetryCollector: null
+    template: templates/telemetry-token-rbac.yaml
+    asserts:
+      # The `helm upgrade --reuse-values` trap, on the new template too.
+      - hasDocuments:
+          count: 0
+
+  - it: passes the Secret coordinates to the container that actually writes it
+    set:
+      telemetryCollector.enabled: true
+    template: templates/jobs-manager-deployment.yaml
+    asserts:
+      # containers[0] is `api`, which runs the tracebloc/jobs-manager image.
+      # containers[1] is `pods-monitor-container`, whose `env:` opening is
+      # BYTE-IDENTICAL — so a patch anchored on that text alone lands on the wrong
+      # container, sets three variables on a process that never reads them, and
+      # the Collector still gets no token. Asserted on both containers for that
+      # reason, not just the right one.
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: api
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TELEMETRY_TOKEN_SECRET_NAMESPACE
+            value: tracebloc-node-agents
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TELEMETRY_TOKEN_SECRET_NAME
+            value: tracebloc-telemetry-token
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TELEMETRY_TOKEN_SECRET_KEY
+            value: token
+      - notContains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: TELEMETRY_TOKEN_SECRET_NAME
+            value: tracebloc-telemetry-token
+
+  - it: passes no Secret coordinates when the Collector is off
+    template: templates/jobs-manager-deployment.yaml
+    asserts:
+      # The reader treats an absent namespace as "not deployed" and makes no API
+      # call at all, so this is the switch that keeps a default install inert.
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TELEMETRY_TOKEN_SECRET_NAMESPACE
+            value: tracebloc-node-agents

--- a/scripts/tests/telemetry-token-agreement.sh
+++ b/scripts/tests/telemetry-token-agreement.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+#  telemetry-token-agreement.sh — the writer, the reader and the RBAC all name the
+#  SAME Secret, in the same namespace, under the same key (backend#2274).
+#
+#  WHY THIS EXISTS. Four documents describe one credential:
+#
+#    * jobs-manager's env      — TELEMETRY_TOKEN_SECRET_{NAMESPACE,NAME,KEY}, the WRITER
+#    * the Collector's volume  — secretName, the READER
+#    * the Collector's config  — bearertokenauth.filename, which encodes the KEY
+#    * a Role + RoleBinding    — resourceNames, and which ServiceAccount may use it
+#
+#  Any one of them disagreeing produces the same symptom: nothing. The Collector
+#  mounts the Secret `optional: true` ON PURPOSE — a missing token must buffer to
+#  disk, not CrashLoopBackOff on every customer node — so a wrong name, a wrong
+#  namespace, a wrong key and a Role bound to the wrong ServiceAccount are ALL
+#  indistinguishable from "not deployed yet". The DaemonSet is Ready, the metrics
+#  are quiet, and no records exist.
+#
+#  That is why the reader holds no defaults of its own (the chart passes all three
+#  values) and why this compares the rendered documents rather than trusting them.
+#
+#  DERIVED IN EVERY DIRECTION. No Secret name, namespace, key or ServiceAccount is
+#  written down here. Everything is read out of one render and compared.
+#
+#  FAILS CLOSED. A missing document is a finding: comparing values you could not
+#  find would report agreement between two absences.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+CHART=client
+
+command -v helm >/dev/null 2>&1 || { echo "[SKIP] helm not installed"; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "[ERROR] python3 required" >&2; exit 1; }
+
+echo "== telemetry token agreement =="
+
+CMP="$(mktemp -t tok-agree.XXXXXX)"
+trap 'rm -f "$CMP"' EXIT
+cat >"$CMP" <<'PY'
+import sys, yaml, posixpath
+
+docs = [d for d in yaml.safe_load_all(sys.stdin) if d]
+if not docs:
+    sys.exit("[ERROR] the chart rendered nothing")
+
+writer = {}          # from jobs-manager's env
+writer_sa = None
+reader_secret = None
+reader_ns = None
+mount_path = None
+auth_filename = None
+role = None
+bound_sas = set()
+
+for d in docs:
+    kind = d.get("kind")
+    if kind == "Deployment":
+        for c in d["spec"]["template"]["spec"].get("containers") or []:
+            for e in c.get("env") or []:
+                if e.get("name", "").startswith("TELEMETRY_TOKEN_SECRET_"):
+                    writer[e["name"]] = e.get("value")
+                    writer_sa = (d["spec"]["template"]["spec"].get("serviceAccountName"), 
+                                 d["metadata"].get("namespace", ""))
+    elif kind == "DaemonSet" and "telemetry" in d["metadata"]["name"]:
+        reader_ns = d["metadata"].get("namespace", "")
+        for v in d["spec"]["template"]["spec"].get("volumes") or []:
+            if "secret" in v:
+                reader_secret = v["secret"].get("secretName")
+                for c in d["spec"]["template"]["spec"].get("containers") or []:
+                    for m in c.get("volumeMounts") or []:
+                        if m.get("name") == v["name"]:
+                            mount_path = m.get("mountPath")
+    elif kind == "ConfigMap" and "telemetry-collector" in d["metadata"]["name"]:
+        cfg = yaml.safe_load(d["data"]["config.yaml"])
+        auth_filename = ((cfg.get("extensions") or {}).get("bearertokenauth") or {}).get("filename")
+    elif kind == "Role" and d["metadata"]["name"].endswith("-token"):
+        role = d
+    elif kind == "RoleBinding" and d["metadata"]["name"].endswith("-token"):
+        for s in d.get("subjects") or []:
+            bound_sas.add((s.get("name"), s.get("namespace", "")))
+
+# --- fail closed on anything we could not locate -----------------------------
+missing = [n for n, v in (
+    ("jobs-manager's TELEMETRY_TOKEN_SECRET_* env", writer or None),
+    ("the Collector DaemonSet's token volume", reader_secret),
+    ("the Collector's bearertokenauth.filename", auth_filename),
+    ("the token Role", role),
+    ("the token RoleBinding's subjects", bound_sas or None),
+) if not v]
+if missing:
+    sys.exit("[ERROR] could not locate: " + "; ".join(missing)
+             + " — comparing values that were not found would report agreement "
+               "between absences")
+
+problems = []
+
+# 1. the NAME, across writer / reader / RBAC
+names = {
+    "jobs-manager env": writer.get("TELEMETRY_TOKEN_SECRET_NAME"),
+    "Collector volume": reader_secret,
+}
+scoped = [r for r in role.get("rules") or [] if r.get("resourceNames")]
+if not scoped:
+    problems.append("the token Role has no name-scoped rule at all — `get`/`patch` "
+                    "would cover every Secret in the namespace")
+else:
+    for r in scoped:
+        for n in r["resourceNames"]:
+            names[f"Role resourceNames ({','.join(r.get('verbs') or [])})"] = n
+if len(set(names.values())) != 1:
+    problems.append("the Secret NAME disagrees across documents: "
+                    + ", ".join(f"{k}={v!r}" for k, v in sorted(names.items())))
+
+# 2. the NAMESPACE
+nss = {
+    "jobs-manager env": writer.get("TELEMETRY_TOKEN_SECRET_NAMESPACE"),
+    "Collector DaemonSet": reader_ns,
+    "token Role": role["metadata"].get("namespace", ""),
+}
+if len(set(nss.values())) != 1:
+    problems.append("the NAMESPACE disagrees: "
+                    + ", ".join(f"{k}={v!r}" for k, v in sorted(nss.items())))
+
+# 3. the KEY. With no `items` on the volume, the Secret's keys project as files
+#    named by key, so the Collector's credential file is <mountPath>/<key>.
+if mount_path and auth_filename:
+    derived_key = posixpath.basename(auth_filename)
+    derived_dir = posixpath.dirname(auth_filename)
+    if derived_dir.rstrip("/") != (mount_path or "").rstrip("/"):
+        problems.append(f"bearertokenauth reads {auth_filename!r} but the Secret is "
+                        f"mounted at {mount_path!r} — the Collector would read a "
+                        "path nothing projects to")
+    if derived_key != writer.get("TELEMETRY_TOKEN_SECRET_KEY"):
+        problems.append(f"the KEY disagrees: the Collector reads {derived_key!r} "
+                        f"(from {auth_filename!r}) but jobs-manager writes "
+                        f"{writer.get('TELEMETRY_TOKEN_SECRET_KEY')!r}")
+
+# 4. the RoleBinding must bind the ServiceAccount that actually writes.
+if writer_sa and writer_sa not in bound_sas:
+    problems.append(f"the token RoleBinding does not bind the writer: jobs-manager "
+                    f"runs as {writer_sa} but the binding covers {sorted(bound_sas)} "
+                    "— the create would 403 and the Collector would buffer forever")
+
+print(f"   secret     {sorted(set(names.values()))[0]}")
+print(f"   namespace  {sorted(set(nss.values()))[0]}")
+print(f"   key        {posixpath.basename(auth_filename)}")
+print(f"   writer sa  {writer_sa[0]} (ns {writer_sa[1]})")
+
+if problems:
+    sys.exit("[ERROR] " + "; ".join(problems))
+
+print("  ok: writer, reader, key and RBAC all name the same Secret")
+PY
+
+helm template t "$CHART" \
+  --set clientId=x --set clientPassword=y \
+  --set storageClass.create=false \
+  --set telemetryCollector.enabled=true 2>/dev/null | python3 "$CMP"
+
+echo "telemetry token agreement: green"


### PR DESCRIPTION
Closes tracebloc/backend#2274. Parent epic: tracebloc/backend#1872.

The write side landed in [client-runtime#368](https://github.com/tracebloc/client-runtime/pull/368); this is the half it was waiting for. It needs `telemetryCollector.tokenSecret`, which only existed once [#779](https://github.com/tracebloc/client/pull/779) merged.

## ⚠️ The RBAC gap isn't in the ticket

jobs-manager's cluster-wide rule in `rbac.yaml` grants `secrets: [create, get]` and **not `patch`**. So on the chart as it stood, the create would succeed and every **refresh** would `403`.

That failure needs no code change to appear. `bearertokenauth` watches the projected file, so a rotated token is picked up without restarting the Collector — but only if something rewrites the Secret. Without `patch`, the Collector works until the first token rotation, then 401s on every export and buffers to disk until the cap. I found it reading the rule while writing the reader and [recorded it on the ticket](https://github.com/tracebloc/backend/issues/2274) then; this closes it.

**Gated on the Collector alone**, deliberately unlike its sibling node-agents Roles. Those carry a second condition — that `nodeAgents.namespace` differs from the release namespace — because the release-namespace grant already covers them when the two coincide. This one isn't covered either way: the missing verb is missing in *any* namespace. The Role name is release-scoped, so it can't collide when the namespaces do coincide.

**Two rules, because `resourceNames` is not honoured for `create`** — the API server can't match a name that doesn't exist yet. So `create` is namespace-scoped and `get`/`patch` are pinned to the one Secret, which is the half that would otherwise let jobs-manager rewrite anything in the namespace. Same shape and reason as `image-refresh-rbac.yaml`'s collection-verb split.

## The coordinates go to one container, and that's a real trap

`pods-monitor-container` has a **byte-identical `env:` opening** and doesn't run `jobs_manager.py`. My first patch asserted a unique match, found two, and refused — which is the only reason it didn't land on the wrong container, where it would have set three variables on a process that never reads them while the Collector still got no token. Both containers are asserted.

jobs-manager holds **no defaults** for the name, namespace or key: the chart declares them and passes them here, so the two sides can't disagree.

## Four documents, one credential — so it gets a guard

The writer (jobs-manager's env), the reader (the Collector's volume), the key (`bearertokenauth.filename`), and the Role + RoleBinding. **Any one disagreeing produces the same symptom: nothing.** The Collector mounts the Secret `optional: true` on purpose — a missing token must buffer, not CrashLoopBackOff on every customer node — so a wrong name, a wrong namespace, a wrong key, and a Role bound to the wrong ServiceAccount are *all* indistinguishable from "not deployed yet".

`scripts/tests/telemetry-token-agreement.sh` compares all four out of one render and writes none of them down. It derives the key the way the Collector actually resolves it — `basename(bearertokenauth.filename)`, since the volume has no `items` and Secret keys project as files named by key — and checks the mount directory matches, so a filename pointing at a path nothing projects to is caught too.

| Mutation | Result |
|---|---|
| Role `resourceNames` renamed | KILLED |
| writer env NAME changed | KILLED |
| writer env KEY changed | KILLED |
| writer env NAMESPACE changed | KILLED |
| RoleBinding bound to the wrong ServiceAccount | KILLED |
| the name-scoped rule dropped | KILLED |
| the Role template deleted | KILLED (fails closed) |
| env wired to the wrong container | 1 unit test failed |
| the `enabled` gate removed | 2 unit tests failed |

## Still not done when this merges

Per the ticket, done is **a record arriving at `/tracebloc/edge/telemetry` from a real edge** — which now needs someone to flip `telemetryCollector.enabled=true` on a fleet and confirm. A Secret that exists proves nothing, because the Collector's absent-token behaviour is to buffer quietly.

## Test plan

- [x] `helm unittest .` — 537 passed
- [x] `make drift` — 12/12 guards green (incl. the new one)
- [x] `make check` — parse, shellcheck `-S warning`, helm-lint, helm-vocab
- [x] Mutation matrix above; every anchor asserted applied
- [x] Renders inert with the Collector off (no RBAC, no env) and survives `telemetryCollector: null`
- [ ] Enable on a fleet and confirm a record arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Role that can create secrets in the node-agents namespace and patch one named token Secret, plus env that points jobs-manager at that credential. Gated on telemetryCollector.enabled and name-scoped for get/patch, but it is still RBAC and secret-handling.
> 
> **Overview**
> When `telemetryCollector.enabled` is true, jobs-manager now receives `TELEMETRY_TOKEN_SECRET_{NAMESPACE,NAME,KEY}` so it can write the Collector's ingest token. The vars go only on the `api` container (not pods-monitor). They are omitted when the Collector is off.
> 
> A new Role/RoleBinding in the node-agents namespace fills the gap that cluster-wide `rbac.yaml` grants `secrets: [create, get]` but **not `patch`**. Without that, create would succeed and every token refresh would 403, leaving the Collector 401ing after the first rotation. `create` is namespace-scoped; `get`/`patch` are pinned to the one Secret.
> 
> A fail-closed drift guard (`telemetry-token-agreement.sh`) checks that writer env, Collector volume, `bearertokenauth` key, and RoleBinding all name the same Secret. Chart version is **1.9.59**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 654aa8710d0adf0c947976366fe49dc575e2f05c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->