### PR TITLE
feat(#1528): wire DB_BOOTSTRAP_* into jobs-manager to re-parent the mint off edgeuser (S3)

### DIFF
--- a/client/Chart.yaml
+++ b/client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: client
 description: A unified Helm chart for tracebloc on AKS, EKS, bare-metal, and OpenShift
 type: application
-version: 1.9.51
-appVersion: "1.9.51"
+version: 1.9.52
+appVersion: "1.9.52"
 keywords:
   - tracebloc
   - kubernetes

--- a/client/templates/_helpers.tpl
+++ b/client/templates/_helpers.tpl
@@ -631,6 +631,26 @@ Usage: {{ include "tracebloc.ingestorDigest" . }}
 {{- end -}}
 {{- end }}
 
+{{/*
+  Whether to re-parent the account-minting bootstrap off edgeuser onto MySQL
+  root (backend#1528 S3). Resolves identically to tracebloc.serviceDbAccounts —
+  operator override first, else the per-environment default — so the fleet's S3
+  posture reads out of one place the same way, and the CLIENT_ENV normalization
+  (backend#1723) is shared. This is the LAST, edgeuser-retiring step, so
+  bootstrapDbReparentByEnv is false everywhere by default; flip dev first only
+  after serviceDbAccounts + perExperimentDbCreds are verified on the fleet.
+*/}}
+{{- define "tracebloc.bootstrapDbReparent" -}}
+{{- $override := (default dict .Values).bootstrapDbReparent -}}
+{{- if not (kindIs "invalid" $override) -}}
+{{- if $override }}true{{ end -}}
+{{- else -}}
+{{- $env := include "tracebloc.clientEnv" . -}}
+{{- $byEnv := default dict .Values.bootstrapDbReparentByEnv -}}
+{{- if get $byEnv $env }}true{{ end -}}
+{{- end -}}
+{{- end }}
+
 {{- define "tracebloc.clientEnv" -}}
 {{- $raw := (default dict .Values.env).CLIENT_ENV | default "prod" -}}
 {{- $aliases := dict "development" "dev" "staging" "stg" "production" "prod" -}}

--- a/client/templates/jobs-manager-deployment.yaml
+++ b/client/templates/jobs-manager-deployment.yaml
@@ -358,6 +358,24 @@ spec:
               name: {{ include "tracebloc.secretName" . }}
               key: TB_INGEST_PASSWORD
         {{- end }}
+        {{- if (include "tracebloc.bootstrapDbReparent" .) }}
+        # backend#1528 S3 (RFC-0003 D10 close-out): re-parent the account-minting
+        # bootstrap DDL OFF the root-equivalent edgeuser onto MySQL root, so
+        # edgeuser can be REVOKEd / DROPped. jobs-manager authenticates as this
+        # identity ONLY to CREATE USER / GRANT the scoped accounts (tb_credmgr /
+        # tb_meta / tb_ingest) — privileges those accounts deliberately lack.
+        # client-runtime#310's _bootstrap_db_config reads DB_BOOTSTRAP_USER and
+        # DB_BOOTSTRAP_PASSWORD together (both-or-neither), so both render here or
+        # neither. Rendered only when the S3 gate is on; a default install stays
+        # byte-identical (the mint keeps running as edgeuser).
+        - name: DB_BOOTSTRAP_USER
+          value: "root"
+        - name: DB_BOOTSTRAP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "tracebloc.secretName" . }}
+              key: DB_BOOTSTRAP_PASSWORD
+        {{- end }}
         # Ingestor image wiring for the POST /internal/submit-ingestion-run
         # endpoint. jobs-manager spawns each ingestion Job from these values
         # (see client-runtime submit_ingestion_run._build_image_reference):

--- a/client/templates/secrets.yaml
+++ b/client/templates/secrets.yaml
@@ -90,6 +90,39 @@
 {{-     $tbIngestPassword = randAlphaNum 48 -}}
 {{-   end -}}
 {{- end -}}
+{{- /*
+  Bootstrap re-parent password (backend#1528 S3). DB_BOOTSTRAP_PASSWORD is the
+  password jobs-manager authenticates with to run the account-minting DDL
+  (CREATE USER / GRANT for tb_credmgr / tb_meta / tb_ingest). S3 re-parents that
+  mint OFF the root-equivalent edgeuser onto MySQL root (client-runtime#310), so
+  edgeuser can finally be REVOKEd / DROPped.
+
+  Resolution differs DELIBERATELY from the accounts above — jobs-manager
+  AUTHENTICATES as this identity, it never mints or ALTERs it:
+    1. explicit .Values.bootstrapDbPassword (the real root password — `Edg9@Tr@ce`
+       on an unrotated image, or the rotated value for the S3 window), else
+    2. the value already stored in the live Secret (preserve across upgrades), else
+    3. FAIL. There is NO generate-random tier: a random password the server was
+       never told to expect would lock jobs-manager out of MySQL — it runs no
+       `ALTER USER root` to make the account match — CrashLooping the minter.
+  No alphanumeric constraint (unlike the credmgr / tb_* passwords, which ARE
+  interpolated into CREATE USER DDL): this value is only ever a mysql-connector
+  connection parameter, and the baked root password is not alphanumeric. Emitted
+  only when the S3 re-parent gate is on.
+*/ -}}
+{{- $bootstrapDbPassword := "" -}}
+{{- if (include "tracebloc.bootstrapDbReparent" .) -}}
+{{-   if .Values.bootstrapDbPassword -}}
+{{-     if regexMatch "^<.*>$" .Values.bootstrapDbPassword -}}
+{{-       fail "bootstrapDbPassword looks like a placeholder (e.g. \"<ROOT_PASSWORD>\"); set the real MySQL root password" -}}
+{{-     end -}}
+{{-     $bootstrapDbPassword = .Values.bootstrapDbPassword -}}
+{{-   else if and $existingSecret $existingSecret.data (hasKey $existingSecret.data "DB_BOOTSTRAP_PASSWORD") -}}
+{{-     $bootstrapDbPassword = (index $existingSecret.data "DB_BOOTSTRAP_PASSWORD" | b64dec) -}}
+{{-   else -}}
+{{-     fail "bootstrapDbReparent is on but bootstrapDbPassword is unset (backend#1528 S3): set it to the MySQL root password (`Edg9@Tr@ce` on an unrotated mysql-client image, or the rotated value). There is no generated default — jobs-manager authenticates as root to run the account-minting DDL and cannot rotate root to match a random value, so a missing pin would lock the minter out. See values.yaml." -}}
+{{-   end -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -108,6 +141,9 @@ data:
 {{- if (include "tracebloc.serviceDbAccounts" .) }}
   TB_META_PASSWORD: {{ $tbMetaPassword | b64enc | quote }}
   TB_INGEST_PASSWORD: {{ $tbIngestPassword | b64enc | quote }}
+{{- end }}
+{{- if (include "tracebloc.bootstrapDbReparent" .) }}
+  DB_BOOTSTRAP_PASSWORD: {{ $bootstrapDbPassword | b64enc | quote }}
 {{- end }}
 {{- if and (ne .Values.resourceMonitor false) (ne .Values.nodeAgents.namespace.name .Release.Namespace) }}
 ---

--- a/client/tests/jobs_manager_test.yaml
+++ b/client/tests/jobs_manager_test.yaml
@@ -714,6 +714,44 @@ tests:
                 name: RELEASE-NAME-secrets
                 key: TB_INGEST_PASSWORD
 
+  # backend#1528 S3: the bootstrap re-parent env (edgeuser -> root for the mint
+  # DDL) is flag-gated on bootstrapDbReparent so a default install is
+  # byte-identical. DB_BOOTSTRAP_USER/PASSWORD render together (both-or-neither),
+  # only on jobs-manager (the sole minter).
+  - it: bootstrap re-parent env absent by default (byte-for-byte off)
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_BOOTSTRAP_USER
+            value: "root"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_BOOTSTRAP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-secrets
+                key: DB_BOOTSTRAP_PASSWORD
+
+  - it: bootstrap re-parent env wired when bootstrapDbReparent is on
+    set:
+      bootstrapDbReparent: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_BOOTSTRAP_USER
+            value: "root"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_BOOTSTRAP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-secrets
+                key: DB_BOOTSTRAP_PASSWORD
+
   # -------------------------------------------------------------------------
   # Readiness probe — backend#1779
   #

--- a/client/tests/secrets_test.yaml
+++ b/client/tests/secrets_test.yaml
@@ -207,3 +207,66 @@ tests:
       tbIngestPassword: "bad-pass!"
     asserts:
       - failedTemplate: {}
+
+  # backend#1528 S3: DB_BOOTSTRAP_PASSWORD is gated on the bootstrapDbReparent
+  # resolution. Unlike the accounts above it has NO generate-random tier — a
+  # missing pin fails the render — and NO alphanumeric constraint (it is a
+  # connection parameter, never DDL; the baked root password contains '@').
+  - it: DB_BOOTSTRAP_PASSWORD absent by default (byte-for-byte off)
+    template: templates/secrets.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
+    asserts:
+      - notExists:
+          path: data.DB_BOOTSTRAP_PASSWORD
+        documentIndex: 0
+
+  - it: bootstrapDbPassword pin flows into the Secret when the gate is on (non-alphanumeric allowed)
+    template: templates/secrets.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
+      bootstrapDbReparent: true
+      bootstrapDbPassword: "Edg9@Tr@ce"
+    asserts:
+      - equal:
+          path: data.DB_BOOTSTRAP_PASSWORD
+          value: "RWRnOUBUckBjZQ=="
+        documentIndex: 0
+
+  - it: resolves the gate via bootstrapDbReparentByEnv (dev on)
+    template: templates/secrets.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
+      env:
+        CLIENT_ENV: dev
+      bootstrapDbReparentByEnv:
+        dev: true
+      bootstrapDbPassword: "Edg9@Tr@ce"
+    asserts:
+      - isNotEmpty:
+          path: data.DB_BOOTSTRAP_PASSWORD
+        documentIndex: 0
+
+  - it: fails when the gate is on but bootstrapDbPassword is unset (no generated default)
+    template: templates/secrets.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
+      bootstrapDbReparent: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "bootstrapDbReparent is on but bootstrapDbPassword is unset (backend#1528 S3): set it to the MySQL root password (`Edg9@Tr@ce` on an unrotated mysql-client image, or the rotated value). There is no generated default — jobs-manager authenticates as root to run the account-minting DDL and cannot rotate root to match a random value, so a missing pin would lock the minter out. See values.yaml."
+
+  - it: rejects a placeholder bootstrapDbPassword pin
+    template: templates/secrets.yaml
+    set:
+      clientId: "my-client-id"
+      clientPassword: "my-secret-pass"
+      bootstrapDbReparent: true
+      bootstrapDbPassword: "<ROOT_PASSWORD>"
+    asserts:
+      - failedTemplate:
+          errorMessage: "bootstrapDbPassword looks like a placeholder (e.g. \"<ROOT_PASSWORD>\"); set the real MySQL root password"

--- a/client/values.schema.json
+++ b/client/values.schema.json
@@ -427,6 +427,17 @@
       "type": "string",
       "description": "backend#1528 S1: optional operator pin for the tb_ingest account password (3-tier resolution, mirrors credmgrPassword). Empty = generate-and-persist. Set for DR / a pre-created MySQL account / forced rotation. Must be alphanumeric."
     },
+    "bootstrapDbReparent": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "OPERATOR OVERRIDE, normally unset. When null the effective value comes from bootstrapDbReparentByEnv keyed on the resolved CLIENT_ENV, mirroring serviceDbAccounts. backend#1528 S3 (RFC-0003 D10 close-out, FINAL stage): re-parent the account-minting bootstrap DDL off the root-equivalent edgeuser onto MySQL root (client-runtime#310 reads DB_BOOTSTRAP_USER/PASSWORD), the prerequisite for REVOKE/DROP of edgeuser. Off everywhere by default; flip per environment dev-first, only after serviceDbAccounts + perExperimentDbCreds are verified on the fleet and the S0 SHOW GRANTS snapshot is captured. When on, bootstrapDbPassword is REQUIRED."
+    },
+    "bootstrapDbPassword": {
+      "type": "string",
+      "description": "backend#1528 S3: REQUIRED when bootstrapDbReparent resolves on — the password jobs-manager authenticates with as MySQL root to run the mint DDL. NO generated default (2-tier: operator pin -> existing Secret value -> Helm fails): jobs-manager authenticates as root and never runs ALTER USER root, so a random value would lock the minter out and CrashLoop it. Set to the real root password (Edg9@Tr@ce on an unrotated mysql-client image, or the rotated value per backend#947). NOT constrained to alphanumeric — never interpolated into DDL, only a connection parameter."
+    },
     "perIngestionTables": {
       "type": "boolean",
       "description": "RFC-0003 D16 (backend#1204/#1205): stamp PER_INGESTION_TABLES=1 into every ingestion Job. Flip per environment, dev first; file-bearing categories are refused under the flag until client-runtime#203 phase 2."
@@ -1272,6 +1283,13 @@
     "serviceDbAccountsByEnv": {
       "type": "object",
       "description": "Per-environment default for the dedicated tb_meta/tb_ingest identities, keyed on the RESOLVED CLIENT_ENV (dev|stg|prod \u2014 documented aliases are normalized first). This is the mechanism behind #1151's 'flip per environment, dev first'; before it, that plan had no implementation and the fleet's posture could not be read in one place. backend#1752.",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "bootstrapDbReparentByEnv": {
+      "type": "object",
+      "description": "Per-environment default for the backend#1528 S3 bootstrap re-parent (edgeuser -> root for the account-minting DDL), keyed on the RESOLVED CLIENT_ENV (dev|stg|prod \u2014 aliases normalized first). Mirrors serviceDbAccountsByEnv. This is the LAST, edgeuser-retiring step, so it is false everywhere by default; flip dev-first only after the earlier flags are verified on the fleet.",
       "additionalProperties": {
         "type": "boolean"
       }

--- a/client/values.yaml
+++ b/client/values.yaml
@@ -1273,6 +1273,46 @@ tbMetaPassword: ""
 tbIngestPassword: ""
 
 # ============================================================
+# S3 bootstrap re-parent (backend#1528 D10 close-out — final stage)
+# ============================================================
+# The account-minting DDL (CREATE USER / GRANT for tb_credmgr, tb_meta and
+# tb_ingest) still authenticates AS the root-equivalent edgeuser. While it does,
+# edgeuser cannot be REVOKEd / DROPped. This gate re-parents that mint onto MySQL
+# root — client-runtime#310's _bootstrap_db_config reads DB_BOOTSTRAP_USER /
+# DB_BOOTSTRAP_PASSWORD (both-or-neither) — which is the prerequisite for
+# retiring edgeuser. Additive to the data plane: it changes only which identity
+# runs the mint, never which the scoped accounts hold.
+#
+# This is the LAST, prod-irreversible-adjacent step of the rollout, so it is OFF
+# everywhere by default. Flip per environment, dev first, only once
+# serviceDbAccounts + perExperimentDbCreds are verified on that fleet and the S0
+# `SHOW GRANTS FOR 'edgeuser'@'%'` snapshot is captured (the rollback reference).
+#
+# UNSET by default: the effective value comes from bootstrapDbReparentByEnv
+# below, keyed on the resolved CLIENT_ENV. Set this to force one answer on an
+# edge regardless of environment (an operator override — DR, a fleet held back
+# deliberately, or a customer opt-out). Mirrors serviceDbAccounts (backend#1752).
+bootstrapDbReparent:
+
+bootstrapDbReparentByEnv:
+  dev: false
+  stg: false
+  prod: false
+
+# REQUIRED when the gate above is on: the password jobs-manager authenticates
+# with, as MySQL root, to run the mint DDL. There is NO generated default —
+# jobs-manager AUTHENTICATES as root (it never runs `ALTER USER root`), so a
+# random value the server was never told to expect would lock the minter out of
+# MySQL and CrashLoop it. Set this to the real root password: `Edg9@Tr@ce` on an
+# unrotated mysql-client image (Dockerfile.mysql_client bakes MYSQL_ROOT_PASSWORD
+# to that literal), or the rotated value once root is rotated off it (backend#947).
+# Helm fails the render if the gate is on and this is unset (with an existing
+# Secret value preserved across upgrades in between). NOT constrained to
+# alphanumeric — unlike the credmgr / tb_* passwords it is never interpolated
+# into DDL, only passed as a mysql-connector connection parameter.
+bootstrapDbPassword: ""
+
+# ============================================================
 # Ingestion endpoint authorization (client-runtime#21)
 # ============================================================
 # jobs-manager's POST /internal/submit-ingestion-run authenticates callers


### PR DESCRIPTION
## What

**backend#1528 S3** — the chart half of the bootstrap re-parent. The runtime seam already merged (**client-runtime#310**: `_bootstrap_db_config` resolves the minting identity from `DB_BOOTSTRAP_USER` / `DB_BOOTSTRAP_PASSWORD`, both-or-neither, falling back to `edgeuser` when unset). This PR injects those into the **jobs-manager** deployment, gated on a new S3 flag, so the account-minting DDL (`CREATE USER` / `GRANT` for `tb_credmgr` / `tb_meta` / `tb_ingest`) authenticates as **MySQL `root`** instead of the root-equivalent `edgeuser`.

While the mint authenticates *as* `edgeuser`, `edgeuser` cannot be `REVOKE`d / `DROP`ped. Re-parenting it onto `root` (which already holds the global `CREATE USER` + `GRANT OPTION` the mint needs) is the prerequisite that unblocks the rest of S3.

## Changes

- **`values.yaml`** — `bootstrapDbReparent` (operator override) + `bootstrapDbReparentByEnv{dev,stg,prod: false}` + `bootstrapDbPassword`. Default-**off** everywhere; this is the last, `edgeuser`-retiring step, flipped dev-first per fleet only once `serviceDbAccounts` + `perExperimentDbCreds` are verified and the S0 `SHOW GRANTS` snapshot is captured.
- **`_helpers.tpl`** — `tracebloc.bootstrapDbReparent`, resolving exactly like `tracebloc.serviceDbAccounts` (override → `…ByEnv` → normalized `CLIENT_ENV`), so the fleet's S3 posture reads out of one place and shares the backend#1723 alias normalization.
- **`secrets.yaml`** — `DB_BOOTSTRAP_PASSWORD` resolved **2-tier: pin → existing Secret → `fail`**. Deliberately **no** generate-random tier: jobs-manager *authenticates* as `root` and never runs `ALTER USER root`, so a random value the server was never told to expect would lock the minter out and CrashLoop it. **No** alphanumeric constraint (unlike the credmgr/tb_* passwords it is never interpolated into DDL — only a mysql-connector connection parameter; the baked root password `Edg9@Tr@ce` isn't alphanumeric anyway). Placeholder-guarded.
- **`jobs-manager-deployment.yaml`** — `DB_BOOTSTRAP_USER=root` + `DB_BOOTSTRAP_PASSWORD` (secretKeyRef), gated, both-or-neither.
- **`values.schema.json`** — three new keys. **`Chart.yaml`** 1.9.51 → 1.9.52 (+ `appVersion` lockstep).
- **Tests** — +8 helm-unittest cases across `secrets_test.yaml` / `jobs_manager_test.yaml`.

## Design notes (both confirmed with the reviewer route on the ticket)

- **Require-pin, fail-fast** over a baked `Edg9@Tr@ce` fallback — keeps the literal out of the chart (doesn't fight backend#947) and fits the operator-driven, prod-irreversible-adjacent rollout.
- **ByEnv gate** mirroring `serviceDbAccounts` — the backend#1752 lesson that a plain global bool caused a silent fleet break.

## Verification

- `helm unittest` full suite: **499 passed** (33 suites).
- `helm template` (ci/eks base): **default render = 0 `DB_BOOTSTRAP` refs (byte-identical)**; gate-on+pin wires the Secret (`DB_BOOTSTRAP_PASSWORD`) and both env vars; gate-on **without** pin fails fast with the guidance message; `bootstrapDbReparentByEnv.dev=true` wires it while `prod` (default) doesn't; placeholder pin rejected.
- `helm lint` clean; `chart-version-guard.sh` satisfied.

**Additive and default-off — nothing renders until the S3 rollout flips the flag per fleet.**

## Not in this PR (remaining S3)
- Narrow `client-runtime/mysql-client-initdb/10-edgeuser-bridge-grants.sql` once the mint no longer runs as edgeuser.
- Ops-gated, prod-irreversible: `REVOKE` edgeuser → `DROP USER`, fleet-staged dev→stg→prod, gated on the S0 snapshot.
- The literal sweep (backend#947).

Refs: backend#1528 (D10 close-out, S3) · client-runtime#310 (runtime seam) · backend#1752 (ByEnv rollout) · backend#947 (literal removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Handles MySQL root credentials for account-minting DDL, but the gate is default-off everywhere so existing installs stay byte-identical until an operator flips it. A wrong pin with the flag on would CrashLoop the minter.
> 
> **Overview**
> Wires **backend#1528 S3**: when `bootstrapDbReparent` is on, jobs-manager mints `tb_*` accounts as MySQL **root** (`DB_BOOTSTRAP_USER` / `DB_BOOTSTRAP_PASSWORD`) so `edgeuser` can later be revoked. Default installs stay byte-identical.
> 
> The gate mirrors `serviceDbAccounts` (operator override, else `bootstrapDbReparentByEnv` keyed on resolved `CLIENT_ENV`; all envs **false**). `bootstrapDbPassword` is 2-tier only (pin → existing Secret → **fail**): no random default, because jobs-manager never `ALTER USER root`. Placeholders are rejected; non-alphanumeric is allowed.
> 
> Chart **1.9.51 → 1.9.52**. Helm-unittest covers default-off, gate-on wiring, ByEnv, missing pin, and placeholder fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ba65a1dac6844e93f4aed2182f7ce646b14ac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->